### PR TITLE
fix: Add environment to build-frontend-admin for OIDC credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -468,6 +468,7 @@ jobs:
     name: Build Frontend (Admin)
     runs-on: ubuntu-latest
     needs: [detect-changes]
+    environment: ${{ needs.detect-changes.outputs.target-env }}
     if: needs.detect-changes.outputs.deploy-frontend == 'true'
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Fix AWS OIDC credential loading error in build-frontend-admin job.

## Problem
```
Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

## Root Cause
The `build-frontend-admin` job was missing the `environment` setting, so it couldn't access the `AWS_ROLE_ARN` secret stored in the environment.

## Fix
Added `environment: ${{ needs.detect-changes.outputs.target-env }}` to the job configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)