### PR TITLE
fix(ci): add E2E test paths to deploy workflow trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ on:
       - 'go-functions/**'
       - 'frontend/**'
       - '.github/workflows/deploy.yml'
+      - 'tests/e2e/**'
+      - 'tests/config/**'
+      - 'playwright.aws.config.ts'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Related Issue
Closes #162

## Summary
- `deploy.yml` の `paths` フィルターに `tests/e2e/**`, `tests/config/**`, `playwright.aws.config.ts` を追加
- E2E テストコードのみの変更で `develop` にマージした際に、デプロイなしで `post-deploy-e2e-dev` ジョブが自動実行されるようになる
- 既存の `detect-changes` ロジックにより、テストのみの変更ではデプロイジョブは全て `skipped` となり、E2E テストのみが実行される

## Test plan
- [ ] E2E テストファイルのみの変更で `develop` にプッシュ → デプロイワークフローがトリガーされる
- [ ] デプロイジョブが全て `skipped` になることを確認
- [ ] `post-deploy-e2e-dev` ジョブのみが実行される
- [ ] `terraform/**` や `frontend/**` の変更時は従来通りデプロイ + E2E テストが実行される（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code) Agent Teams