### PR TITLE
security(scan): suppress gitleaks false positives and redact doc password (Phase A)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,6 +18,14 @@ paths = [
   '''.*/go\.sum''',
   '''package-lock\.json''',
   '''.*/package-lock\.json''',
+  # justification: provider blocks reference `cloudflare/cloudflare` source string and
+  # a fixed-length placeholder token used when the custom-domain feature is disabled.
+  # Real api_token values are sourced from var.cloudflare_api_token (TF Cloud workspace var).
+  '''terraform/environments/[^/]+/versions\.tf''',
+  # justification: parity tests embed obviously-fake JWT shapes ("eyJ...") to assert
+  # error-format equivalence between Go and legacy implementations. Already classified
+  # as `test` by gitleaks Code Scanning.
+  '''go-functions/tests/parity/.*_test\.go''',
 ]
 regexes = [
   # AWS canonical example credentials from public documentation

--- a/docs/DEV_BASIC_AUTH.md
+++ b/docs/DEV_BASIC_AUTH.md
@@ -397,16 +397,16 @@ This implementation was migrated from local `cdk.context.json` storage to AWS Pa
 ```json
 {
   "basicAuth": {
-    "username": "okshin",
-    "password": "r1aIysnn1x9wCBAOem93ikqt"
+    "username": "<dev-username>",
+    "password": "<REDACTED-EXAMPLE-PASSWORD>"
   }
 }
 ```
 
 **After (Parameter Store)**:
 ```bash
-/serverless-blog/dev/basic-auth/username → "okshin"
-/serverless-blog/dev/basic-auth/password → "r1aIysnn1x9wCBAOem93ikqt" (encrypted)
+/serverless-blog/dev/basic-auth/username → "<dev-username>"
+/serverless-blog/dev/basic-auth/password → "<REDACTED-EXAMPLE-PASSWORD>" (encrypted)
 ```
 
 **Migration Benefits**:


### PR DESCRIPTION
## Summary

Code Scanning **Phase A** triage per [`docs/SECURITY_SCANNING.md`](../blob/develop/docs/SECURITY_SCANNING.md). Resolves **13 of 39** open Gitleaks alerts; the remaining 26 stale alerts (referencing `infrastructure/test/__snapshots__/*.snap` and `rust-functions/tests/api_parity/auth_parity.rs`, both removed from `develop`) will auto-close on the next `security-scan.yml` run.

### `.gitleaks.toml` allowlist additions

| Path pattern | Justification |
|---|---|
| `terraform/environments/[^/]+/versions\.tf` | Provider block embeds the static `placeholdertokenfordisabledfeature000000` placeholder used when `var.enable_custom_domain` is false. Real `cloudflare_api_token` values come from the TF Cloud workspace variable. |
| `go-functions/tests/parity/.*_test\.go` | Parity tests use truncated `eyJ...` JWT shapes to assert error-format equivalence between Go and the legacy implementation. Already classified as `test` by gitleaks Code Scanning. |

### `docs/DEV_BASIC_AUTH.md` redaction

The migration-notes section embedded a real-looking password literal (`r1aIysnn1x9wCBAOem93ikqt`) twice. Replaced both occurrences with `<REDACTED-EXAMPLE-PASSWORD>` and changed the example username from `okshin` → `<dev-username>` so the doc no longer trips `generic-api-key`.

> ⚠️ **Action item for the human reviewer**: if `r1aIysnn1x9wCBAOem93ikqt` was ever the actual Parameter Store value for `/serverless-blog/dev/basic-auth/password`, rotate it independently of this PR.

## Resolved alerts

- 4× `cloudflare-api-key` → #385 #386 #387 #388 (`terraform/environments/{dev,prd}/versions.tf:51`)
- 8× `generic-api-key` → `go-functions/tests/parity/auth_parity_test.go`
- 1× `generic-api-key` → #418 (`docs/DEV_BASIC_AUTH.md:401`)

## Out of scope (handled in follow-ups)

- 2× `js/missing-origin-check` on MSW dev mock service workers — UI-dismissed separately as "Won't fix" with justification "MSW dev mock service worker, not bundled to production".
- 26× stale Gitleaks alerts on already-deleted files — will auto-close on next `security-scan.yml` run; otherwise UI-closed by maintainer.
- 74× Trivy CVEs and 23× CodeQL findings — Phase B / C / D.

## Test plan

- [ ] `security-scan.yml` Gitleaks job is green and reports 0 new findings on the touched paths
- [ ] No new alerts appear on the Code Scanning tab for `versions.tf` or `auth_parity_test.go` patterns
- [ ] CodeQL JS/TS scan unchanged (config-only change, no source modifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)