### PR TITLE
Fix: ViteにPostCSSプラグインを明示的に追加してTailwind CSS v4を正しく処理

### DIFF
--- a/frontend/admin/vite.config.ts
+++ b/frontend/admin/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/postcss';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  css: {
+    postcss: {
+      plugins: [tailwindcss()],
+    },
+  },
   build: {
     rollupOptions: {
       // MSWと関連する依存関係を外部化（プロダクションビルドから除外）

--- a/frontend/public/vite.config.ts
+++ b/frontend/public/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import tailwindcss from '@tailwindcss/postcss';
 
 export default defineConfig({
   plugins: [react()],
+  css: {
+    postcss: {
+      plugins: [tailwindcss()],
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
- frontend/admin/vite.config.tsにPostCSS設定を追加
- frontend/public/vite.config.tsにPostCSS設定を追加
- Tailwind CSS v4の@importディレクティブが正しく処理されるように修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)