### PR TITLE
ci: fix Code Scanning rate limit and Bun frozen lockfile failures

### DIFF
--- a/.github/actions/setup-bun-deps/action.yml
+++ b/.github/actions/setup-bun-deps/action.yml
@@ -26,4 +26,15 @@ runs:
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: bun install --frozen-lockfile
+      # Dependabot only updates package.json (the npm ecosystem doesn't touch
+      # bun.lock), so --frozen-lockfile would always fail on its PRs. The
+      # dependabot-bun-lockfile workflow regenerates and pushes bun.lock back
+      # to the PR; here we just need to let the install succeed so the rest
+      # of CI (lint/test/build) can run.
+      run: |
+        if [[ "${GITHUB_ACTOR}" == "dependabot[bot]" ]]; then
+          echo "Dependabot PR: running bun install without --frozen-lockfile"
+          bun install --no-summary
+        else
+          bun install --frozen-lockfile
+        fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@
 # Phase 1 (visibility): weekly grouped PRs for minor/patch updates, individual PRs for majors.
 # Security advisories are published as separate ungrouped PRs regardless of these settings.
 #
+# Schedule strategy:
+#   Spread weekly runs across Mon–Sat to avoid the GitHub Code Scanning API rate
+#   limit (5,000 req/h per installation) when many ecosystems open PRs concurrently.
+#   Times are staggered by 1h within each day for the same reason.
+#
 # Note on Bun:
 #   We use the `npm` ecosystem because Dependabot's experimental `bun` ecosystem
 #   does not reliably parse `bun.lock` (text format) at this time.
@@ -15,7 +20,7 @@ version: 2
 
 updates:
   # ============================================================
-  # JavaScript / TypeScript (Bun via npm ecosystem)
+  # JavaScript / TypeScript (Bun via npm ecosystem) — Monday
   # ============================================================
   - package-ecosystem: "npm"
     directory: "/"
@@ -47,7 +52,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "03:00"
+      time: "04:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
     labels:
@@ -72,7 +77,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "03:00"
+      time: "05:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
     labels:
@@ -97,7 +102,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "03:00"
+      time: "06:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
     labels:
@@ -118,13 +123,13 @@ updates:
         update-types: ["version-update:semver-major"]
 
   # ============================================================
-  # Go (Lambda functions)
+  # Go (Lambda functions) — Tuesday
   # ============================================================
   - package-ecosystem: "gomod"
     directory: "/go-functions"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "tuesday"
       time: "03:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
@@ -142,13 +147,13 @@ updates:
         update-types: ["version-update:semver-major"]
 
   # ============================================================
-  # Terraform (environments + modules)
+  # Terraform environments — Wednesday
   # ============================================================
   - package-ecosystem: "terraform"
     directory: "/terraform/environments/dev"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "wednesday"
       time: "03:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
@@ -163,8 +168,8 @@ updates:
     directory: "/terraform/environments/prd"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "03:00"
+      day: "wednesday"
+      time: "04:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
     labels:
@@ -174,98 +179,104 @@ updates:
       prefix: "chore(deps)"
       include: "scope"
 
+  # ============================================================
+  # Terraform modules (first half) — Thursday
+  # ============================================================
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/acm"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "thursday", time: "03:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/agentcore"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "thursday", time: "04:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/api"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "thursday", time: "05:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/auth"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "thursday", time: "06:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/cdn"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "thursday", time: "07:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/codebuild"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "thursday", time: "08:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
+  # ============================================================
+  # Terraform modules (second half) — Friday
+  # ============================================================
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/database"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "friday", time: "03:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/dns-cloudflare"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "friday", time: "04:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/dns-route53"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "friday", time: "05:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/lambda"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "friday", time: "06:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/monitoring"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "friday", time: "07:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/storage"
-    schedule: { interval: "weekly", day: "monday", time: "03:00", timezone: "Asia/Tokyo" }
+    schedule: { interval: "weekly", day: "friday", time: "08:00", timezone: "Asia/Tokyo" }
     open-pull-requests-limit: 3
     labels: ["dependencies", "terraform"]
     commit-message: { prefix: "chore(deps)", include: "scope" }
 
   # ============================================================
