### PR TITLE
Fix: Job Output値のマスキングを削除してフロントエンドデプロイを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -198,16 +198,10 @@ jobs:
             --query "Stacks[0].Outputs[?OutputKey=='AdminSiteDistributionId'].OutputValue" \
             --output text)
 
-          # Mask sensitive values
-          echo "::add-mask::$PUBLIC_BUCKET"
-          echo "::add-mask::$ADMIN_BUCKET"
-          echo "::add-mask::$PUBLIC_DIST_ID"
-          echo "::add-mask::$ADMIN_DIST_ID"
-
-          echo "Public Bucket: ***"
-          echo "Admin Bucket: ***"
-          echo "Public Distribution ID: ***"
-          echo "Admin Distribution ID: ***"
+          echo "Public Bucket: $PUBLIC_BUCKET"
+          echo "Admin Bucket: $ADMIN_BUCKET"
+          echo "Public Distribution ID: $PUBLIC_DIST_ID"
+          echo "Admin Distribution ID: $ADMIN_DIST_ID"
 
           # Set outputs for next job
           echo "public-bucket-name=$PUBLIC_BUCKET" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Requirement R31: GitHub Actions CI/CD デプロイワークフロー

## 問題点

Get Stack OutputsステップでCloudFormation Outputsをマスク（::add-mask::）したため、 GitHub ActionsがJob Output値もスキップしていました。

```
##[warning]Skip output 'public-bucket-name' since it may contain secret.
##[warning]Skip output 'admin-bucket-name' since it may contain secret.
```

結果として、deploy-frontendジョブが受け取るバケット名が空になり、
`s3:///`という不正なS3 URIでデプロイが失敗していました。

## 修正内容

### マスキングの削除
- `echo "::add-mask::$PUBLIC_BUCKET"` 等を削除
- バケット名とDistribution IDは公開情報であり、マスク不要
- `echo "Public Bucket: ***"` → `echo "Public Bucket: $PUBLIC_BUCKET"`

### 技術的背景
GitHub ActionsのJob Outputでは、マスク（シークレット）扱いされた値は
セキュリティ上の理由で次のジョブに渡されません。

S3バケット名とCloudFront Distribution IDは：
- CloudFormationテンプレートに記述される公開情報
- AWSコンソールで誰でも確認可能
- シークレット扱いする必要がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)