### PR TITLE
chore(terraform): migrate DynamoDB GSI to key_schema (AWS provider v6.29+)

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,8 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.0.0"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -22,24 +24,26 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "6.28.0"
+  version     = "6.43.0"
   constraints = ">= 6.0.0, ~> 6.0"
   hashes = [
-    "h1:wzZdGs0FFmNqIgPyo9tKnGKJ37BGNSgwRrEXayL29+0=",
-    "zh:0ba0d5eb6e0c6a933eb2befe3cdbf22b58fbc0337bf138f95bf0e8bb6e6df93e",
-    "zh:23eacdd4e6db32cf0ff2ce189461bdbb62e46513978d33c5de4decc4670870ec",
-    "zh:307b06a15fc00a8e6fd243abde2cbe5112e9d40371542665b91bec1018dd6e3c",
-    "zh:37a02d5b45a9d050b9642c9e2e268297254192280df72f6e46641daca52e40ec",
-    "zh:3da866639f07d92e734557d673092719c33ede80f4276c835bf7f231a669aa33",
-    "zh:480060b0ba310d0f6b6a14d60b276698cb103c48fd2f7e2802ae47c963995ec6",
-    "zh:57796453455c20db80d9168edbf125bf6180e1aae869de1546a2be58e4e405ec",
-    "zh:69139cba772d4df8de87598d8d8a2b1b4b254866db046c061dccc79edb14e6b9",
-    "zh:7312763259b859ff911c5452ca8bdf7d0be6231c5ea0de2df8f09d51770900ac",
-    "zh:8d2d6f4015d3c155d7eb53e36f019a729aefb46ebfe13f3a637327d3a1402ecc",
-    "zh:94ce589275c77308e6253f607de96919b840c2dd36c44aa798f693c9dd81af42",
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "h1:TuLqfrTx7PrnCuYIqNJHLJ4UtCq8xsiuhDBoRA71Bxw=",
+    "h1:yvdZqdEHHDk0WWL8oiK8dLaouJMSVZRkxGLEhDZyFCo=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:adaceec6a1bf4f5df1e12bd72cf52b72087c72efed078aef636f8988325b1a8b",
-    "zh:d37be1ce187d94fd9df7b13a717c219964cd835c946243f096c6b230cdfd7e92",
-    "zh:fe6205b5ca2ff36e68395cb8d3ae10a3728f405cdbcd46b206a515e1ebcf17a1",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
   ]
 }

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -43,18 +43,30 @@ resource "aws_dynamodb_table" "blog_posts" {
   # Partition key: category, Sort key: createdAt
   global_secondary_index {
     name            = "CategoryIndex"
-    hash_key        = "category"
-    range_key       = "createdAt"
     projection_type = "ALL"
+    key_schema {
+      attribute_name = "category"
+      key_type       = "HASH"
+    }
+    key_schema {
+      attribute_name = "createdAt"
+      key_type       = "RANGE"
+    }
   }
 
   # Requirement 2.4: PublishStatusIndex GSI
   # Partition key: publishStatus, Sort key: createdAt
   global_secondary_index {
     name            = "PublishStatusIndex"
-    hash_key        = "publishStatus"
-    range_key       = "createdAt"
     projection_type = "ALL"
+    key_schema {
+      attribute_name = "publishStatus"
+      key_type       = "HASH"
+    }
+    key_schema {
+      attribute_name = "createdAt"
+      key_type       = "RANGE"
+    }
   }
 
   # SlugIndex GSI for friendly URL lookup and uniqueness enforcement
@@ -63,8 +75,11 @@ resource "aws_dynamodb_table" "blog_posts" {
   # for legacy items pending backfill.
   global_secondary_index {
     name            = "SlugIndex"
-    hash_key        = "slug"
     projection_type = "ALL"
+    key_schema {
+      attribute_name = "slug"
+      key_type       = "HASH"
+    }
   }
 
   # Requirement 2.5: Point-in-Time Recovery
@@ -127,8 +142,11 @@ resource "aws_dynamodb_table" "categories" {
   # Partition key: slug, Projection: KEYS_ONLY
   global_secondary_index {
     name            = "SlugIndex"
-    hash_key        = "slug"
     projection_type = "KEYS_ONLY"
+    key_schema {
+      attribute_name = "slug"
+      key_type       = "HASH"
+    }
   }
 
   # Requirement 1.4: Point-in-Time Recovery
@@ -195,9 +213,15 @@ resource "aws_dynamodb_table" "mindmaps" {
   # Used to efficiently query published mindmaps
   global_secondary_index {
     name            = "PublishStatusIndex"
-    hash_key        = "publishStatus"
-    range_key       = "createdAt"
     projection_type = "ALL"
+    key_schema {
+      attribute_name = "publishStatus"
+      key_type       = "HASH"
+    }
+    key_schema {
+      attribute_name = "createdAt"
+      key_type       = "RANGE"
+    }
   }
 
   # Point-in-Time Recovery


### PR DESCRIPTION
## Summary

- AWS Provider **v6.29.0** で `aws_dynamodb_table` の `global_secondary_index` 内 `hash_key` / `range_key` が deprecated となり、`key_schema { attribute_name, key_type }` ブロックが代替として導入された ([PR #45357](https://github.com/hashicorp/terraform-provider-aws/pull/45357))。 deprecation warning が `terraform plan` で 8 件出ていたのを解消。
- `terraform/modules/database/main.tf` の **5 GSI** を新形式に書き換え。属性名・projection_type・テーブル top-level の `hash_key = "id"` は変更なし。
- dev / prd の lockfile はすでに provider v6.43.0 にアップ済み（dependabot 経由）なので、Terraform バージョン制約の変更は不要。

### 変更対象 GSI

| Table | GSI | Keys |
|---|---|---|
| `blog_posts` | CategoryIndex | category(HASH) + createdAt(RANGE) |
| `blog_posts` | PublishStatusIndex | publishStatus(HASH) + createdAt(RANGE) |
| `blog_posts` | SlugIndex | slug(HASH) |
| `categories` | SlugIndex | slug(HASH) |
| `mindmaps` | PublishStatusIndex | publishStatus(HASH) + createdAt(RANGE) |

### 触っていないもの
- 各テーブルの top-level `hash_key = "id"`（非推奨ではない、`Forces new resource`）
- `attribute` ブロック群、`point_in_time_recovery`、`server_side_encryption`、`tags`、`lifecycle`
- LSI（このプロジェクトには未使用）

## Test plan

- [x] `terraform fmt -check -recursive` 通過
- [x] `terraform validate` 通過（dev, prd, database module 単独）
- [ ] **GitHub Actions の `terraform plan` で `No changes` を確認**（最重要）
  - 万一 `~ update in-place` または `-/+ destroy and replace` が出た場合は属性名タイポを疑い、apply 前に差分を共有
- [ ] `range_key is deprecated` 警告が plan ログから消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)