### PR TITLE
fix(e2e): align ArticlePage.ts selectors with Astro post detail template

### DIFF
--- a/tests/e2e/pages/ArticlePage.ts
+++ b/tests/e2e/pages/ArticlePage.ts
@@ -11,8 +11,8 @@ import { BasePage } from './BasePage';
 export class ArticlePage extends BasePage {
   // ページ要素のセレクター
   private readonly selectors = {
-    articleTitle: '[data-testid="article-title"]',
-    articleContent: '[data-testid="article-content"]',
+    articleTitle: '[data-testid="post-title"]',
+    articleContent: '[data-testid="post-content"]',
     articleMeta: '[data-testid="article-meta"]',
     articleAuthor: '[data-testid="article-author"]',
     articleDate: '[data-testid="article-date"]',
@@ -34,7 +34,7 @@ export class ArticlePage extends BasePage {
   async waitForPageLoad(): Promise<void> {
     await super.waitForPageLoad();
 
-    // 記事ページでは article-title が表示されるまで待つ
+    // 記事ページでは post-title が表示されるまで待つ
     // SSGプリレンダリングページでもSPA遷移ページでも安定して動作する
     await this.page
       .locator(this.selectors.articleTitle)


### PR DESCRIPTION
## Related Issue
Closes #164

## Summary
- `ArticlePage.ts` の `data-testid` セレクターを Astro 記事詳細テンプレート (`[id].astro`) の実際の値に修正
  - `article-title` → `post-title`
  - `article-content` → `post-content`
- これにより AWS 環境 E2E テストの `TimeoutError` が解消される

## Test plan
- [ ] AWS 環境 E2E テスト: `article.spec.ts` が `[data-testid="post-title"]` を正しく検出しタイムアウトしない
- [ ] MSW 環境: 既存テストがリグレッションなし
- [ ] `home.spec.ts` の記事カード（`data-testid="article-title"`）には影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code) Agent Teams