### PR TITLE
Fix CDK deploy order to resolve cross-stack reference error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -404,20 +404,71 @@ jobs:
             fi
           fi
 
-      - name: CDK Deploy
+      - name: CDK Deploy (Phase 1 - Base Infrastructure)
         working-directory: infrastructure
         env:
           BASIC_AUTH_USERNAME: ${{ steps.basic-auth.outputs.username }}
           BASIC_AUTH_PASSWORD: ${{ steps.basic-auth.outputs.password }}
         run: |
           echo "========================================="
-          echo "CDK Deploy - ${{ steps.env.outputs.env_name }} Environment"
+          echo "CDK Deploy Phase 1 - Base Infrastructure"
           echo "========================================="
           if [ "${{ steps.env.outputs.stage }}" == "prd" ]; then
             echo "⚠️  Deploying to PRODUCTION"
             echo ""
           fi
-          bunx cdk deploy --all --require-approval never --context stage=${{ steps.env.outputs.stage }} --context rustTrafficPercent=100 --ci --outputs-file cdk-outputs.json
+          # Deploy base stacks first (no cross-stack Lambda references)
+          bunx cdk deploy \
+            ServerlessBlogLayersStack \
+            ServerlessBlogDatabaseStack \
+            ServerlessBlogStorageStack \
+            ServerlessBlogAuthStack \
+            ServerlessBlogApiStack \
+            ServerlessBlogCdnStack \
+            --require-approval never \
+            --context stage=${{ steps.env.outputs.stage }} \
+            --context rustTrafficPercent=100 \
+            --ci
+          echo "✓ Phase 1 complete"
+
+      - name: CDK Deploy (Phase 2 - Lambda Functions)
+        working-directory: infrastructure
+        env:
+          BASIC_AUTH_USERNAME: ${{ steps.basic-auth.outputs.username }}
+          BASIC_AUTH_PASSWORD: ${{ steps.basic-auth.outputs.password }}
+        run: |
+          echo "========================================="
+          echo "CDK Deploy Phase 2 - Lambda Functions"
+          echo "========================================="
+          # Deploy Lambda stacks
+          bunx cdk deploy \
+            ServerlessBlogLambdaFunctionsStack \
+            ServerlessBlogRustLambdaStack \
+            --require-approval never \
+            --context stage=${{ steps.env.outputs.stage }} \
+            --context rustTrafficPercent=100 \
+            --ci
+          echo "✓ Phase 2 complete"
+
+      - name: CDK Deploy (Phase 3 - API Integrations & Monitoring)
+        working-directory: infrastructure
+        env:
+          BASIC_AUTH_USERNAME: ${{ steps.basic-auth.outputs.username }}
+          BASIC_AUTH_PASSWORD: ${{ steps.basic-auth.outputs.password }}
+        run: |
+          echo "========================================="
+          echo "CDK Deploy Phase 3 - API Integrations & Monitoring"
+          echo "========================================="
+          # Deploy integration and monitoring stacks last
+          bunx cdk deploy \
+            ServerlessBlogApiIntegrationsStack \
+            ServerlessBlogMonitoringStack \
+            --require-approval never \
+            --context stage=${{ steps.env.outputs.stage }} \
+            --context rustTrafficPercent=100 \
+            --ci \
+            --outputs-file cdk-outputs.json
+          echo "✓ Phase 3 complete"
           echo "✓ CDK Deployment completed successfully"
 
       - name: Upload CDK Outputs


### PR DESCRIPTION
## Summary
- Fix CDK deployment failure caused by cross-stack reference dependency
- Split CDK deploy into 3 phases to handle stack dependencies correctly

## Problem
CloudFormation error: `Cannot delete export ServerlessBlogLambdaFunctionsStack:ExportsOutputFnGetAttUpdatePostFunction... as it is in use by ServerlessBlogApiStack`

## Root Cause
- `ServerlessBlogApiStack` has a stale import reference to `UpdatePostFunction` from `LambdaFunctionsStack`
- The `--all` flag deploys stacks in an order that doesn't respect this dependency removal

## Solution
Split deployment into 3 phases:
1. **Phase 1 - Base Infrastructure**: Layers, Database, Storage, Auth, API, CDN
   - Updates ApiStack first, removing stale Lambda references
2. **Phase 2 - Lambda Functions**: Node.js and Rust Lambda stacks
   - Can now safely update exports after consumers are updated
3. **Phase 3 - API Integrations & Monitoring**: Final integration layer

## Test plan
- [ ] Deploy to dev environment and verify all stacks deploy successfully
- [ ] Verify API endpoints work correctly after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)