### PR TITLE
fix(ci): add mindmap Lambda functions to CI build matrix and fix Cloudflare token placeholder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,20 @@ jobs:
             path: categories/bulk_sort
           - function: categories-delete
             path: categories/delete
+          - function: mindmaps-create
+            path: mindmaps/create
+          - function: mindmaps-get
+            path: mindmaps/get
+          - function: mindmaps-list
+            path: mindmaps/list
+          - function: mindmaps-update
+            path: mindmaps/update
+          - function: mindmaps-delete
+            path: mindmaps/delete
+          - function: mindmaps-get_public
+            path: mindmaps/get_public
+          - function: mindmaps-list_public
+            path: mindmaps/list_public
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -534,7 +548,7 @@ jobs:
           echo "========================================="
           echo "Verifying Lambda Binaries"
           echo "========================================="
-          FUNCS="posts-create posts-get posts-get_public posts-list posts-update posts-delete auth-login auth-logout auth-refresh images-get_upload_url images-delete categories-list categories-create categories-update categories-bulk_sort categories-delete"
+          FUNCS="posts-create posts-get posts-get_public posts-list posts-update posts-delete auth-login auth-logout auth-refresh images-get_upload_url images-delete categories-list categories-create categories-update categories-bulk_sort categories-delete mindmaps-create mindmaps-get mindmaps-list mindmaps-update mindmaps-delete mindmaps-get_public mindmaps-list_public"
           MISSING=0
           for f in $FUNCS; do
             if [ -f "go-functions/bin/$f/bootstrap" ]; then
@@ -548,7 +562,7 @@ jobs:
             echo "ERROR: $MISSING binaries missing!"
             exit 1
           fi
-          echo "✓ All 16 binaries verified"
+          echo "✓ All 23 binaries verified"
 
       - name: Save combined Lambda cache
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/terraform/environments/dev/versions.tf
+++ b/terraform/environments/dev/versions.tf
@@ -48,5 +48,5 @@ provider "aws" {
 # but the provider still validates the token format. Use a dummy 40-char placeholder
 # when the feature is disabled to allow CI to run without Cloudflare credentials.
 provider "cloudflare" {
-  api_token = var.enable_custom_domain ? var.cloudflare_api_token : "placeholder-token-for-disabled-feature00"
+  api_token = var.enable_custom_domain ? var.cloudflare_api_token : "placeholdertokenfordisabledfeature000000"
 }

--- a/terraform/environments/prd/versions.tf
+++ b/terraform/environments/prd/versions.tf
@@ -48,5 +48,5 @@ provider "aws" {
 # but the provider still validates the token format. Use a dummy 40-char placeholder
 # when the feature is disabled to allow CI to run without Cloudflare credentials.
 provider "cloudflare" {
-  api_token = var.enable_custom_domain ? var.cloudflare_api_token : "placeholder-token-for-disabled-feature00"
+  api_token = var.enable_custom_domain ? var.cloudflare_api_token : "placeholdertokenfordisabledfeature000000"
 }


### PR DESCRIPTION
## Related Issue
Closes #144

## Summary
- `terraform-build-lambdas` マトリクスに7つのmindmap Lambda関数を追加（16→23関数）
- `terraform-merge-artifacts` のバイナリ検証リストとカウントを更新（16→23）
- Cloudflare APIトークンのプレースホルダーを英数字のみ40文字に変更（dev/prd両環境）

## Test plan
- [x] terraform fmt -check -recursive: PASS
- [x] マトリクス関数数が23であることを確認
- [x] プレースホルダートークンが40文字・英数字のみであることを確認
- [x] pre-commit hooks (terraform validate, trivy scan): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code) Agent Teams