### PR TITLE
security(codeql): make HTML strip idempotent (Phase C, JS portion)

### DIFF
--- a/frontend/public-astro/src/lib/postUtils.ts
+++ b/frontend/public-astro/src/lib/postUtils.ts
@@ -11,21 +11,20 @@ import type { Post } from './api';
 /**
  * HTMLからプレーンテキストを抽出する
  *
- * Iteratively strips `<...>` patterns until the string is idempotent so that
- * residual fragments (e.g. `<<script>>` collapsing into `<script>` after one
- * pass) cannot survive. The output is used for excerpts and SEO descriptions
- * where it is rendered as React/Astro text content (escaped automatically),
- * not as `innerHTML`.
+ * Strips `<...>` patterns until the string is idempotent so that residual
+ * fragments (e.g. `<<script>>` collapsing into `<script>` after one pass)
+ * cannot survive. The fixed-point loop uses CodeQL's recognized pattern
+ * `while (a !== (a = a.replace(...)))` so the
+ * `js/incomplete-multi-character-sanitization` rule sees the recursion.
+ *
+ * The output is used for excerpts and SEO descriptions where it is rendered
+ * as React/Astro text content (escaped automatically), not as `innerHTML`.
  */
 export function stripHtml(html: string): string {
-  const tagPattern = /<[^>]*>/g;
-  let prev = html;
-  let next = html.replace(tagPattern, '');
-  while (next !== prev) {
-    prev = next;
-    next = next.replace(tagPattern, '');
-  }
-  return next.trim();
+  let result = html;
+  // eslint-disable-next-line no-cond-assign
+  while (result !== (result = result.replace(/<[^>]*>/g, '')));
+  return result.trim();
 }
 
 /**

--- a/frontend/public-astro/src/lib/postUtils.ts
+++ b/frontend/public-astro/src/lib/postUtils.ts
@@ -10,9 +10,22 @@ import type { Post } from './api';
 
 /**
  * HTMLからプレーンテキストを抽出する
+ *
+ * Iteratively strips `<...>` patterns until the string is idempotent so that
+ * residual fragments (e.g. `<<script>>` collapsing into `<script>` after one
+ * pass) cannot survive. The output is used for excerpts and SEO descriptions
+ * where it is rendered as React/Astro text content (escaped automatically),
+ * not as `innerHTML`.
  */
 export function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, '').trim();
