### PR TITLE
feat(ci): add dependency vulnerability scanning to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,16 @@ jobs:
         working-directory: frontend/admin
         run: bun run lint
 
+      - name: Security audit (public-site)
+        run: npm audit --production --audit-level=high
+        working-directory: frontend/public
+        continue-on-error: true
+
+      - name: Security audit (admin-dashboard)
+        run: npm audit --production --audit-level=high
+        working-directory: frontend/admin
+        continue-on-error: true
+
   # =======================================
   # Job 2: Backend Unit Tests - REMOVED (Task 21.3)
   # Node.js implementation (functions/) has been deleted.
@@ -193,6 +203,13 @@ jobs:
           version: v2.7
           working-directory: go-functions
           args: --timeout=5m
+
+      - name: Go vulnerability check
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+        working-directory: go-functions
+        continue-on-error: true
 
   # =======================================
   # Job 2.6b: Go Tests - Coverage (conditional on 'go' label)


### PR DESCRIPTION
## Related Issue
Closes #131

## Summary
- フロントエンド (public-site, admin) に `npm audit --production --audit-level=high` を追加
- Go関数に `govulncheck` による脆弱性チェックを追加
- Phase 1: `continue-on-error: true` で警告のみ（既存CIフロー非破壊）

## Test plan
- CI実行時にnpm auditステップが追加されていることを確認
- CI実行時にgovulncheckステップが追加されていることを確認
- 既存のlint/testジョブが影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code) Agent Teams