### PR TITLE
Security: Update React to 19.2.1 (CVE-2025-55182)

### DIFF
--- a/frontend/admin/package-lock.json
+++ b/frontend/admin/package-lock.json
@@ -11,8 +11,8 @@
         "@aws-amplify/ui-react": "^6.13.1",
         "aws-amplify": "^6.15.7",
         "axios": "^1.13.1",
-        "react": "^19.1.1",
-        "react-dom": "^19.1.1",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.9.5",
         "remark-gfm": "^4.0.1"
@@ -10862,9 +10862,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -10872,16 +10872,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.1"
       }
     },
     "node_modules/react-hook-form": {

--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -19,8 +19,8 @@
     "@aws-amplify/ui-react": "^6.13.1",
     "aws-amplify": "^6.15.7",
     "axios": "^1.13.1",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.9.5",
     "remark-gfm": "^4.0.1"

--- a/frontend/public/package-lock.json
+++ b/frontend/public/package-lock.json
@@ -5073,9 +5073,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5083,16 +5083,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.1"
       }
     },
     "node_modules/react-is": {


### PR DESCRIPTION
## Summary
- React と react-dom を 19.2.1 にアップデート
- CVE-2025-55182（React Server Components の重大なRCE脆弱性）に対応

## 背景
2025年12月3日に公開された CVE-2025-55182 は、React Server Components (RSC) の "Flight" プロトコルに存在する重大な脆弱性です（CVSS 10.0）。

このプロジェクトは RSC を使用していないため直接的な影響はありませんが、セキュリティベストプラクティスとして修正バージョンへアップデートしました。

## 変更内容
- `frontend/public`: react/react-dom 19.2.0 → 19.2.1
- `frontend/admin`: react/react-dom 19.1.1 → 19.2.1

## テスト結果
- frontend/public: 78 tests passed ✅
- frontend/admin: 250 tests passed ✅

## 参考情報
- [React公式ブログ](https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components)
- [CVE-2025-55182 詳細](https://www.wiz.io/blog/critical-vulnerability-in-react-cve-2025-55182)

🤖 Generated with [Claude Code](https://claude.com/claude-code)