### PR TITLE
feat: Add environment-specific API Gateway configuration

### DIFF
--- a/infrastructure/bin/blog-app.ts
+++ b/infrastructure/bin/blog-app.ts
@@ -67,6 +67,7 @@ const authStack = new AuthStack(app, 'ServerlessBlogAuthStack', { env });
 const apiStack = new ApiStack(app, 'ServerlessBlogApiStack', {
   env,
   userPool: authStack.userPool,
+  stage,
 });
 
 // CDN Stack (CloudFront)
@@ -128,6 +129,7 @@ const apiIntegrationsStack = new ApiIntegrationsStack(
     authorizer: apiStack.authorizer,
     lambdaFunctions: getLambdaFunctions(),
     implementationLabel: getImplementationLabel(),
+    stage,
   }
 );
 

--- a/infrastructure/lib/api-integrations-stack.ts
+++ b/infrastructure/lib/api-integrations-stack.ts
@@ -33,6 +33,11 @@ export interface ApiIntegrationsStackProps extends cdk.StackProps {
    * Used for documentation and logging
    */
   implementationLabel?: string;
+  /**
+   * Environment stage (e.g., 'dev' or 'prd')
+   * Used for environment-specific configurations
+   */
+  stage: string;
 }
 
 /**

--- a/infrastructure/lib/api-stack.ts
+++ b/infrastructure/lib/api-stack.ts
@@ -7,6 +7,7 @@ import { NagSuppressions } from 'cdk-nag';
 
 export interface ApiStackProps extends cdk.StackProps {
   userPool: cognito.IUserPool;
+  stage: string;
 }
 
 export class ApiStack extends cdk.Stack {
@@ -16,14 +17,17 @@ export class ApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ApiStackProps) {
     super(scope, id, props);
 
-    const { userPool } = props;
+    const { userPool, stage } = props;
+    const isProduction = stage === 'prd';
 
-    // CloudWatch Logs for API Gateway Access Logs
-    const apiLogGroup = new logs.LogGroup(this, 'ApiGatewayAccessLogs', {
-      logGroupName: '/aws/apigateway/serverless-blog-api',
-      retention: logs.RetentionDays.ONE_WEEK,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-    });
+    // CloudWatch Logs for API Gateway Access Logs (本番環境のみ使用)
+    const apiLogGroup = isProduction
+      ? new logs.LogGroup(this, 'ApiGatewayAccessLogs', {
+          logGroupName: '/aws/apigateway/serverless-blog-api',
+          retention: logs.RetentionDays.THREE_MONTHS, // prd: 90日
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        })
+      : undefined;
 
     // REST API作成
     this.restApi = new apigateway.RestApi(this, 'BlogApi', {
@@ -48,27 +52,34 @@ export class ApiStack extends cdk.Stack {
       },
       // CloudWatchロール自動作成
       cloudWatchRole: true,
-      // デプロイ設定
+      // デプロイ設定（環境別）
       deployOptions: {
-        stageName: 'prod',
-        tracingEnabled: true,
-        metricsEnabled: true,
-        loggingLevel: apigateway.MethodLoggingLevel.INFO,
-        dataTraceEnabled: true,
-        accessLogDestination: new apigateway.LogGroupLogDestination(
-          apiLogGroup
-        ),
-        accessLogFormat: apigateway.AccessLogFormat.jsonWithStandardFields({
-          caller: true,
-          httpMethod: true,
-          ip: true,
-          protocol: true,
-          requestTime: true,
-          resourcePath: true,
-          responseLength: true,
-          status: true,
-          user: true,
-        }),
+        stageName: isProduction ? 'prod' : 'dev',
+        tracingEnabled: isProduction, // dev:無効, prd:有効
+        metricsEnabled: isProduction, // dev:無効, prd:有効
+        loggingLevel: isProduction
+          ? apigateway.MethodLoggingLevel.INFO
+          : apigateway.MethodLoggingLevel.OFF,
+        dataTraceEnabled: isProduction,
+        ...(isProduction && apiLogGroup
+          ? {
+              accessLogDestination: new apigateway.LogGroupLogDestination(
+                apiLogGroup
+              ),
+              accessLogFormat:
+                apigateway.AccessLogFormat.jsonWithStandardFields({
+                  caller: true,
+                  httpMethod: true,
+                  ip: true,
+                  protocol: true,
+                  requestTime: true,
+                  resourcePath: true,
+                  responseLength: true,
+                  status: true,
+                  user: true,
+                }),
+            }
+          : {}),
       },
     });
 
@@ -129,20 +140,38 @@ export class ApiStack extends cdk.Stack {
     // AwsSolutions-APIG3: AWS WAF integration
     // AwsSolutions-APIG4: API Gatewayの認証が未実装
     // 理由: リソースにメソッドが未統合のため。Lambda統合時に認証を実装予定
+    const baseSuppressions = [
+      {
+        id: 'AwsSolutions-APIG3',
+        reason:
+          'AWS WAF integration is not required for development environment. Should be enabled in production for DDoS protection and request filtering.',
+      },
+      {
+        id: 'AwsSolutions-APIG4',
+        reason:
+          'Authorization will be implemented when Lambda functions are integrated with API Gateway methods. Currently resources are created but methods are not yet attached.',
+      },
+    ];
+
+    // dev環境のみ: アクセスログ・CloudWatch logging無効化の抑止
+    const devSuppressions = isProduction
+      ? []
+      : [
+          {
+            id: 'AwsSolutions-APIG1',
+            reason:
+              'Access logging is disabled in development environment to reduce costs. Enabled in production.',
+          },
+          {
+            id: 'AwsSolutions-APIG6',
+            reason:
+              'CloudWatch logging is disabled in development environment to reduce costs. Enabled in production.',
+          },
+        ];
+
     NagSuppressions.addResourceSuppressions(
       this.restApi,
-      [
-        {
-          id: 'AwsSolutions-APIG3',
-          reason:
-            'AWS WAF integration is not required for development environment. Should be enabled in production for DDoS protection and request filtering.',
-        },
-        {
-          id: 'AwsSolutions-APIG4',
-          reason:
-            'Authorization will be implemented when Lambda functions are integrated with API Gateway methods. Currently resources are created but methods are not yet attached.',
-        },
-      ],
+      [...baseSuppressions, ...devSuppressions],
       true
     );
 


### PR DESCRIPTION
## Summary
- Add stage parameter to ApiStack and ApiIntegrationsStack for environment-specific configuration
- Configure API Gateway stageName dynamically (dev/prod based on stage context)
- Enable tracing, metrics, and access logs only in production environment
- Set CloudWatch log retention to 90 days for production, disabled for dev to reduce costs
- Add CDK Nag suppressions for dev environment logging settings (APIG1, APIG6)

## Environment-specific Settings

| Setting | dev | prd |
|---------|-----|-----|
| stageName | `dev` | `prod` |
| Tracing (X-Ray) | Disabled | Enabled |
| Access Logs | Disabled | Enabled |
| Metrics | Disabled | Enabled |
| Log Retention | N/A | 90 days |

## Test plan
- [x] CDK synth with `--context stage=dev` passes
- [x] CDK synth with `--context stage=prd` passes
- [x] Verified stageName is correctly set for each environment
- [x] Verified tracing/metrics/logging settings differ by environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)