### PR TITLE
chore: Remove CDK stacks and clean up import.tf for Terraform migration

### DIFF
--- a/infrastructure/bin/blog-app.ts
+++ b/infrastructure/bin/blog-app.ts
@@ -87,6 +87,9 @@ const cdnStack = new CdnStack(app, 'ServerlessBlogCdnStack', {
 
 // Go Lambda Functions Stack (唯一のサポートされている実装)
 // API integrations are handled by ApiIntegrationsStack
+// NOTE: CloudFront domain is HARDCODED to break circular dependency for stack deletion
+// This domain is managed by Terraform (distribution ESRLM0CV5EBG7)
+const HARDCODED_CLOUDFRONT_DOMAIN = 'db0rcxmu4fmis.cloudfront.net';
 const goLambdaStack = new GoLambdaStack(app, 'ServerlessBlogGoLambdaStack', {
   env,
   blogPostsTable: databaseStack.blogPostsTable,
@@ -95,7 +98,7 @@ const goLambdaStack = new GoLambdaStack(app, 'ServerlessBlogGoLambdaStack', {
   authorizer: apiStack.authorizer,
   userPoolId: authStack.userPool.userPoolId,
   userPoolClientId: authStack.userPoolClient.userPoolClientId,
-  cloudFrontDomainName: cdnStack.distribution.distributionDomainName,
+  cloudFrontDomainName: HARDCODED_CLOUDFRONT_DOMAIN,
   createApiIntegrations: false, // API integrations handled by ApiIntegrationsStack
 });
 

--- a/infrastructure/lib/cdn-stack.ts
+++ b/infrastructure/lib/cdn-stack.ts
@@ -152,6 +152,7 @@ export class CdnStack extends cdk.Stack {
         runtime: cloudfront.FunctionRuntime.JS_2_0,
         autoPublish: true,
       });
+      basicAuthFunction.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
 
       // Combined Basic Auth + SPA routing for Admin site (DEV)
       // CloudFront only allows one function per event type, so we combine both functions
@@ -200,6 +201,7 @@ export class CdnStack extends cdk.Stack {
           autoPublish: true,
         }
       );
+      adminCombinedFunction.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
     }
 
     // CloudFront Function for Admin SPA routing (PRD only)
@@ -232,6 +234,7 @@ export class CdnStack extends cdk.Stack {
         runtime: cloudfront.FunctionRuntime.JS_2_0,
         autoPublish: true,
       });
+      adminSpaFunction.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
     }
 
     // CloudFront Function for Images path rewriting
@@ -261,6 +264,7 @@ export class CdnStack extends cdk.Stack {
         autoPublish: true,
       }
     );
+    imagePathFunction.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
 
     // Cache policy for images with long TTL
     const imageCachePolicy = new cloudfront.CachePolicy(
@@ -279,6 +283,7 @@ export class CdnStack extends cdk.Stack {
         cookieBehavior: cloudfront.CacheCookieBehavior.none(),
       }
     );
+    imageCachePolicy.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
 
     // API Gateway Origin setup
     // Construct API Gateway hostname from REST API ID and region
@@ -315,6 +320,7 @@ export class CdnStack extends cdk.Stack {
       runtime: cloudfront.FunctionRuntime.JS_2_0,
       autoPublish: true,
     });
+    apiPathFunction.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
 
     // Origin Request Policy for API Gateway
     // Forward necessary headers and query strings to API Gateway
@@ -335,6 +341,7 @@ export class CdnStack extends cdk.Stack {
         cookieBehavior: cloudfront.OriginRequestCookieBehavior.none(),
       }
     );
+    apiOriginRequestPolicy.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
 
     // Unified CloudFront Distribution for all sites (public, admin, images)
     // Using Origin Access Control (OAC) - recommended best practice over OAI
@@ -450,6 +457,10 @@ export class CdnStack extends cdk.Stack {
         minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
       }
     );
+
+    // Apply RETAIN policy for safe CloudFormation stack deletion
+    // This ensures CloudFront resources remain when stack is deleted (Terraform manages them)
+    this.distribution.applyRemovalPolicy(cdk.RemovalPolicy.RETAIN);
 
     // CDK Nag suppressions for Unified Distribution
     NagSuppressions.addResourceSuppressions(

--- a/terraform/environments/dev/import.tf
+++ b/terraform/environments/dev/import.tf
@@ -190,44 +190,8 @@ import {
 # }
 
 #------------------------------------------------------------------------------
-# CDN Module Imports
+# CDN Module Imports - REMOVED
+# CDK CdnStack was deleted, CDN resources will be recreated by Terraform
 #------------------------------------------------------------------------------
-import {
-  to = module.cdn.aws_cloudfront_distribution.main
-  id = "ESRLM0CV5EBG7"
-}
-
-import {
-  to = module.cdn.aws_cloudfront_origin_access_control.s3_oac
-  id = "E3HGZ6IT0VJXIP"
-}
-
-import {
-  to = module.cdn.aws_cloudfront_function.image_path
-  id = "ImagePathFunction-dev"
-}
-
-import {
-  to = module.cdn.aws_cloudfront_function.admin_combined[0]
-  id = "AdminCombinedFunction-dev"
-}
-
-import {
-  to = module.cdn.aws_cloudfront_function.api_path
-  id = "ApiPathFunction-dev"
-}
-
-import {
-  to = module.cdn.aws_cloudfront_function.basic_auth[0]
-  id = "BasicAuthFunction-dev"
-}
-
-import {
-  to = module.cdn.aws_cloudfront_cache_policy.images
-  id = "073fd421-ac36-448c-a0f8-37033f73e2ee"
-}
-
-import {
-  to = module.cdn.aws_cloudfront_origin_request_policy.api
-  id = "49da6566-5d17-4347-aecd-5fca52d2e527"
-}
+# All CDN imports have been removed as the resources no longer exist
+# and will be created fresh by Terraform


### PR DESCRIPTION
- Remove CDN module imports from import.tf (resources deleted with CDK stacks)
- Add RemovalPolicy.RETAIN to cdn-stack.ts CloudFront resources
- Hardcode CloudFront domain in blog-app.ts to break circular dependency

CDK stacks deleted:
- ServerlessBlogCdnStack
- ServerlessBlogApiStack
- ServerlessBlogGoLambdaStack
- ServerlessBlogStorageStack
- ServerlessBlogAuthStack
- ServerlessBlogDatabaseStack

Terraform will recreate CDN resources on next apply.