### PR TITLE
test(e2e): add Tiptap/image/axe helpers and visual regression defaults

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@aws-sdk/s3-request-presigner": "^3.490.0",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@playwright/test": "^1.56.1",
         "@types/aws-lambda": "^8.10.157",
         "@types/node": "^20.10.6",
@@ -133,6 +134,8 @@
     "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.914.0", "", { "dependencies": { "@smithy/types": "^4.8.0", "fast-xml-parser": "5.2.5", "tslib": "^2.6.2" } }, "sha512-k75evsBD5TcIjedycYS7QXQ98AmOtbnxRJOPtCo0IwYRmy7UvqgS/gBL5SmrIqeV6FDSYRQMgdBxSMp6MLmdew=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.0.1", "", {}, "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.11.2", "", { "dependencies": { "axe-core": "~4.11.3" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
 
@@ -363,6 +366,8 @@
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "aws-xray-sdk-core": ["aws-xray-sdk-core@3.11.0", "", { "dependencies": { "@aws-sdk/types": "^3.4.1", "@aws/lambda-invoke-store": "^0.0.1", "@smithy/service-error-classification": "^2.0.4", "@types/cls-hooked": "^4.3.3", "atomic-batcher": "^1.0.2", "cls-hooked": "^4.2.2", "semver": "^7.5.3" } }, "sha512-b7RRs3/twrsCxb113ZgycyaYcXJUQADFMKTiAfzRJu/2hBD2UZkyrjrh8BNTwQ5PUJJmHLoapv1uhpJFk3qKvQ=="],
+
+    "axe-core": ["axe-core@4.11.3", "", {}, "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@aws-sdk/s3-request-presigner": "^3.490.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@playwright/test": "^1.56.1",
     "@types/aws-lambda": "^8.10.157",
     "@types/node": "^20.10.6",

--- a/playwright.admin.config.ts
+++ b/playwright.admin.config.ts
@@ -45,8 +45,8 @@ export default defineConfig({
     // ベースURL（管理画面用）
     baseURL: process.env.ADMIN_BASE_URL || 'http://localhost:3001',
 
-    // トレース設定（失敗時のみ）
-    trace: 'on-first-retry',
+    // トレース設定（失敗時に保持）
+    trace: 'retain-on-failure',
 
     // スクリーンショット設定（失敗時のみ）
     screenshot: 'only-on-failure',
@@ -67,6 +67,12 @@ export default defineConfig({
   timeout: 90000,
   expect: {
     timeout: 30000,
+    // ビジュアルリグレッション既定値: 1% を超える差分を検出したら失敗
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.01,
+      animations: 'disabled',
+      caret: 'hide',
+    },
   },
 
   // プロジェクト設定（Chromiumのみ - 2025-11-07変更）

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,8 +45,8 @@ export default defineConfig({
     // ベースURL（環境変数で切り替え可能）
     baseURL: process.env.BASE_URL || 'http://localhost:3000',
 
-    // トレース設定（失敗時のみ）
-    trace: 'on-first-retry',
+    // トレース設定（失敗時に保持）
+    trace: 'retain-on-failure',
 
     // スクリーンショット設定（失敗時のみ）
     screenshot: 'only-on-failure',
@@ -78,6 +78,12 @@ export default defineConfig({
   timeout: 60000,
   expect: {
     timeout: 10000,
+    // ビジュアルリグレッション既定値: 1% を超える差分を検出したら失敗
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.01,
+      animations: 'disabled',
+      caret: 'hide',
+    },
   },
 
   // プロジェクト設定（Chromiumのみ - 2025-11-07変更）

--- a/tests/e2e/utils/axeHelpers.ts
+++ b/tests/e2e/utils/axeHelpers.ts
@@ -1,0 +1,57 @@
+import { Page, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * 軸のアクセシビリティ違反を 0 に保つアサーション。
+ *
+ * 主要画面 (Login, Dashboard, PostList, PostEditor, PostDetail) で 1 アサート
+ * 入れる前提。検出ルールは axe-core デフォルトの WCAG 2.1 A/AA。
+ *
+ * 使用側で意図的に許容したい違反がある場合は exclude / disableRules で絞る。
+ */
+export async function assertNoA11yViolations(
+  page: Page,
+  options: {
+    /** axe.run の対象セレクタを絞る (例: 主要コンテンツのみ) */
+    include?: string;
+    /** 検査から除外するセレクタ */
+    exclude?: string[];
+    /** 一時的に無効化したい axe ルール ID */
+    disableRules?: string[];
+    /** 検査タグで絞り込み (デフォルト: WCAG 2.1 A/AA) */
+    tags?: string[];
+  } = {}
+): Promise<void> {
+  let builder = new AxeBuilder({ page }).withTags(
+    options.tags ?? ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+  );
+  if (options.include) builder = builder.include(options.include);
+  if (options.exclude?.length) {
+    for (const sel of options.exclude) builder = builder.exclude(sel);
+  }
+  if (options.disableRules?.length) {
+    builder = builder.disableRules(options.disableRules);
+  }
+  const results = await builder.analyze();
+  expect(
+    results.violations,
+    `axe a11y violations:\n${formatViolations(results.violations)}`
+  ).toEqual([]);
+}
+
+function formatViolations(
+  violations: {
+    id: string;
+    impact?: string | null;
+    help: string;
+    nodes: { target: unknown[] }[];
+  }[]
+): string {
+  if (violations.length === 0) return '(none)';
+  return violations
+    .map(
+      (v) =>
+        `- [${v.impact ?? 'unknown'}] ${v.id}: ${v.help} (${v.nodes.length} node(s))`
+    )
+    .join('\n');
+}

--- a/tests/e2e/utils/imageFixtures.ts
+++ b/tests/e2e/utils/imageFixtures.ts
@@ -1,0 +1,59 @@
+/**
+ * テスト用画像フィクスチャ生成
+ *
+ * Playwright テストで Tiptap エディタへペースト/ドロップする画像 File を
+ * その場で生成するためのヘルパー。実ファイルを用意せず、特定の MIME と
+ * バイトサイズを持つダミー画像を返す。
+ */
+
+/**
+ * 1x1 透明 PNG のバイト列。サイズは固定 67 バイト。
+ * ペースト/ドロップ動作の検証用に十分。
+ */
+const ONE_BY_ONE_PNG = Buffer.from(
+  '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d4944415478da6300010000000500010d0a2db40000000049454e44ae426082',
+  'hex'
+);
+
+/**
+ * テスト用 PNG 画像フィクスチャを生成する。
+ * sizeKB を指定すると、PNG 末尾にダミーバイトをパディングして指定サイズに膨らませる
+ * (アップロード上限 5MB の境界テスト等に利用)。
+ */
+export function fixturePng(opts: { name?: string; sizeKB?: number } = {}): {
+  name: string;
+  mimeType: string;
+  buffer: Buffer;
+} {
+  const name = opts.name ?? 'test.png';
+  const base = ONE_BY_ONE_PNG;
+  if (!opts.sizeKB || opts.sizeKB * 1024 <= base.length) {
+    return { name, mimeType: 'image/png', buffer: base };
+  }
+  const padding = Buffer.alloc(opts.sizeKB * 1024 - base.length, 0);
+  return {
+    name,
+    mimeType: 'image/png',
+    buffer: Buffer.concat([base, padding]),
+  };
+}
+
+/**
+ * 1x1 JPEG 画像 (約 134 バイト)。MIME 別動作のスモークテスト用。
+ */
+const ONE_BY_ONE_JPEG = Buffer.from(
+  'ffd8ffe000104a46494600010100000100010000ffdb004300080606070605080707070909080a0c140d0c0b0b0c1912130f141d1a1f1e1d1a1c1c20242e2720222c231c1c2837292c30313434341f27393d38323c2e333432ffdb0043010909090c0b0c180d0d1832211c213232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232ffc00011080001000103012200021101031101ffc4001f0000010501010101010100000000000000000102030405060708090a0bffc400b5100002010303020403050504040000017d01020300041105122131410613516107227114328191a1082342b1c11552d1f02433627282090a161718191a25262728292a3435363738393a434445464748494a535455565758595a636465666768696a737475767778797a838485868788898a92939495969798999aa2a3a4a5a6a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae1e2e3e4e5e6e7e8e9eaf1f2f3f4f5f6f7f8f9faffc4001f0100030101010101010101010000000000000102030405060708090a0bffc400b51100020102040403040705040400010277000102031104052131061241510761711322328108144291a1b1c109233352f0156272d10a162434e125f11718191a262728292a35363738393a434445464748494a535455565758595a636465666768696a737475767778797a82838485868788898a92939495969798999aa2a3a4a5a6a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae2e3e4e5e6e7e8e9eaf2f3f4f5f6f7f8f9faffda000c03010002110311003f00fbfbfffd9',
+  'hex'
+);
+
+export function fixtureJpeg(opts: { name?: string } = {}): {
+  name: string;
+  mimeType: string;
+  buffer: Buffer;
+} {
+  return {
+    name: opts.name ?? 'test.jpg',
+    mimeType: 'image/jpeg',
+    buffer: ONE_BY_ONE_JPEG,
+  };
+}

--- a/tests/e2e/utils/tiptapHelpers.ts
+++ b/tests/e2e/utils/tiptapHelpers.ts
@@ -1,0 +1,166 @@
+import { Locator, Page, expect } from '@playwright/test';
+
+/**
+ * Tiptap (ProseMirror) エディタ操作ヘルパー
+ *
+ * 通常の <textarea> と異なり、Tiptap は contenteditable な ProseMirror ノード上で
+ * 動くため `page.fill()` が効かない。本ヘルパーは Tiptap エディタへの入力 / 内容取得 /
+ * 画像ペースト・ドロップなど、E2E テストで頻出する操作を統一インタフェースで提供する。
+ *
+ * 前提: エディタ DOM のラッパに data-testid="tiptap-editor" が付与され、
+ * 内部の contenteditable 要素が role="textbox" を持つこと。
+ */
+
+const EDITOR_TESTID = 'tiptap-editor';
+const EDITOR_SELECTOR = `[data-testid="${EDITOR_TESTID}"] [contenteditable="true"]`;
+
+/** Tiptap エディタの contenteditable 要素を返す。 */
+export function getTiptapEditor(page: Page): Locator {
+  return page.locator(EDITOR_SELECTOR);
+}
+
+/** エディタにフォーカスし、key sequence でテキストを入力する。 */
+export async function typeIntoEditor(page: Page, text: string): Promise<void> {
+  const editor = getTiptapEditor(page);
+  await editor.click();
+  await editor.pressSequentially(text);
+}
+
+/** エディタの内容を ProseMirror 経由で完全に置換する (テスト初期状態セットアップ用)。 */
+export async function setEditorContent(
+  page: Page,
+  markdown: string
+): Promise<void> {
+  await page.evaluate(
+    ({ md, sel }) => {
+      const el = document.querySelector(sel) as HTMLElement | null;
+      if (!el) throw new Error('Tiptap editor not found');
+      const editor =
+        (
+          el as unknown as {
+            __tiptapEditor?: {
+              commands: { setContent: (md: string) => boolean };
+            };
+          }
+        ).__tiptapEditor ??
+        (
+          window as unknown as {
+            __tiptapEditor?: {
+              commands: { setContent: (md: string) => boolean };
+            };
+          }
+        ).__tiptapEditor;
+      if (!editor) {
+        throw new Error(
+          'Tiptap editor instance not exposed on window. Set window.__tiptapEditor in test mode.'
+        );
+      }
+      editor.commands.setContent(md);
+    },
+    { md: markdown, sel: EDITOR_SELECTOR }
+  );
+}
+
+/**
+ * 現在のエディタ内容を Markdown として取得する。
+ * tiptap-markdown プラグインが editor.storage.markdown.getMarkdown() を提供する想定。
+ */
+export async function getEditorMarkdown(page: Page): Promise<string> {
+  return await page.evaluate(() => {
+    const editor = (
+      window as unknown as {
+        __tiptapEditor?: {
+          storage: { markdown?: { getMarkdown: () => string } };
+          getText: () => string;
+        };
+      }
+    ).__tiptapEditor;
+    if (!editor)
+      throw new Error('Tiptap editor instance not exposed on window');
+    return editor.storage.markdown?.getMarkdown() ?? editor.getText();
+  });
+}
+
+/** 現在のエディタ内容のプレーンテキストを取得する。 */
+export async function getEditorText(page: Page): Promise<string> {
+  return await getTiptapEditor(page).innerText();
+}
+
+/** Markdown 内容が指定の文字列を含むことをアサート。 */
+export async function expectEditorMarkdownToContain(
+  page: Page,
+  needle: string
+): Promise<void> {
+  const md = await getEditorMarkdown(page);
+  expect(
+    md,
+    `editor markdown should contain ${JSON.stringify(needle)}`
+  ).toContain(needle);
+}
+
+/**
+ * クリップボードから画像をペーストするのと同等のイベントを dispatch する。
+ *
+ * 実際のクリップボード API は Playwright のヘッドレス環境で扱いづらいため、
+ * DataTransfer を組み立てて `paste` イベントを直接発火させる。
+ */
+export async function pasteImage(
+  page: Page,
+  file: { name: string; mimeType: string; buffer: Buffer }
+): Promise<void> {
+  const base64 = file.buffer.toString('base64');
+  await page.evaluate(
+    ({ name, mime, b64, sel }) => {
+      const binary = atob(b64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      const f = new File([bytes], name, { type: mime });
+      const dt = new DataTransfer();
+      dt.items.add(f);
+      const editor = document.querySelector(sel) as HTMLElement | null;
+      if (!editor) throw new Error('Tiptap editor not found');
+      editor.focus();
+      const event = new ClipboardEvent('paste', {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      editor.dispatchEvent(event);
+    },
+    { name: file.name, mime: file.mimeType, b64: base64, sel: EDITOR_SELECTOR }
+  );
+}
+
+/**
+ * エディタに画像ファイルをドロップする (ドラッグ&ドロップ操作の最終結果と等価)。
+ */
+export async function dropImage(
+  page: Page,
+  file: { name: string; mimeType: string; buffer: Buffer }
+): Promise<void> {
+  const base64 = file.buffer.toString('base64');
+  await page.evaluate(
+    ({ name, mime, b64, sel }) => {
+      const binary = atob(b64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      const f = new File([bytes], name, { type: mime });
+      const dt = new DataTransfer();
+      dt.items.add(f);
+      const editor = document.querySelector(sel) as HTMLElement | null;
+      if (!editor) throw new Error('Tiptap editor not found');
+      const rect = editor.getBoundingClientRect();
+      const opts = {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: dt,
+        clientX: rect.left + rect.width / 2,
+        clientY: rect.top + rect.height / 2,
+      } as DragEventInit;
+      editor.dispatchEvent(new DragEvent('dragenter', opts));
+      editor.dispatchEvent(new DragEvent('dragover', opts));
+      editor.dispatchEvent(new DragEvent('drop', opts));
+    },
+    { name: file.name, mime: file.mimeType, b64: base64, sel: EDITOR_SELECTOR }
+  );
+}


### PR DESCRIPTION
## Summary
- Add `tests/e2e/utils/{tiptapHelpers,imageFixtures,axeHelpers}.ts` — reusable Playwright helpers for upcoming Tiptap-based editor tests, synthetic image fixtures, and axe-core a11y assertions.
- Add `@axe-core/playwright` as a root devDependency.
- Set Playwright `expect.toHaveScreenshot` defaults (`maxDiffPixelRatio: 0.01`, `animations: 'disabled'`, `caret: 'hide'`) on both `playwright.config.ts` and `playwright.admin.config.ts`.
- Switch `trace` from `on-first-retry` to `retain-on-failure` for easier failure analysis (HTML report + `trace.zip` retained).

## Why
Foundation for the writer-experience overhaul. The upcoming Tiptap editor migration, inline image paste/drop, autosave, and metadata sidebar PRs all need:
- A standard way to drive ProseMirror's `contenteditable` from Playwright (`user.fill` doesn't work).
- Synthetic image bytes for paste/drop simulation without checking binary fixtures into the repo.
- Visual regression defaults so screenshot diffs don't bikeshed pixel-by-pixel.
- A11y assertion sugar that's actually called from specs.

No existing specs are affected — these are pure additions.

## Test plan
- [x] `bun install` succeeds (axe-core + transitive deps installed)
- [x] `bunx playwright test --config=playwright.admin.config.ts --list` lists existing 6 specs cleanly
- [x] `bunx playwright test --config=playwright.config.ts --list` lists existing 7 specs cleanly
- [x] `tsc --noEmit` clean on the three new helper files
- [ ] CI green (no terraform/go/frontend changes; expect skipped jobs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)