### PR TITLE
security(codeql): give X-Ray stubs an observable side effect (resolve #430)

### DIFF
--- a/go-functions/internal/middleware/tracing.go
+++ b/go-functions/internal/middleware/tracing.go
@@ -9,6 +9,7 @@ package middleware
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
@@ -150,22 +151,31 @@ func (t *xrayTracer) EndSubsegment(seg Segment) {
 	seg.Close(nil)
 }
 
-// AddAnnotation adds a searchable annotation to the segment
+// AddAnnotation adds a searchable annotation to the segment.
+//
+// In a real X-Ray implementation this would record an indexed, searchable
+// annotation; until that wiring lands, the stub emits a debug-level slog
+// entry so callers can still observe what would have been recorded
+// (and so static analysis can see the call has an observable effect).
 func (t *xrayTracer) AddAnnotation(seg Segment, key, value string) {
 	if seg == nil {
 		return
 	}
-	// In real X-Ray implementation, this would add an annotation
-	// Annotations are indexed and searchable in X-Ray console
+	slog.Debug("xray.AddAnnotation (stub)", "segment", seg.Name(), "key", key, "value", value)
 }
 
-// AddMetadata adds metadata to the segment
+// AddMetadata adds metadata to the segment.
+//
+// In a real X-Ray implementation this would record (un-indexed) metadata
+// visible in trace details; until that wiring lands, the stub emits a
+// debug-level slog entry so callers can still observe what would have
+// been recorded (and so static analysis can see the call has an
+// observable effect).
 func (t *xrayTracer) AddMetadata(seg Segment, key string, value interface{}) {
 	if seg == nil {
 		return
 	}
-	// In real X-Ray implementation, this would add metadata
-	// Metadata is not indexed but can be viewed in trace details
+	slog.Debug("xray.AddMetadata (stub)", "segment", seg.Name(), "key", key, "value", value)
 }
 
 // AddSafeMetadata adds metadata to the segment, filtering sensitive fields


### PR DESCRIPTION
## Summary

Resolves CodeQL alert **#430** (`go/useless-expression` on `go-functions/internal/middleware/tracing.go:183`) — the same root cause that originally surfaced as #317 / #318 in Phase C: the X-Ray tracer's `AddAnnotation` and `AddMetadata` are empty stubs pending real X-Ray wiring, so any call into them is "an expression with no effect" by CodeQL's reasoning.

PR #236 (Phase C2) collapsed the two `AddMetadata` calls inside `AddSafeMetadata` into one — closing #317 and #318 — but the surviving single call now reproduces the same finding at line 183 (alert #430).

### Fix

Give the stubs a real, minimal **observable side effect** — both `AddAnnotation` and `AddMetadata` now emit a `slog.Debug` line:

```go
slog.Debug("xray.AddMetadata (stub)", "segment", seg.Name(), "key", key, "value", value)
```

`slog.Debug` is filtered out by default at INFO level, so production log volume is unchanged. Developers debugging tracing locally can flip the slog handler level to see what the future X-Ray integration would have recorded.

### Why this approach

| | This PR (debug-log stub) | Alternative: dismiss as "won't fix" |
|---|---|---|
| Resolves #430 | ✅ | ✅ |
| Preserves delegation contract | ✅ | ✅ |
| Adds debugability hook | ✅ | ✗ |
| Future-proof for next gosec/codeql tightening | ✅ | depends on dismissal staying |
| Behavior change in prod logs | none (debug filtered) | none |

### Verification

- `golangci-lint run ./...` → **0 issues**
- `go test ./internal/middleware/...` → ok
- The change touches only the two stub bodies in `tracing.go`; the public API and `AddSafeMetadata`'s `filterSensitiveData` delegation pattern are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)