### PR TITLE
fix: Add stage parameter to ApiStack tests

### DIFF
--- a/infrastructure/test/__snapshots__/api-stack.test.ts.snap
+++ b/infrastructure/test/__snapshots__/api-stack.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`ApiStack Snapshot test 1`] = `
 {
@@ -112,7 +112,7 @@ exports[`ApiStack Snapshot test 1`] = `
       "DeletionPolicy": "Delete",
       "Properties": {
         "LogGroupName": "/aws/apigateway/serverless-blog-api",
-        "RetentionInDays": 7,
+        "RetentionInDays": 90,
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Delete",

--- a/infrastructure/test/api-stack.test.ts
+++ b/infrastructure/test/api-stack.test.ts
@@ -21,8 +21,10 @@ describe('ApiStack', () => {
     });
 
     // Create ApiStack with reference to AuthStack
+    // Use 'prd' stage to test production configuration (tracing, metrics, logging enabled)
     apiStack = new ApiStack(app, 'TestApiStack', {
       userPool: authStack.userPool,
+      stage: 'prd',
       env: {
         account: '123456789012',
         region: 'ap-northeast-1',

--- a/infrastructure/test/cdk-nag-security.test.ts
+++ b/infrastructure/test/cdk-nag-security.test.ts
@@ -102,6 +102,7 @@ describe('CDK Nag Security Validation', () => {
       const stack = new ApiStack(app, 'TestApiStack', {
         env,
         userPool: authStack.userPool,
+        stage: 'prd',
       });
       cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
       app.synth();
@@ -187,6 +188,7 @@ describe('CDK Nag Security Validation', () => {
       const stack = new ApiStack(app, 'TestApiStack', {
         env,
         userPool: authStack.userPool,
+        stage: 'prd',
       });
       cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
       app.synth();


### PR DESCRIPTION
## Summary
- Add `stage: 'prd'` parameter to ApiStack instantiation in tests
- Update snapshot for production configuration
- Fix cdk-nag-security.test.ts ApiStack tests

## Root Cause
The previous PR (#73) added a required `stage` parameter to `ApiStackProps`, but the test files were not updated to pass this parameter.

## Test plan
- [x] `bun test api-stack` passes
- [x] `bun test cdk-nag-security` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)