### PR TITLE
feat(posts): add slug, excerpt, coverImageUrl fields and SlugIndex GSI

### DIFF
--- a/frontend/admin/src/api/posts.ts
+++ b/frontend/admin/src/api/posts.ts
@@ -14,6 +14,9 @@ export interface Post {
   publishStatus: 'draft' | 'published';
   createdAt: string;
   updatedAt: string;
+  slug?: string;
+  excerpt?: string;
+  coverImageUrl?: string;
 }
 
 export interface CreatePostRequest {
@@ -22,14 +25,20 @@ export interface CreatePostRequest {
   category: string;
   tags?: string[];
   publishStatus: 'draft' | 'published';
+  slug?: string;
+  excerpt?: string;
+  coverImageUrl?: string;
 }
 
 export interface UpdatePostRequest {
-  title: string;
-  contentMarkdown: string;
-  category: string;
+  title?: string;
+  contentMarkdown?: string;
+  category?: string;
   tags?: string[];
-  publishStatus: 'draft' | 'published';
+  publishStatus?: 'draft' | 'published';
+  slug?: string;
+  excerpt?: string;
+  coverImageUrl?: string;
 }
 
 /**

--- a/frontend/public-astro/src/lib/api.ts
+++ b/frontend/public-astro/src/lib/api.ts
@@ -27,6 +27,9 @@ export interface Post {
   updatedAt: string;
   publishedAt?: string;
   imageUrls?: string[];
+  slug?: string;
+  excerpt?: string;
+  coverImageUrl?: string;
 }
 
 /**

--- a/go-functions/internal/domain/types.go
+++ b/go-functions/internal/domain/types.go
@@ -58,6 +58,10 @@ func getJapaneseTokenizer() *tokenizer.Tokenizer {
 
 // BlogPost represents a blog post entity.
 // JSON tags use camelCase for API compatibility with existing TypeScript/Rust implementations.
+//
+// Slug, Excerpt, and CoverImageURL are added for the writer-experience overhaul.
+// They are pointers so legacy items lacking these attributes round-trip without
+// emitting null fields in JSON.
 type BlogPost struct {
 	ID              string   `json:"id" dynamodbav:"id"`
 	Title           string   `json:"title" dynamodbav:"title"`
@@ -71,6 +75,9 @@ type BlogPost struct {
 	UpdatedAt       string   `json:"updatedAt" dynamodbav:"updatedAt"`
 	PublishedAt     *string  `json:"publishedAt,omitempty" dynamodbav:"publishedAt,omitempty"`
 	ImageURLs       []string `json:"imageUrls" dynamodbav:"imageUrls"`
+	Slug            *string  `json:"slug,omitempty" dynamodbav:"slug,omitempty"`
+	Excerpt         *string  `json:"excerpt,omitempty" dynamodbav:"excerpt,omitempty"`
+	CoverImageURL   *string  `json:"coverImageUrl,omitempty" dynamodbav:"coverImageUrl,omitempty"`
 }
 
 // CreatePostRequest represents the request body for creating a post.
@@ -81,6 +88,9 @@ type CreatePostRequest struct {
 	Tags            []string `json:"tags,omitempty"`
 	PublishStatus   *string  `json:"publishStatus,omitempty"`
 	ImageURLs       []string `json:"imageUrls,omitempty"`
+	Slug            *string  `json:"slug,omitempty"`
+	Excerpt         *string  `json:"excerpt,omitempty"`
+	CoverImageURL   *string  `json:"coverImageUrl,omitempty"`
 }
 
 // Validate validates the CreatePostRequest.
@@ -94,6 +104,14 @@ func (r *CreatePostRequest) Validate() error {
 	if r.Category == "" {
 		return errors.New("category is required")
 	}
+	if r.Slug != nil {
+		if *r.Slug == "" {
+			return errors.New("slug cannot be empty when provided")
+		}
+		if !slugPattern.MatchString(*r.Slug) {
+			return errors.New("slug must contain only lowercase alphanumeric characters and hyphens")
+		}
+	}
 	return nil
 }
 
@@ -105,6 +123,23 @@ type UpdatePostRequest struct {
 	Tags            []string `json:"tags,omitempty"`
 	PublishStatus   *string  `json:"publishStatus,omitempty"`
 	ImageURLs       []string `json:"imageUrls,omitempty"`
+	Slug            *string  `json:"slug,omitempty"`
+	Excerpt         *string  `json:"excerpt,omitempty"`
+	CoverImageURL   *string  `json:"coverImageUrl,omitempty"`
+}
+
+// Validate validates the UpdatePostRequest.
+// Only fields that are provided are validated; partial updates are supported.
+func (r *UpdatePostRequest) Validate() error {
+	if r.Slug != nil {
+		if *r.Slug == "" {
+			return errors.New("slug cannot be empty when provided")
+		}
+		if !slugPattern.MatchString(*r.Slug) {
+			return errors.New("slug must contain only lowercase alphanumeric characters and hyphens")
+		}
+	}
+	return nil
 }
 
 // ListPostsResponse represents the paginated list response.

--- a/go-functions/internal/domain/types_test.go
+++ b/go-functions/internal/domain/types_test.go
@@ -175,6 +175,36 @@ func TestCreatePostRequestValidation(t *testing.T) {
 			wantErr: true,
 			errMsg:  "category",
 		},
+		{
+			name: "valid request with slug",
+			request: CreatePostRequest{
+				Title:           "Test Title",
+				ContentMarkdown: "# Hello",
+				Category:        "technology",
+				Slug:            strPtr("my-post-slug"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty slug pointer rejected",
+			request: CreatePostRequest{
+				Title:           "Test Title",
+				ContentMarkdown: "# Hello",
+				Category:        "technology",
+				Slug:            strPtr(""),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid slug format rejected",
+			request: CreatePostRequest{
+				Title:           "Test Title",
+				ContentMarkdown: "# Hello",
+				Category:        "technology",
+				Slug:            strPtr("Invalid Slug!"),
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -187,6 +217,58 @@ func TestCreatePostRequestValidation(t *testing.T) {
 				if tt.errMsg != "" && err.Error() != tt.errMsg+" is required" {
 					t.Errorf("Expected error message containing %q, got %q", tt.errMsg, err.Error())
 				}
+			}
+		})
+	}
+}
+
+// TestUpdatePostRequestValidation tests UpdatePostRequest.Validate (slug format only).
+// Other fields use partial-update semantics and have no required-field rules.
+func TestUpdatePostRequestValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		request UpdatePostRequest
+		wantErr bool
+	}{
+		{
+			name:    "empty request is valid (partial update with no slug change)",
+			request: UpdatePostRequest{},
+			wantErr: false,
+		},
+		{
+			name:    "valid slug accepted",
+			request: UpdatePostRequest{Slug: strPtr("my-post-slug")},
+			wantErr: false,
+		},
+		{
+			name:    "empty slug pointer rejected",
+			request: UpdatePostRequest{Slug: strPtr("")},
+			wantErr: true,
+		},
+		{
+			name:    "invalid slug format rejected",
+			request: UpdatePostRequest{Slug: strPtr("UPPER_CASE")},
+			wantErr: true,
+		},
+		{
+			name: "non-slug fields ignored even when slug is nil",
+			request: UpdatePostRequest{
+				Title:           strPtr("New title"),
+				ContentMarkdown: strPtr("# Body"),
+				Category:        strPtr("technology"),
+				Tags:            []string{"go"},
+				PublishStatus:   strPtr("published"),
+				ImageURLs:       []string{"https://example.com/image.jpg"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -33,6 +33,12 @@ resource "aws_dynamodb_table" "blog_posts" {
     type = "S"
   }
 
+  # GSI attribute for slug lookup (writer-experience overhaul)
+  attribute {
+    name = "slug"
+    type = "S"
+  }
+
   # Requirement 2.3: CategoryIndex GSI
   # Partition key: category, Sort key: createdAt
   global_secondary_index {
@@ -48,6 +54,16 @@ resource "aws_dynamodb_table" "blog_posts" {
     name            = "PublishStatusIndex"
     hash_key        = "publishStatus"
     range_key       = "createdAt"
+    projection_type = "ALL"
+  }
+
+  # SlugIndex GSI for friendly URL lookup and uniqueness enforcement
+  # Partition key: slug, Projection: ALL (Astro getStaticPaths reads full post by slug)
+  # Items without slug attribute are simply absent from this index, which is fine
+  # for legacy items pending backfill.
+  global_secondary_index {
+    name            = "SlugIndex"
+    hash_key        = "slug"
     projection_type = "ALL"
   }
 


### PR DESCRIPTION
## Summary
Foundation for the writer-experience overhaul. Schema and type scaffolding only — create/update handlers and admin UI changes follow in subsequent PRs.

- **`terraform/modules/database/main.tf`**: add a `slug` attribute and a `SlugIndex` GSI (projection `ALL`) to the BlogPosts table. Items lacking `slug` are simply absent from the index — fine for legacy items pending backfill.
- **`go-functions/internal/domain/types.go`**: add optional pointer fields `Slug`, `Excerpt`, `CoverImageURL` (with `omitempty`) to `BlogPost`, `CreatePostRequest`, `UpdatePostRequest`. Slug uses the existing `slugPattern` regex shared with Categories. `UpdatePostRequest.Validate()` added to enforce slug format when provided.
- **`frontend/admin/src/api/posts.ts`**: sync `Post` / `CreatePostRequest` / `UpdatePostRequest` types. Loosen `UpdatePostRequest` to all-optional fields in preparation for partial-PUT autosave (next PR).
- **`frontend/public-astro/src/lib/api.ts`**: sync `Post` type for build-time SSG fetches.

## Why
- `SlugIndex` GSI enables Astro `getStaticPaths` lookup by slug at build time and uniqueness enforcement in the create/update handlers.
- Optional pointer fields with `omitempty` mean legacy items round-trip without emitting `null` in JSON — no backfill needed for the schema change to land safely.
- Loosening `UpdatePostRequest` to optional fields up-front lets the upcoming autosave PR send partial PUTs without further type churn.

## Dependency
This PR is currently stacked on top of #191 (the flaky PostCreatePage test fix) so the husky pre-commit hook can run the admin test suite cleanly. Once #191 merges, this branch will rebase onto develop and #191's commit will drop out of the diff.

## Verification
- [x] `terraform validate` passes locally on `terraform/modules/database`
- [x] `cd frontend/admin && bunx tsc --noEmit` clean
- [x] `cd frontend/admin && bun run test -- --run` — 697 passed, 5 skipped (32 files)
- [x] `cd go-functions && make lint test` (golangci-lint v2.7 to match CI) — all packages pass with ≥90% coverage
- [ ] CI's `terraform-plan-dev` job on this PR produces the expected diff: `+1 attribute (slug)`, `+1 GSI (SlugIndex)` on `aws_dynamodb_table.blog_posts`
- [ ] After merge → `deploy-infrastructure-dev` apply step shows the same diff and applies successfully

## Out of scope
- Slug uniqueness check in create/update Go handlers → PR6 (metadata sidebar)
- Auto slug generation from title → PR6
- Astro `[slug].astro` route → PR7
- Backfill script → PR7

🤖 Generated with [Claude Code](https://claude.com/claude-code)