### PR TITLE
chore(go-lint): align CI golangci-lint to v2.11 and restore inline nolint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.7
+          version: v2.11
           working-directory: go-functions
           args: --timeout=5m
 

--- a/go-functions/.golangci.yml
+++ b/go-functions/.golangci.yml
@@ -138,15 +138,6 @@ linters:
           - funlen
           - revive
           - errcheck  # errorResponse always returns nil error
-      # CODEBUILD_PROJECT_NAME passes buildtrigger.SanitizeProjectName at the
-      # trust boundary (regex `^[A-Za-z0-9][A-Za-z0-9_-]{1,254}$`), so the slog
-      # calls below it have no log-injection vector. gosec versions differ on
-      # whether they recognize the regex sanitizer, so the exclusion is scoped
-      # to the specific G706 rule on these handlers' triggerSiteBuild paths.
-      - path: cmd/(posts|mindmaps)/(create|delete|update)/main\.go
-        text: "G706"
-        linters:
-          - gosec
 
 issues:
   max-issues-per-linter: 0

--- a/go-functions/cmd/mindmaps/create/main.go
+++ b/go-functions/cmd/mindmaps/create/main.go
@@ -168,9 +168,11 @@ func triggerSiteBuild(ctx context.Context) {
 	}
 	trigger := buildtrigger.NewBuildTrigger(client, projectName)
 	if err := trigger.TriggerBuild(ctx); err != nil {
+		//nolint:gosec // G706: projectName already passed buildtrigger.SanitizeProjectName regex validation, so no log-injection vector
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		return
 	}
+	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
 }
 

--- a/go-functions/cmd/mindmaps/delete/main.go
+++ b/go-functions/cmd/mindmaps/delete/main.go
@@ -155,9 +155,11 @@ func triggerSiteBuild(ctx context.Context) {
 	}
 	trigger := buildtrigger.NewBuildTrigger(client, projectName)
 	if err := trigger.TriggerBuild(ctx); err != nil {
+		//nolint:gosec // G706: projectName already passed buildtrigger.SanitizeProjectName regex validation, so no log-injection vector
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		return
 	}
+	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
 }
 

--- a/go-functions/cmd/mindmaps/update/main.go
+++ b/go-functions/cmd/mindmaps/update/main.go
@@ -204,9 +204,11 @@ func triggerSiteBuild(ctx context.Context) {
 	}
 	trigger := buildtrigger.NewBuildTrigger(client, projectName)
 	if err := trigger.TriggerBuild(ctx); err != nil {
+		//nolint:gosec // G706: projectName already passed buildtrigger.SanitizeProjectName regex validation, so no log-injection vector
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		return
 	}
+	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
 }
 

--- a/go-functions/cmd/posts/create/main.go
+++ b/go-functions/cmd/posts/create/main.go
@@ -207,10 +207,12 @@ func triggerSiteBuild(ctx context.Context) {
 
 	trigger := buildtrigger.NewBuildTrigger(client, projectName)
 	if err := trigger.TriggerBuild(ctx); err != nil {
+		//nolint:gosec // G706: projectName already passed buildtrigger.SanitizeProjectName regex validation, so no log-injection vector
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		return
 	}
 
+	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
 }
 

--- a/go-functions/cmd/posts/delete/main.go
+++ b/go-functions/cmd/posts/delete/main.go
@@ -219,10 +219,12 @@ func triggerSiteBuild(ctx context.Context) {
 
 	trigger := buildtrigger.NewBuildTrigger(client, projectName)
 	if err := trigger.TriggerBuild(ctx); err != nil {
+		//nolint:gosec // G706: projectName already passed buildtrigger.SanitizeProjectName regex validation, so no log-injection vector
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		return
 	}
 
+	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
 }
 

--- a/go-functions/cmd/posts/update/main.go
+++ b/go-functions/cmd/posts/update/main.go
@@ -252,10 +252,12 @@ func triggerSiteBuild(ctx context.Context) {
 
 	if err := trigger.TriggerBuild(ctx); err != nil {
 		// Requirement 10.10: Handle CodeBuild API errors gracefully
+		//nolint:gosec // G706: projectName already passed buildtrigger.SanitizeProjectName regex validation, so no log-injection vector
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		return
 	}
 
+	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #236. PR #236 had to land with a config-level G706 exclusion in `go-functions/.golangci.yml` because CI ran golangci-lint **v2.7.2** (whose gosec recognized the regex sanitizer in `buildtrigger.SanitizeProjectName` and did **not** raise G706) while local development ran **v2.11.4** (whose gosec still raises G706). The mismatch produced 12 `nolintlint` *unused-directive* errors in CI for the per-line `//nolint:gosec` annotations.

The exclusion-based fix worked but left two downsides on the table:

1. The local/CI version skew remained — every future Go change risks the same friction.
2. The path+text G706 exclusion silently absorbed *any* future legitimate G706 findings on the six cmd handler files (within scope, but invisible).

This change resolves the skew at the source.

### Changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml:201` | `version: v2.7` → `version: v2.11` (golangci-lint-action) |
| `go-functions/.golangci.yml` | Remove the path+text G706 exclusion that was added in 8b1aa60 |
| `go-functions/cmd/{posts,mindmaps}/{create,delete,update}/main.go` (×6) | Restore the `//nolint:gosec` annotations on the `slog.Error` / `slog.Info` lines, with the same per-line justification ("regex-validated, no log-injection vector") |

### Why this is safe

Verified locally on v2.11.4 that the only gosec/staticcheck findings on this codebase are the same ones already fixed in #236 (G706 ×12 + QF1012 ×4). The version bump does **not** surface any new lint debt on existing code.

Under v2.11:
- gosec raises G706 on the slog calls below `SanitizeProjectName`
- The restored `//nolint:gosec` directives correctly correspond to a real finding → no longer "unused" → `nolintlint` is happy
- The `.golangci.yml` exclusion is no longer needed and is removed

### Verification

- `golangci-lint run ./...` (local v2.11.4) → **0 issues**
- All Go tests pass via the pre-commit hook

### Trade-offs explicitly considered

| | Config exclusion (#236) | Version bump (this PR) |
|---|---|---|
| diff size | small | tiny (1 line CI + comment restore) |
| local/CI skew | persists | **resolved** |
| nolint as documentation | gone | **restored** |
| Future G706 visibility | silently absorbed | per-line, requires explicit nolint to suppress |

🤖 Generated with [Claude Code](https://claude.com/claude-code)