### PR TITLE
chore(ci): bump Go stdlib to 1.25.9 and drop broken npm audit steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ permissions:
   id-token: write # Required for AWS OIDC authentication
 
 env:
-  GO_VERSION: '1.25.5'
+  GO_VERSION: '1.25.9'
   TERRAFORM_VERSION: '1.14.0'
   AWS_REGION: 'ap-northeast-1'
 
@@ -149,16 +149,6 @@ jobs:
       - name: Lint frontend
         working-directory: frontend/admin
         run: bun run lint
-
-      - name: Security audit (public-site)
-        run: npm audit --production --audit-level=high
-        working-directory: frontend/public
-        continue-on-error: true
-
-      - name: Security audit (admin-dashboard)
-        run: npm audit --production --audit-level=high
-        working-directory: frontend/admin
-        continue-on-error: true
 
   # =======================================
   # Job 2: Backend Unit Tests - REMOVED (Task 21.3)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ permissions:
 
 env:
   TERRAFORM_VERSION: '1.14.0'
-  GO_VERSION: '1.25.5'
+  GO_VERSION: '1.25.9'
   BUN_VERSION: '1.2.0'
   AWS_REGION: 'ap-northeast-1'
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -127,7 +127,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.9'
           check-latest: true
           cache-dependency-path: go-functions/go.sum
 

--- a/go-functions/go.mod
+++ b/go-functions/go.mod
@@ -1,6 +1,6 @@
 module serverless-blog/go-functions
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/aws/aws-lambda-go v1.54.0


### PR DESCRIPTION
## Summary

Clean up the two non-gating CI steps that were silently producing **12 failure annotations** on every recent PR (notably visible on PR #237's Annotations panel) — both jobs concluded SUCCESS thanks to ``continue-on-error: true``, so the noise was invisible to the All CI Checks gate but loud in the UI.

The annotations were **not** from ESLint or golangci-lint; they were from misnamed sub-steps:

1. **\`Security audit (public-site)\` / \`Security audit (admin-dashboard)\` (under "ESLint & Prettier Check")** — running ``npm audit --production`` against bun-managed projects (\`frontend/{public,admin}\` only have \`bun.lock\`), failing every run with ``ENOLOCK``.
2. **\`Go vulnerability check\` (under "Go Lint (golangci-lint)")** — \`govulncheck\` reporting 9 reachable Go 1.25.5 stdlib CVEs in \`crypto/tls\` / \`crypto/x509\` / \`html/template\` / \`os\` / \`net/url\`, all fixed by Go ≥ 1.25.9.

### Changes
- Bump GO_VERSION/go directive ``1.25.5`` → ``1.25.9`` in:
  - ``go-functions/go.mod``
  - ``.github/workflows/ci.yml``
  - ``.github/workflows/deploy.yml``
  - ``.github/workflows/security-scan.yml``
- Drop the two ``npm audit`` steps from ``.github/workflows/ci.yml``. JS dependency vuln coverage is already provided by **Trivy fs scan** + **CodeQL JS/TS** + **Dependabot** in ``security-scan.yml`` / repo settings.

### Local verification
- ``cd go-functions && govulncheck ./...`` → "No vulnerabilities found." (was 9 reachable on 1.25.5)
- ``make lint`` → 0 issues
- ``make test`` → all packages PASS

Closes #194
Closes #195

## Test plan
- [ ] CI "Go Lint (golangci-lint)" job: ``govulncheck`` step exits 0, **no** "X calls Y, which eventually calls Z" failure annotations
- [ ] CI "ESLint & Prettier Check" job: **no** "Process completed with exit code 1" failure annotations
- [ ] All gating checks remain green
- [ ] Deploy workflow still builds Lambda artifacts under Go 1.25.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)