### PR TITLE
ci(deploy): drop redundant terraform plan step (CI runs plan on PR)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -406,17 +406,17 @@ jobs:
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           terraform init -backend-config="bucket=terraform-state-${ACCOUNT_ID}"
 
-      - name: Terraform Plan
-        working-directory: terraform/environments/dev
-        run: terraform plan -out=tfplan.binary
-
+      # Plan is run on PR by ci.yml's terraform-plan-dev job. We skip the
+      # explicit plan step here to avoid duplication. `terraform apply
+      # -auto-approve` will internally re-plan against current state and
+      # apply atomically; the plan summary still appears in the apply log.
       - name: Terraform Apply
         working-directory: terraform/environments/dev
         run: |
           echo "========================================="
           echo "Deploying to DEV Environment"
           echo "========================================="
-          terraform apply -auto-approve tfplan.binary
+          terraform apply -auto-approve
           echo "✓ DEV deployment complete"
 
       - name: Get Outputs
@@ -502,17 +502,17 @@ jobs:
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           terraform init -backend-config="bucket=terraform-state-${ACCOUNT_ID}"
 
-      - name: Terraform Plan
-        working-directory: terraform/environments/prd
-        run: terraform plan -out=tfplan.binary
-
+      # Plan is run on PR by ci.yml's terraform-plan-prd job. We skip the
+      # explicit plan step here to avoid duplication. `terraform apply
+      # -auto-approve` will internally re-plan against current state and
+      # apply atomically; the plan summary still appears in the apply log.
       - name: Terraform Apply
         working-directory: terraform/environments/prd
         run: |
           echo "========================================="
           echo "⚠️  Deploying to PRODUCTION Environment"
           echo "========================================="
-          terraform apply -auto-approve tfplan.binary
+          terraform apply -auto-approve
           echo "✓ PRODUCTION deployment complete"
 
       - name: Get Outputs


### PR DESCRIPTION
## Summary
`ci.yml` already runs `terraform-plan-dev` and `terraform-plan-prd` on every labelled PR (lines 766-992) — OIDC + SSM credential injection, full `terraform plan -detailed-exitcode`, plan artifact upload, and an automatic PR comment with the diff. The plan step in `deploy.yml`'s `deploy-infrastructure-{dev,prd}` jobs duplicated this work after merge.

This PR replaces:
\`\`\`yaml
- name: Terraform Plan
  run: terraform plan -out=tfplan.binary
- name: Terraform Apply
  run: terraform apply -auto-approve tfplan.binary
\`\`\`
with a single:
\`\`\`yaml
- name: Terraform Apply
  run: terraform apply -auto-approve
\`\`\`
in both DEV and PRD jobs.

## Why
- **Removes duplication**: plan was being computed twice (once on PR, once on merge). Reviewers see the diff at PR time; the deploy log retains the plan summary inside `apply` output.
- **Atomicity**: `terraform apply -auto-approve` (no plan file) acquires the state lock, refreshes, plans, and applies in one operation — closes the small race window where state could change between the explicit plan and apply steps.
- **Smaller artifacts**: no more `tfplan.binary` produced by deploy.

## Test plan
- [ ] CI green on this PR (only `.github/workflows/deploy.yml` changed; expect non-CI/CD jobs skipped)
- [ ] After merge, the next infrastructure-touching deploy run shows the plan summary inside the apply step's log
- [ ] No surprise diffs in the apply output (since we already see the plan in PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)