+  const tagPattern = /<[^>]*>/g;
+  let prev = html;
+  let next = html.replace(tagPattern, '');
+  while (next !== prev) {
+    prev = next;
+    next = next.replace(tagPattern, '');
+  }
+  return next.trim();
 }
 
 /**

--- a/frontend/public-astro/tests/codebuild-trigger.test.ts
+++ b/frontend/public-astro/tests/codebuild-trigger.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { mockPosts } from './mock-api-server';
+import { stripHtml } from '../src/lib/postUtils';
 
 const distDir = join(import.meta.dirname, '../dist');
 
@@ -158,7 +159,7 @@ describe('CodeBuildトリガー連携テスト (Task 8.2)', () => {
         const html = readFileSync(postPath, 'utf-8');
 
         // Strip HTML tags from contentHtml to get plain text for comparison
-        const plainContent = post.contentHtml.replace(/<[^>]*>/g, '').trim();
+        const plainContent = stripHtml(post.contentHtml);
         if (plainContent) {
           // Content should appear somewhere in the page
           expect(html).toContain(plainContent);

--- a/frontend/public-astro/tests/rss.test.ts
+++ b/frontend/public-astro/tests/rss.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { mockPosts } from './mock-api-server';
+import { stripHtml } from '../src/lib/postUtils';
 
 const projectDir = join(import.meta.dirname, '..');
 const distDir = join(projectDir, 'dist');
@@ -265,7 +266,7 @@ describe('RSS Feed Generation (Task 3.4)', () => {
 
       if (japanesePost) {
         // HTML stripped description should be in the feed
-        const plainText = japanesePost.contentHtml.replace(/<[^>]*>/g, '');
+        const plainText = stripHtml(japanesePost.contentHtml);
         const containsJapaneseContent =
           content.includes(plainText) || content.includes(`<![CDATA[`);
         expect(containsJapaneseContent).toBe(true);

--- a/frontend/public/src/pages/PostDetailPage.tsx
+++ b/frontend/public/src/pages/PostDetailPage.tsx
@@ -72,16 +72,12 @@ const PostDetailPage: React.FC = () => {
 
   // Generate description from contentHtml (extract first 150 characters of text)
   const generateDescription = (html: string): string => {
-    // Iteratively strip tags so residual fragments like `<<script>>` cannot
-    // collapse into `<script>` after a single pass. Output is used as a
-    // <meta description>, rendered as text by SEOHead.
-    const tagPattern = /<[^>]*>/g;
-    let prev = html;
-    let text = html.replace(tagPattern, '');
-    while (text !== prev) {
-      prev = text;
-      text = text.replace(tagPattern, '');
-    }
+    // Idempotent strip — fixed-point loop using CodeQL's recognized pattern
+    // so `js/incomplete-multi-character-sanitization` sees the recursion.
+    // Output is rendered as <meta description> text content, not innerHTML.
+    let text = html;
+    // eslint-disable-next-line no-cond-assign
+    while (text !== (text = text.replace(/<[^>]*>/g, '')));
     return text.substring(0, 150) + (text.length > 150 ? '...' : '');
   };
 

--- a/frontend/public/src/pages/PostDetailPage.tsx
+++ b/frontend/public/src/pages/PostDetailPage.tsx
@@ -72,7 +72,16 @@ const PostDetailPage: React.FC = () => {
 
   // Generate description from contentHtml (extract first 150 characters of text)
   const generateDescription = (html: string): string => {
-    const text = html.replace(/<[^>]*>/g, ''); // Strip HTML tags
+    // Iteratively strip tags so residual fragments like `<<script>>` cannot
+    // collapse into `<script>` after a single pass. Output is used as a
+    // <meta description>, rendered as text by SEOHead.
+    const tagPattern = /<[^>]*>/g;
+    let prev = html;
+    let text = html.replace(tagPattern, '');
+    while (text !== prev) {
+      prev = text;
+      text = text.replace(tagPattern, '');
+    }
     return text.substring(0, 150) + (text.length > 150 ? '...' : '');
   };
 

--- a/frontend/public/src/pages/PostListPage.tsx
+++ b/frontend/public/src/pages/PostListPage.tsx
@@ -12,6 +12,20 @@ import type { Post, CategoryListItem } from '../types/post';
 import { SEOHead } from '../components/SEOHead';
 import { PostListSkeleton } from '../components/skeleton';
 
+// Iteratively strip `<...>` patterns so residual fragments like `<<b>>` cannot
+// collapse into a tag after a single pass. The output is rendered as React
+// text content (escaped automatically), not as innerHTML.
+const stripTags = (html: string): string => {
+  const tagPattern = /<[^>]*>/g;
+  let prev = html;
+  let next = html.replace(tagPattern, '');
+  while (next !== prev) {
+    prev = next;
+    next = next.replace(tagPattern, '');
+  }
+  return next;
+};
+
 const PostListPage: React.FC = () => {
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
@@ -259,9 +273,7 @@ const PostListPage: React.FC = () => {
                   <div className="excerpt" data-testid="article-excerpt">
                     {/* 記事の要約（最初の100文字） */}
                     {post.contentHtml
-                      ? post.contentHtml
-                          .substring(0, 100)
-                          .replace(/<[^>]*>/g, '') + '...'
+                      ? stripTags(post.contentHtml.substring(0, 100)) + '...'
                       : ''}
                   </div>
                 </Link>

--- a/frontend/public/src/pages/PostListPage.tsx
+++ b/frontend/public/src/pages/PostListPage.tsx
@@ -12,18 +12,16 @@ import type { Post, CategoryListItem } from '../types/post';
 import { SEOHead } from '../components/SEOHead';
 import { PostListSkeleton } from '../components/skeleton';
 
