### PR TITLE
fix: Add -trimpath flag for reproducible Lambda builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
           echo "========================================="
           mkdir -p bin/${{ matrix.function }}
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
-            go build -ldflags="-s -w" -tags="lambda.norpc" \
+            go build -trimpath -ldflags="-s -w" -tags="lambda.norpc" \
             -o bin/${{ matrix.function }}/bootstrap ./cmd/${{ matrix.path }}
           echo "✓ ${{ matrix.function }} built successfully"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -225,7 +225,7 @@ jobs:
         run: |
           mkdir -p bin/${{ matrix.function }}
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
-            go build -ldflags="-s -w" -tags="lambda.norpc" \
+            go build -trimpath -ldflags="-s -w" -tags="lambda.norpc" \
             -o bin/${{ matrix.function }}/bootstrap ./cmd/${{ matrix.path }}
           echo "✓ ${{ matrix.function }} built"
 


### PR DESCRIPTION
## Summary
Add `-trimpath` flag to Go build commands to ensure reproducible Lambda builds.

## Problem
Lambda `source_code_hash` was changing on every Terraform plan/apply even when source code hadn't changed.

## Root Cause
Without `-trimpath`, Go embeds absolute file paths in binaries:
```
/home/runner/work/serverlessBlog/serverlessBlog/go-functions/cmd/posts/create/main.go
```

Different CI runners produce different binaries → different hashes → unnecessary Lambda updates.

## Solution
Add `-trimpath` flag to strip paths from binaries:
```bash
go build -trimpath -ldflags="-s -w" -tags="lambda.norpc" ...
```

## Files Changed
- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)