### PR TITLE
Update: ログイン画面とパスワードリセット画面のデザインをPublicサイトに統一

### DIFF
--- a/frontend/admin/src/pages/ForgotPasswordPage.test.tsx
+++ b/frontend/admin/src/pages/ForgotPasswordPage.test.tsx
@@ -21,7 +21,12 @@ describe('ForgotPasswordPage', () => {
   describe('レンダリング', () => {
     it('ロゴが表示される', () => {
       renderForgotPasswordPage();
-      expect(screen.getByAltText('Polylex')).toBeInTheDocument();
+      expect(screen.getByAltText('Logo')).toBeInTheDocument();
+    });
+
+    it('サイトタイトルが表示される', () => {
+      renderForgotPasswordPage();
+      expect(screen.getByText('Bone of my fallacy')).toBeInTheDocument();
     });
 
     it('Adminバッジが表示される', () => {
@@ -244,7 +249,9 @@ describe('ForgotPasswordPage', () => {
   describe('ロゴリンク', () => {
     it('ロゴがルートへのリンクを持つ', () => {
       renderForgotPasswordPage();
-      const logoLink = screen.getByRole('link', { name: /Polylex/i });
+      const logoLink = screen.getByRole('link', {
+        name: /Bone of my fallacy/i,
+      });
       expect(logoLink).toHaveAttribute('href', '/');
     });
   });

--- a/frontend/admin/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/admin/src/pages/ForgotPasswordPage.tsx
@@ -50,10 +50,11 @@ const ForgotPasswordPage = () => {
             <div className="forgot-header">
               <Link to="/" className="forgot-logo">
                 <img
-                  src="/logo_name.png"
-                  alt="Polylex"
+                  src="/fallacy.png"
+                  alt="Logo"
                   className="forgot-logo-image"
                 />
+                <span className="forgot-site-title">Bone of my fallacy</span>
               </Link>
               <span className="forgot-badge">Admin</span>
             </div>
@@ -152,12 +153,21 @@ const ForgotPasswordPage = () => {
         }
 
         .forgot-logo-image {
-          height: 48px;
+          height: 40px;
           width: auto;
+          margin-right: 12px;
+        }
+
+        .forgot-site-title {
+          font-family: 'Caveat', cursive;
+          font-size: 1.5rem;
+          font-weight: 600;
+          color: #1f2937;
+          letter-spacing: 0.02em;
         }
 
         .forgot-badge {
-          background: #111827;
+          background: #2D2A5A;
           color: white;
           padding: 4px 10px;
           border-radius: 6px;
@@ -170,7 +180,7 @@ const ForgotPasswordPage = () => {
         .forgot-title {
           font-size: 1.5rem;
           font-weight: 700;
-          color: #111827;
+          color: #2D2A5A;
           text-align: center;
           margin: 0 0 16px 0;
         }
@@ -245,7 +255,7 @@ const ForgotPasswordPage = () => {
         .forgot-btn-primary {
           width: 100%;
           padding: 12px 20px;
-          background: #111827;
+          background: #2D2A5A;
           color: white;
           border: none;
           border-radius: 10px;
@@ -257,7 +267,7 @@ const ForgotPasswordPage = () => {
         }
 
         .forgot-btn-primary:hover {
-          background: #374151;
+          background: #3d3a6a;
         }
 
         .forgot-btn-primary:disabled {
@@ -277,7 +287,7 @@ const ForgotPasswordPage = () => {
         }
 
         .forgot-btn-link:hover {
-          color: #111827;
+          color: #2D2A5A;
         }
 
         @media (max-width: 480px) {

--- a/frontend/admin/src/pages/LoginPage.tsx
+++ b/frontend/admin/src/pages/LoginPage.tsx
@@ -62,10 +62,11 @@ const LoginPage = () => {
             <div className="login-header">
               <Link to="/" className="login-logo">
                 <img
-                  src="/logo_name.png"
-                  alt="Polylex"
+                  src="/fallacy.png"
+                  alt="Logo"
                   className="login-logo-image"
                 />
+                <span className="login-site-title">Bone of my fallacy</span>
               </Link>
               <span className="login-badge">Admin</span>
             </div>
@@ -117,12 +118,21 @@ const LoginPage = () => {
         }
 
         .login-logo-image {
-          height: 48px;
+          height: 40px;
           width: auto;
+          margin-right: 12px;
+        }
+
+        .login-site-title {
+          font-family: 'Caveat', cursive;
+          font-size: 1.5rem;
+          font-weight: 600;
+          color: #1f2937;
+          letter-spacing: 0.02em;
         }
 
         .login-badge {
-          background: #111827;
+          background: #2D2A5A;
           color: white;
           padding: 4px 10px;
           border-radius: 6px;
@@ -135,7 +145,7 @@ const LoginPage = () => {
         .login-title {
           font-size: 1.5rem;
           font-weight: 700;
-          color: #111827;
+          color: #2D2A5A;
           text-align: center;
           margin: 0 0 8px 0;
         }
@@ -172,7 +182,7 @@ const LoginPage = () => {
         .login-card button[type="submit"] {
           width: 100%;
           padding: 12px 20px;
-          background: #111827;
+          background: #2D2A5A;
           color: white;
           border: none;
           border-radius: 10px;
@@ -183,7 +193,7 @@ const LoginPage = () => {
         }
 
         .login-card button[type="submit"]:hover {
-          background: #374151;
+          background: #3d3a6a;
         }
 
         .login-card button[type="submit"]:disabled {
@@ -201,7 +211,7 @@ const LoginPage = () => {
 
         .login-card a:hover,
         .login-card button:not([type="submit"]):hover {
-          color: #111827;
+          color: #2D2A5A;
         }
 
         .login-card label {


### PR DESCRIPTION
## Summary
- ロゴをfallacy.pngに変更
- サイトタイトル「Bone of my fallacy」を追加
- カラースキームを#2D2A5Aに統一
- Caveatフォントを使用
- テストを更新

## Test plan
- [ ] ログイン画面のデザインがPublicサイトと一致することを確認
- [ ] パスワードリセット画面のデザインがPublicサイトと一致することを確認
- [ ] 全ての管理画面ページでフォントとカラーが統一されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)