-  # GitHub Actions (workflows + composite actions)
+  # GitHub Actions (workflows + composite actions) — Saturday
   # ============================================================
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "saturday"
       time: "03:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
@@ -286,8 +297,8 @@ updates:
     directory: "/.github/actions/setup-bun-deps"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "03:00"
+      day: "saturday"
+      time: "04:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 3
     labels:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,6 +718,9 @@ jobs:
 
       - name: Upload Checkov SARIF to Code Scanning
         if: always() && hashFiles('results.sarif') != ''
+        # Code Scanning API rate limit can fail this step when many Dependabot PRs
+        # run concurrently. SARIF visibility is best-effort, so don't fail the job.
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -1,0 +1,95 @@
+# Auto-regenerate bun.lock on Dependabot PRs that touch a Bun-managed package.json.
+#
+# Dependabot uses the npm ecosystem (because its experimental bun ecosystem cannot
+# parse bun.lock reliably yet) and only updates package.json — it does not refresh
+# bun.lock. The CI's `bun install --frozen-lockfile` then fails with
+# "lockfile had changes, but lockfile is frozen". This workflow runs `bun install`
+# on each changed directory and commits the regenerated bun.lock back to the PR.
+#
+# Security notes:
+#   - Triggered only when the PR author is dependabot[bot].
+#   - Uses pull_request_target so we have write access to push the lockfile back,
+#     but checks out the PR HEAD explicitly. We then run `bun install`, which can
+#     execute lifecycle scripts; this is bounded because Dependabot only bumps
+#     versions of dependencies already present in package.json.
+
+name: Dependabot Bun Lockfile Sync
+
+on:
+  pull_request_target:
+    paths:
+      - 'package.json'
+      - 'frontend/*/package.json'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dependabot-bun-lockfile-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-lockfile:
+    name: Sync bun.lock
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        with:
+          bun-version: '1.2.0'
+
+      - name: Detect changed package.json directories
+        id: detect
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          mapfile -t changed < <(
+            git diff --name-only "origin/${BASE_REF}...HEAD" -- 'package.json' 'frontend/*/package.json' \
+              | xargs -r -n1 dirname \
+              | sort -u
+          )
+          if [[ ${#changed[@]} -eq 0 ]]; then
+            echo "No package.json changes detected"
+            echo "dirs=" >> "$GITHUB_OUTPUT"
+          else
+            printf 'Changed dirs:\n%s\n' "${changed[*]}"
+            echo "dirs=${changed[*]}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run bun install in each changed directory
+        if: steps.detect.outputs.dirs != ''
+        run: |
+          set -euo pipefail
+          for dir in ${{ steps.detect.outputs.dirs }}; do
+            echo "::group::bun install in $dir"
+            (cd "$dir" && bun install --no-summary)
+            echo "::endgroup::"
+          done
+
+      - name: Commit and push regenerated lockfile
+        if: steps.detect.outputs.dirs != ''
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          # Stage only bun.lock files; ignore node_modules and other side-effects.
+          git add -- 'bun.lock' 'frontend/*/bun.lock' 2>/dev/null || true
+          if git diff --cached --quiet; then
+            echo "No bun.lock changes to commit"
+            exit 0
+          fi
+          git config user.name 'dependabot[bot]'
+          git config user.email '49699333+dependabot[bot]@users.noreply.github.com'
+          git commit -m "chore(deps): regenerate bun.lock"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -131,6 +131,9 @@ jobs:
 
       - name: Upload Trivy SARIF to Code Scanning
         if: always() && hashFiles('trivy-fs.sarif') != ''
+        # Code Scanning API rate limit can fail this step when many Dependabot PRs
+        # run concurrently. SARIF visibility is best-effort, so don't fail the job.
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:
           sarif_file: trivy-fs.sarif


### PR DESCRIPTION
## Summary

CI が失敗していた3つの構造的問題を修正します。詳細な調査ログは内部の調査レポート (`/Users/shin/.claude/plans/github-actions-ci-workflow-whimsical-tulip.md`) を参照。

### 1. SARIF アップロード non-blocking 化
- `.github/workflows/ci.yml` の Checkov upload-sarif と `.github/workflows/security-scan.yml` の Trivy upload-sarif に `continue-on-error: true` を追加
- **背景**: Dependabot が同時刻に多数の PR を作成すると Code Scanning API のインストール単位レートリミット (5,000 req/h) を超え、`API rate limit exceeded for installation` で SARIF アップロードが失敗していた (Trivy/Gitleaks/Checkov)。SARIF はベストエフォートのため、ジョブを失敗させない
- gitleaks は親ステップで既に `continue-on-error: true`、CodeQL は内部 SARIF アップロードのため対象外

### 2. Dependabot スケジュール分散
- 21 ecosystem 全てが Mon 03:00 JST に集中 → Mon-Sat に分散、同一日内も 1h ずつ stagger
  | 曜日 | ecosystem | 件数 |
  |------|-----------|------|
  | Mon | npm (root, public, public-astro, admin) | 4 |
  | Tue | gomod (go-functions) | 1 |
  | Wed | terraform/environments (dev, prd) | 2 |
  | Thu | terraform/modules (acm/agentcore/api/auth/cdn/codebuild) | 6 |
  | Fri | terraform/modules (database/dns-cloudflare/dns-route53/lambda/monitoring/storage) | 6 |
  | Sat | github-actions (root, setup-bun-deps) | 2 |

### 3. Bun lockfile 自動同期
- `.github/actions/setup-bun-deps/action.yml`: `GITHUB_ACTOR == 'dependabot[bot]'` のとき `--frozen-lockfile` をスキップ
  - 背景: Dependabot は npm ecosystem 経由で `package.json` のみ更新し `bun.lock` は再生成しないため、`bun install --frozen-lockfile` が必ず lockfile drift エラーで失敗していた
- `.github/workflows/dependabot-bun-lockfile.yml` (新規): Dependabot PR で変更された各 `package.json` のディレクトリで `bun install` を実行し、再生成された `bun.lock` を PR HEAD に push back
  - `pull_request_target` を使用 (write 権限が必要なため)
  - 実行は `github.actor == 'dependabot[bot]'` で gating、checkout は PR HEAD で実施

## Test plan

- [ ] PR 自身の CI が通ること
- [ ] develop マージ後、既存 Dependabot PR を1件 close→reopen し以下を確認:
  - [ ] CI の Frontend Tests / ESLint & Prettier ジョブが `bun install --frozen-lockfile` で失敗せず通る
  - [ ] dependabot-bun-lockfile workflow が起動し `bun.lock` を含む新コミットが PR に push される
  - [ ] Security Scan workflow の Trivy アップロード失敗時もジョブ全体は success になる
- [ ] `gh api rate_limit` でレートリミットがリセットされた後、新規 Dependabot トリガーで Code Scanning が成功することを確認
- [ ] Dependabot の次回実行 (Mon 朝 JST) で複数曜日に分散発火することを確認

## Notes

- GITHUB_TOKEN による push は downstream workflow を再起動しない GitHub の仕様により、lockfile-sync workflow が push した commit では CI が自動再実行されない。ただし設定1A により初回 CI は dependabot actor のとき `--frozen-lockfile` をスキップして通るため、CI 自動再実行は不要
- `docs/SECURITY_SCANNING.md` の Phase 1→3 ロードマップに沿い、SARIF は visibility-only のままで behavior change なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)