### PR TITLE
Fix: CDK Deployの進捗表示を改善（grep フィルタリングを削除）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,7 +166,7 @@ jobs:
             echo "⚠️  Deploying to PRODUCTION"
             echo ""
           fi
-          npx cdk deploy --all --require-approval never --context stage=${{ steps.env.outputs.stage }} --ci --outputs-file cdk-outputs.json 2>&1 | grep -v "arn:aws" | grep -v "https://" | grep -v "^ServerlessBlog.*Stack\." || true
+          npx cdk deploy --all --require-approval never --context stage=${{ steps.env.outputs.stage }} --ci --outputs-file cdk-outputs.json
           echo "✓ CDK Deployment completed successfully"
 
       - name: Get Stack Outputs


### PR DESCRIPTION
Requirement R31: GitHub Actions CI/CD デプロイワークフロー

## 修正内容

### CDK Deployステップのフィルタリング削除
- `grep -v "arn:aws" | grep -v "https://" | grep -v "^ServerlessBlog.*Stack\."` を削除
- `|| true` によるエラー無視も削除

## 問題点
```bash
npx cdk deploy ... 2>&1 | grep -v "arn:aws" | grep -v "https://" | grep -v "^ServerlessBlog.*Stack\." || true
```

このフィルタリングにより：
1. デプロイの進捗状況がまったく表示されない
2. エラーが発生してもスキップされる（|| true）
3. ユーザーがデプロイの状態を把握できない

## 修正後
```bash
npx cdk deploy --all --require-approval never --context stage=${{ steps.env.outputs.stage }} --ci --outputs-file cdk-outputs.json
```

完全な出力が表示され、デプロイの進捗とエラーを確認可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)