### PR TITLE
fix: Enable Basic Auth and fix CloudFront cache policy bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -310,6 +310,15 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActions-TerraformApply-DEV
 
+      - name: Get Basic Auth Credentials from SSM
+        run: |
+          USERNAME=$(aws ssm get-parameter --name "/serverless-blog/dev/basic-auth/username" --query "Parameter.Value" --output text)
+          PASSWORD=$(aws ssm get-parameter --name "/serverless-blog/dev/basic-auth/password" --with-decryption --query "Parameter.Value" --output text)
+          echo "::add-mask::$USERNAME"
+          echo "::add-mask::$PASSWORD"
+          echo "TF_VAR_basic_auth_username=$USERNAME" >> $GITHUB_ENV
+          echo "TF_VAR_basic_auth_password=$PASSWORD" >> $GITHUB_ENV
+
       - name: Terraform Init
         working-directory: terraform/environments/dev
         run: terraform init

--- a/terraform/environments/dev/import.tf
+++ b/terraform/environments/dev/import.tf
@@ -203,9 +203,8 @@ import {
   id = "ApiPathFunction-dev"
 }
 
-# Note: admin_spa is conditional (count = var.enable_basic_auth ? 0 : 1)
-# Only import if enable_basic_auth is false
-import {
-  to = module.cdn.aws_cloudfront_function.admin_spa[0]
-  id = "AdminSpaFunction-dev"
-}
+# Note: With enable_basic_auth = true:
+# - admin_spa (count=0) is NOT created
+# - basic_auth (count=1) IS created
+# - admin_combined (count=1) IS created
+# Existing AdminSpaFunction-dev in AWS must be deleted manually before apply

--- a/terraform/modules/cdn/main.tf
+++ b/terraform/modules/cdn/main.tf
@@ -1,6 +1,13 @@
 # CDN Module - CloudFront Distribution
 # Requirements: 7.1, 7.2, 7.3, 7.4, 7.5, 7.6
 
+# AWS managed cache policy IDs (hardcoded to avoid Terraform provider bug)
+# See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+locals {
+  cache_policy_caching_optimized = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+  cache_policy_caching_disabled  = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+}
+
 # Origin Access Control for S3 buckets
 # Requirement 7.1: Create distribution with OAC for S3 origin
 resource "aws_cloudfront_origin_access_control" "s3_oac" {
@@ -244,7 +251,7 @@ resource "aws_cloudfront_distribution" "main" {
     target_origin_id       = "public-site"
     viewer_protocol_policy = "redirect-to-https"
     compress               = true
-    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized.id
+    cache_policy_id        = local.cache_policy_caching_optimized
 
     # Basic Auth function for dev environment protection
     dynamic "function_association" {
@@ -300,7 +307,7 @@ resource "aws_cloudfront_distribution" "main" {
     target_origin_id       = "admin-site"
     viewer_protocol_policy = "redirect-to-https"
     compress               = true
-    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized.id
+    cache_policy_id        = local.cache_policy_caching_optimized
 
     # Use combined function (auth + SPA) for dev, SPA-only for production
     function_association {
@@ -335,7 +342,7 @@ resource "aws_cloudfront_distribution" "main" {
     target_origin_id         = "api-gateway"
     viewer_protocol_policy   = "redirect-to-https"
     compress                 = true
-    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    cache_policy_id          = local.cache_policy_caching_disabled
     origin_request_policy_id = aws_cloudfront_origin_request_policy.api.id
 
     function_association {
@@ -383,11 +390,3 @@ resource "aws_cloudfront_distribution" "main" {
   )
 }
 
-# Data sources for managed cache policies
-data "aws_cloudfront_cache_policy" "caching_optimized" {
-  name = "Managed-CachingOptimized"
-}
-
-data "aws_cloudfront_cache_policy" "caching_disabled" {
-  name = "Managed-CachingDisabled"
-}


### PR DESCRIPTION
- CDN module: Hardcode AWS managed cache policy IDs to avoid Terraform provider "inconsistent final plan" bug
- deploy.yml: Add SSM parameter retrieval for Basic Auth credentials
- import.tf: Remove admin_spa import (count=0 when Basic Auth enabled)

AWS cleanup: AdminSpaFunction-dev manually deleted (not needed when enable_basic_auth = true)