### PR TITLE
feat(api): add API Gateway throttling configuration

### DIFF
--- a/terraform/modules/api/main.tf
+++ b/terraform/modules/api/main.tf
@@ -1809,8 +1809,10 @@ resource "aws_api_gateway_method_settings" "all" {
   method_path = "*/*"
 
   settings {
-    metrics_enabled = local.is_production
-    logging_level   = local.is_production ? "INFO" : "OFF"
+    metrics_enabled        = local.is_production
+    logging_level          = local.is_production ? "INFO" : "OFF"
+    throttling_rate_limit  = var.throttling_rate_limit
+    throttling_burst_limit = var.throttling_burst_limit
   }
 }
 

--- a/terraform/modules/api/variables.tf
+++ b/terraform/modules/api/variables.tf
@@ -278,3 +278,19 @@ variable "lambda_list_public_mindmaps_invoke_arn" {
   type        = string
   description = "List Public Mindmaps Lambda function invoke ARN"
 }
+
+# ======================
+# API Gateway Throttling
+# ======================
+
+variable "throttling_rate_limit" {
+  description = "API Gateway default throttling rate limit (requests per second)"
+  type        = number
+  default     = 100
+}
+
+variable "throttling_burst_limit" {
+  description = "API Gateway default throttling burst limit"
+  type        = number
+  default     = 200
+}


### PR DESCRIPTION
## Related Issue
Closes #130

## Summary
- API Gateway Stage にデフォルトスロットリング設定を追加
- Rate limit: 100 req/s、Burst limit: 200（変数でカスタマイズ可能）
- `aws_api_gateway_method_settings` に `throttling_rate_limit` / `throttling_burst_limit` を設定

## Test plan
- `terraform validate` パス済み
- `terraform fmt -check` パス済み
- Trivy IaCスキャン パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code) Agent Teams