### PR TITLE
fix(cors): Restrict CORS origin to specific domains

### DIFF
--- a/go-functions/internal/middleware/middleware.go
+++ b/go-functions/internal/middleware/middleware.go
@@ -3,14 +3,21 @@ package middleware
 
 import (
 	"encoding/json"
+	"os"
 
 	"github.com/aws/aws-lambda-go/events"
 )
 
 // CORSHeaders returns standard CORS headers.
+// The Access-Control-Allow-Origin value is read from the ALLOWED_ORIGIN
+// environment variable. If not set, it falls back to "*" for local development.
 func CORSHeaders() map[string]string {
+	origin := os.Getenv("ALLOWED_ORIGIN")
+	if origin == "" {
+		origin = "*"
+	}
 	return map[string]string{
-		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Origin":  origin,
 		"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
 		"Access-Control-Allow-Headers": "Content-Type, Authorization",
 		"Content-Type":                 "application/json",

--- a/go-functions/internal/middleware/middleware_test.go
+++ b/go-functions/internal/middleware/middleware_test.go
@@ -3,14 +3,35 @@ package middleware
 import (
 	"encoding/json"
 	"math"
+	"os"
 	"testing"
 )
 
-func TestCORSHeaders(t *testing.T) {
+func TestCORSHeaders_Default(t *testing.T) {
+	os.Unsetenv("ALLOWED_ORIGIN")
+	headers := CORSHeaders()
+
+	if got := headers["Access-Control-Allow-Origin"]; got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "*")
+	}
+}
+
+func TestCORSHeaders_WithEnvVar(t *testing.T) {
+	os.Setenv("ALLOWED_ORIGIN", "https://example.com")
+	defer os.Unsetenv("ALLOWED_ORIGIN")
+
+	headers := CORSHeaders()
+
+	if got := headers["Access-Control-Allow-Origin"]; got != "https://example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "https://example.com")
+	}
+}
+
+func TestCORSHeaders_StaticHeaders(t *testing.T) {
+	os.Unsetenv("ALLOWED_ORIGIN")
 	headers := CORSHeaders()
 
 	expected := map[string]string{
-		"Access-Control-Allow-Origin":  "*",
 		"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
 		"Access-Control-Allow-Headers": "Content-Type, Authorization",
 		"Content-Type":                 "application/json",

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -59,6 +59,7 @@ module "storage" {
   environment                 = var.environment
   enable_access_logs          = false # Access logs not enabled for dev
   cloudfront_distribution_arn = ""    # Bucket policy set separately to avoid circular dependency
+  cors_allow_origins          = ["*"] # Dev uses wildcard (protected by Basic Auth)
 
   tags = local.common_tags
 }
@@ -73,6 +74,7 @@ module "lambda" {
   source = "../../modules/lambda"
 
   environment         = var.environment
+  cors_allowed_origin = "*" # Dev uses wildcard (protected by Basic Auth)
   table_name          = module.database.table_name
   table_arn           = module.database.table_arn
   bucket_name         = module.storage.image_bucket_name

--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -55,8 +55,9 @@ module "storage" {
 
   project_name                = var.project_name
   environment                 = var.environment
-  enable_access_logs          = true # Access logs enabled for prd
-  cloudfront_distribution_arn = ""   # Bucket policy set separately to avoid circular dependency
+  enable_access_logs          = true                           # Access logs enabled for prd
+  cloudfront_distribution_arn = ""                             # Bucket policy set separately to avoid circular dependency
+  cors_allow_origins          = ["https://${var.domain_name}"] # Restrict CORS to custom domain
 
   tags = local.common_tags
 }
@@ -171,7 +172,7 @@ module "api" {
   environment           = var.environment
   stage_name            = var.environment
   cognito_user_pool_arn = module.auth.user_pool_arn
-  cors_allow_origins    = ["*"]
+  cors_allow_origins    = ["https://${var.domain_name}"]
 
   # Lambda function ARNs (from data sources)
   lambda_create_post_arn            = data.aws_lambda_function.create_post.arn
@@ -360,6 +361,7 @@ module "lambda" {
   user_pool_arn       = module.auth.user_pool_arn
   user_pool_client_id = module.auth.user_pool_client_id
   cloudfront_domain   = module.cdn.distribution_domain_name
+  cors_allowed_origin = "https://${var.domain_name}"
   enable_xray         = true # X-Ray enabled for prd
   go_binary_path      = "${path.module}/../../../go-functions/bin"
 

--- a/terraform/modules/api/main.tf
+++ b/terraform/modules/api/main.tf
@@ -242,7 +242,7 @@ resource "aws_api_gateway_integration_response" "admin_posts_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -357,7 +357,7 @@ resource "aws_api_gateway_integration_response" "admin_posts_id_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,PUT,DELETE,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -424,7 +424,7 @@ resource "aws_api_gateway_integration_response" "admin_images_upload_url_options
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'POST,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -495,7 +495,7 @@ resource "aws_api_gateway_integration_response" "admin_images_key_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'DELETE,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -561,7 +561,7 @@ resource "aws_api_gateway_integration_response" "admin_auth_login_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'POST,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -628,7 +628,7 @@ resource "aws_api_gateway_integration_response" "admin_auth_logout_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'POST,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -694,7 +694,7 @@ resource "aws_api_gateway_integration_response" "admin_auth_refresh_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'POST,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -760,7 +760,7 @@ resource "aws_api_gateway_integration_response" "posts_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -830,7 +830,7 @@ resource "aws_api_gateway_integration_response" "posts_id_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -913,7 +913,7 @@ resource "aws_api_gateway_integration_response" "categories_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -995,7 +995,7 @@ resource "aws_api_gateway_integration_response" "admin_categories_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'POST,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -1105,7 +1105,7 @@ resource "aws_api_gateway_integration_response" "admin_categories_id_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'PUT,DELETE,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -1187,7 +1187,7 @@ resource "aws_api_gateway_integration_response" "admin_categories_sort_options" 
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'PATCH,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -1290,7 +1290,7 @@ resource "aws_api_gateway_integration_response" "admin_mindmaps_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,POST,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -1405,7 +1405,7 @@ resource "aws_api_gateway_integration_response" "admin_mindmaps_id_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,PUT,DELETE,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -1496,7 +1496,7 @@ resource "aws_api_gateway_integration_response" "public_mindmaps_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -1566,7 +1566,7 @@ resource "aws_api_gateway_integration_response" "public_mindmaps_id_options" {
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
   }
 }
 
@@ -1581,7 +1581,7 @@ resource "aws_api_gateway_gateway_response" "default_4xx" {
   response_type = "DEFAULT_4XX"
 
   response_parameters = {
-    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
     "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PUT,DELETE,OPTIONS'"
   }
@@ -1598,7 +1598,7 @@ resource "aws_api_gateway_gateway_response" "default_5xx" {
   response_type = "DEFAULT_5XX"
 
   response_parameters = {
-    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'*'"
+    "gatewayresponse.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
     "gatewayresponse.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
     "gatewayresponse.header.Access-Control-Allow-Methods" = "'GET,POST,PUT,DELETE,OPTIONS'"
   }

--- a/terraform/modules/api/tests/api.tftest.hcl
+++ b/terraform/modules/api/tests/api.tftest.hcl
@@ -5,6 +5,56 @@
 # Mock provider for testing without AWS credentials
 mock_provider "aws" {}
 
+# Global variables for all Lambda ARNs (required by API module)
+variables {
+  lambda_create_post_arn                         = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-create-post-go"
+  lambda_create_post_invoke_arn                  = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-create-post-go/invocations"
+  lambda_list_posts_arn                          = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-list-posts-go"
+  lambda_list_posts_invoke_arn                   = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-list-posts-go/invocations"
+  lambda_get_post_arn                            = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-post-go"
+  lambda_get_post_invoke_arn                     = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-post-go/invocations"
+  lambda_get_public_post_arn                     = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-public-post-go"
+  lambda_get_public_post_invoke_arn              = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-public-post-go/invocations"
+  lambda_update_post_arn                         = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-update-post-go"
+  lambda_update_post_invoke_arn                  = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-update-post-go/invocations"
+  lambda_delete_post_arn                         = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-delete-post-go"
+  lambda_delete_post_invoke_arn                  = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-delete-post-go/invocations"
+  lambda_login_arn                               = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-login-go"
+  lambda_login_invoke_arn                        = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-login-go/invocations"
+  lambda_logout_arn                              = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-logout-go"
+  lambda_logout_invoke_arn                       = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-logout-go/invocations"
+  lambda_refresh_arn                             = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-refresh-go"
+  lambda_refresh_invoke_arn                      = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-refresh-go/invocations"
+  lambda_get_upload_url_arn                      = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-upload-url-go"
+  lambda_get_upload_url_invoke_arn               = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-upload-url-go/invocations"
+  lambda_delete_image_arn                        = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-delete-image-go"
+  lambda_delete_image_invoke_arn                 = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-delete-image-go/invocations"
+  lambda_list_categories_arn                     = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-list-categories-go"
+  lambda_list_categories_invoke_arn              = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-list-categories-go/invocations"
+  lambda_create_category_arn                     = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-create-category-go"
+  lambda_create_category_invoke_arn              = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-create-category-go/invocations"
+  lambda_update_category_arn                     = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-update-category-go"
+  lambda_update_category_invoke_arn              = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-update-category-go/invocations"
+  lambda_update_categories_sort_order_arn        = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-update-categories-sort-order-go"
+  lambda_update_categories_sort_order_invoke_arn = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-update-categories-sort-order-go/invocations"
+  lambda_delete_category_arn                     = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-delete-category-go"
+  lambda_delete_category_invoke_arn              = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-delete-category-go/invocations"
+  lambda_create_mindmap_arn                      = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-create-mindmap-go"
+  lambda_create_mindmap_invoke_arn               = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-create-mindmap-go/invocations"
+  lambda_get_mindmap_arn                         = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-mindmap-go"
+  lambda_get_mindmap_invoke_arn                  = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-mindmap-go/invocations"
+  lambda_list_mindmaps_arn                       = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-list-mindmaps-go"
+  lambda_list_mindmaps_invoke_arn                = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-list-mindmaps-go/invocations"
+  lambda_update_mindmap_arn                      = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-update-mindmap-go"
+  lambda_update_mindmap_invoke_arn               = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-update-mindmap-go/invocations"
+  lambda_delete_mindmap_arn                      = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-delete-mindmap-go"
+  lambda_delete_mindmap_invoke_arn               = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-delete-mindmap-go/invocations"
+  lambda_get_public_mindmap_arn                  = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-public-mindmap-go"
+  lambda_get_public_mindmap_invoke_arn           = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-public-mindmap-go/invocations"
+  lambda_list_public_mindmaps_arn                = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-list-public-mindmaps-go"
+  lambda_list_public_mindmaps_invoke_arn         = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-list-public-mindmaps-go/invocations"
+}
+
 # ======================
 # REST API Creation Tests
 # ======================
@@ -470,7 +520,7 @@ run "gateway_response_4xx_cors_header" {
   }
 
   assert {
-    condition     = aws_api_gateway_gateway_response.default_4xx.response_parameters["gatewayresponse.header.Access-Control-Allow-Origin"] == "'*'"
+    condition     = aws_api_gateway_gateway_response.default_4xx.response_parameters["gatewayresponse.header.Access-Control-Allow-Origin"] == "'${var.cors_allow_origins[0]}'"
     error_message = "4xx Gateway Response must have Access-Control-Allow-Origin header"
   }
 }

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -22,6 +22,7 @@ locals {
     USER_POOL_ID        = var.user_pool_id
     USER_POOL_CLIENT_ID = var.user_pool_client_id
     CLOUDFRONT_DOMAIN   = "https://${var.cloudfront_domain}"
+    ALLOWED_ORIGIN      = var.cors_allowed_origin
   }
 
   common_tags = merge(var.tags, {
@@ -153,11 +154,13 @@ locals {
   # Categories domain environment variables
   categories_environment = {
     CATEGORIES_TABLE_NAME = var.categories_table_name
+    ALLOWED_ORIGIN        = var.cors_allowed_origin
   }
 
   # Mindmaps domain environment variables
   mindmaps_environment = {
-    TABLE_NAME = var.mindmaps_table_name
+    TABLE_NAME     = var.mindmaps_table_name
+    ALLOWED_ORIGIN = var.cors_allowed_origin
   }
 }
 

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -51,6 +51,12 @@ variable "cloudfront_domain" {
   description = "CloudFront domain name (optional, can be updated after initial deployment)"
 }
 
+variable "cors_allowed_origin" {
+  type        = string
+  default     = "*"
+  description = "Allowed origin for CORS (passed to Lambda as ALLOWED_ORIGIN env var)"
+}
+
 variable "enable_xray" {
   type        = bool
   default     = false

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -165,7 +165,7 @@ resource "aws_s3_bucket_cors_configuration" "images" {
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["PUT"]
-    allowed_origins = ["*"]
+    allowed_origins = var.cors_allow_origins
     max_age_seconds = 3000
   }
 }

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -27,6 +27,12 @@ variable "cloudfront_distribution_arn" {
   description = "CloudFront distribution ARN for OAC policy"
 }
 
+variable "cors_allow_origins" {
+  type        = list(string)
+  default     = ["*"]
+  description = "CORS allowed origins for S3 image bucket"
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
## Summary
- Replace hardcoded `Access-Control-Allow-Origin: *` across Go middleware, API Gateway, Lambda env vars, and S3 CORS
- Go middleware reads `ALLOWED_ORIGIN` env var with `*` fallback for local dev
- API Gateway OPTIONS responses and Gateway Responses (4XX/5XX) now use `var.cors_allow_origins[0]`
- S3 image bucket CORS uses `var.cors_allow_origins` list
- dev: `*` (protected by Basic Auth); prd: `https://{domain_name}`
- Also fixes pre-existing broken API module terraform test (missing mindmap Lambda ARN variables)

## Test plan
- [x] `go test ./internal/middleware/...` - all pass (default fallback + env var override)
- [x] `terraform validate` - dev and prd both pass
- [x] `terraform test` in modules/api - all 33 tests pass
- [x] Pre-commit hooks pass (lint, trivy, terraform fmt/validate/test)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)