### PR TITLE
Fix: Remove CloudFormation exports to allow Layer updates

### DIFF
--- a/infrastructure/lib/layers-stack.ts
+++ b/infrastructure/lib/layers-stack.ts
@@ -30,17 +30,15 @@ export class LayersStack extends cdk.Stack {
       layerVersionName: 'serverless-blog-common',
     });
 
-    // Export Layer ARNs for use in other stacks
+    // Output Layer ARNs (no export to avoid cross-stack update issues)
     new cdk.CfnOutput(this, 'PowertoolsLayerVersionArn', {
       value: this.powertoolsLayer.layerVersionArn,
       description: 'ARN of the Powertools Layer',
-      exportName: 'PowertoolsLayerVersionArn',
     });
 
     new cdk.CfnOutput(this, 'CommonLayerVersionArn', {
       value: this.commonLayer.layerVersionArn,
       description: 'ARN of the Common Layer',
-      exportName: 'CommonLayerVersionArn',
     });
   }
 }

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/node": "^20.10.6",
-    "aws-cdk": "^2.180.0",
+    "aws-cdk": "^2.219.0",
     "esbuild": "^0.27.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
@@ -25,7 +25,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.180.0",
+    "aws-cdk-lib": "^2.219.0",
     "cdk-nag": "^2.28.0",
     "constructs": "^10.3.0"
   }

--- a/infrastructure/test/__snapshots__/layers-stack.test.ts.snap
+++ b/infrastructure/test/__snapshots__/layers-stack.test.ts.snap
@@ -5,18 +5,12 @@ exports[`LayersStack Snapshot test 1`] = `
   "Outputs": {
     "CommonLayerVersionArn": {
       "Description": "ARN of the Common Layer",
-      "Export": {
-        "Name": "CommonLayerVersionArn",
-      },
       "Value": {
         "Ref": "CommonLayer306767A0",
       },
     },
     "PowertoolsLayerVersionArn": {
       "Description": "ARN of the Powertools Layer",
-      "Export": {
-        "Name": "PowertoolsLayerVersionArn",
-      },
       "Value": {
         "Ref": "PowertoolsLayer17979D4B",
       },


### PR DESCRIPTION
- Remove exportName from CfnOutput to avoid cross-stack update issues
- Update CDK version to ^2.219.0 for bun.lock support
- Direct stack references are used, CF exports are not needed

Issue: Cannot update export as it is in use by another stack
Reference: https://github.com/aws/aws-cdk/issues/33464

🤖 Generated with [Claude Code](https://claude.com/claude-code)