-// Iteratively strip `<...>` patterns so residual fragments like `<<b>>` cannot
-// collapse into a tag after a single pass. The output is rendered as React
-// text content (escaped automatically), not as innerHTML.
+// Strip `<...>` patterns to a fixed point so residual fragments like `<<b>>`
+// cannot collapse into a tag after a single pass. Uses CodeQL's recognized
+// `while (a !== (a = a.replace(...)))` shape so the
+// `js/incomplete-multi-character-sanitization` query sees the recursion.
+// Output is rendered as React text content, not innerHTML.
 const stripTags = (html: string): string => {
-  const tagPattern = /<[^>]*>/g;
-  let prev = html;
-  let next = html.replace(tagPattern, '');
-  while (next !== prev) {
-    prev = next;
-    next = next.replace(tagPattern, '');
-  }
-  return next;
+  let result = html;
+  // eslint-disable-next-line no-cond-assign
+  while (result !== (result = result.replace(/<[^>]*>/g, '')));
+  return result;
 };
 
 const PostListPage: React.FC = () => {


### PR DESCRIPTION
## Summary

Code Scanning **Phase C (JS portion)** per [`docs/SECURITY_SCANNING.md`](../blob/develop/docs/SECURITY_SCANNING.md). Resolves **5 of 9** open CodeQL warnings — all `js/incomplete-multi-character-sanitization` instances.

The Go warning (`go/useless-expression` in `tracing.go`, alerts #317 / #318) and the 2 `js/missing-origin-check` MSW alerts are deliberately *not* in this PR — see "Out of scope" below for routing.

### The issue

`html.replace(/<[^>]*>/g, '')` only strips tags in a single pass, so residual fragments can re-form a tag (e.g. `<<script>>` collapses into `<script>` after one substitution). Replaced each occurrence with an idempotent loop that keeps stripping until the string stops changing.

| File | Change |
|---|---|
| `frontend/public-astro/src/lib/postUtils.ts` | `stripHtml()` now loops to fixed point |
| `frontend/public/src/pages/PostDetailPage.tsx` | `generateDescription` inlined the loop pattern (used for the SEO `<meta description>`) |
| `frontend/public/src/pages/PostListPage.tsx` | Extracted a local `stripTags` helper used by the article excerpt |
| `frontend/public-astro/tests/rss.test.ts` | Imports the safe `stripHtml` from `postUtils` instead of duplicating the unsafe regex |
| `frontend/public-astro/tests/codebuild-trigger.test.ts` | Same |

In every case the output is rendered as **text content** (React JSX, Astro template, or HTML `<meta>` attribute) — never as `innerHTML` — so even the single-pass version was not exploitable in practice. The change fixes the *class* of issue the CodeQL rule is designed to catch.

### Verification

- `frontend/public`: `bun run test --run` → **92 passed** (6 test files)
- `frontend/public-astro`: `bun run test src/lib/postUtils.test.ts --run` → **16 passed**

## Out of scope (intentionally)

- **`go/useless-expression` × 2 in `go-functions/internal/middleware/tracing.go`** — will land as a follow-up PR. Bundling it here triggers the cross-module Go pre-commit lint, which surfaces 16 unrelated pre-existing findings (12 `gosec/G706` taint warnings + 4 `staticcheck/QF1012` style nits). Splitting the Go change keeps this PR scoped.
- **`js/missing-origin-check` × 2 in MSW dev mock service workers** — UI-dismissed under Phase A as "Won't fix" with justification "MSW dev mock service worker, not bundled to production".
- **CodeQL note (`unused-local-variable`) × 14** — Phase D.

## Test plan

- [ ] CI `Frontend Public tests` and `frontend/public-astro` build/test jobs pass
- [ ] `security-scan.yml` CodeQL JS/TS job reports **0 open** `js/incomplete-multi-character-sanitization` alerts after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)