### PR TITLE
Fix: BrowserRouterにbasenameを設定してCloudFrontルーティングを修正

### DIFF
--- a/frontend/admin/src/App.tsx
+++ b/frontend/admin/src/App.tsx
@@ -15,7 +15,9 @@ import PostEditPage from './pages/PostEditPage';
 
 function App() {
   return (
-    <Router>
+    // CloudFrontで /admin/ パスで配信されるため、basename を設定
+    // import.meta.env.BASE_URL は vite.config.ts の base 設定値が自動的に入る
+    <Router basename={import.meta.env.BASE_URL}>
       <AuthProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />


### PR DESCRIPTION
- Router basename={import.meta.env.BASE_URL} を追加
- CloudFrontの /admin/ パスでルーティングが正常に動作するように
- import.meta.env.BASE_URL は vite base 設定から自動取得

🤖 Generated with [Claude Code](https://claude.com/claude-code)