### PR TITLE
Fix: tsconfig.jsonにexclude追加でビルド時のmocksエラーを解決

### DIFF
--- a/frontend/public/tsconfig.json
+++ b/frontend/public/tsconfig.json
@@ -29,5 +29,6 @@
     /* Testing */
     "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src", "vitest.setup.ts"]
+  "include": ["src", "vitest.setup.ts"],
+  "exclude": ["node_modules", "dist", "../../tests"]
 }


### PR DESCRIPTION
問題:
- tsc -b ビルドモードで../../tests/e2e/mocksが型チェックされる
- includeからmocksを削除しても、tsc -bがスキャンしてしまう
- msw, uuidモジュールエラーが発生

解決策:
- excludeを追加して明示的にtestsディレクトリを除外
- exclude: ["node_modules", "dist", "../../tests"]

ビルド成功を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)