### PR TITLE
Fix: PostListPageでAPIレスポンスのitemsがundefinedの場合の防御的処理を追加

### DIFF
--- a/frontend/public/src/pages/PostListPage.tsx
+++ b/frontend/public/src/pages/PostListPage.tsx
@@ -33,7 +33,7 @@ const PostListPage: React.FC = () => {
 
       const response = await fetchPosts(filters);
 
-      setPosts(response.items);
+      setPosts(response.items || []);
       setNextToken(response.nextToken);
     } catch (err) {
       // エラー時は空の記事リストを表示（500エラーや network errorハンドリング）


### PR DESCRIPTION
response.itemsがundefinedの場合に空配列を設定することで、
posts.mapやposts.lengthでのエラーを防止。

🤖 Generated with [Claude Code](https://claude.com/claude-code)