### PR TITLE
fix(e2e): fix storage clear and timeout for admin unauthorized access test

### DIFF
--- a/tests/e2e/specs/admin-unauthorized-access.spec.ts
+++ b/tests/e2e/specs/admin-unauthorized-access.spec.ts
@@ -17,8 +17,8 @@ test.describe('Admin Unauthorized Access - Minimal E2E', () => {
     page,
   }) => {
     // Arrange: ストレージをクリアして未認証状態にする
-    // まずホームページに移動してからストレージをクリア
-    await page.goto('/');
+    // admin SPAのコンテキストでストレージをクリア（Cognito認証情報を確実に削除）
+    await page.goto('/login');
     await page.context().clearCookies();
     await page.evaluate(() => {
       localStorage.clear();
@@ -29,7 +29,7 @@ test.describe('Admin Unauthorized Access - Minimal E2E', () => {
     await page.goto('/dashboard');
 
     // Assert: ログインページにリダイレクトされることを確認
-    await page.waitForURL('**/login', { timeout: 10000 });
+    await page.waitForURL('**/login', { timeout: 15000 });
     expect(page.url()).toContain('/login');
   });
 });


### PR DESCRIPTION
## Related Issue
Closes #158

## Summary
- ストレージクリア手順を修正: `page.goto('/')` → `page.goto('/login')` でadmin SPAコンテキストのCognito認証情報を確実にクリア
- リダイレクト待機タイムアウトを 10s → 15s に延長（CloudFront + SPA初期ロード + クライアントサイドリダイレクト考慮）

## Test plan
- [ ] AWS環境: `/admin/dashboard` にアクセスした際に `/admin/login` にリダイレクトされる
- [ ] ストレージクリア: Cognitoトークンが確実にクリアされる
- [ ] タイムアウト: SPA初期ロード + リダイレクトの所要時間内に完了する

🤖 Generated with [Claude Code](https://claude.com/claude-code) Agent Teams