### PR TITLE
feat(admin): unify image paste/drop/toolbar via Tiptap UploadImage extension (WX PR4)

### DIFF
--- a/frontend/admin/src/components/PostEditor.test.tsx
+++ b/frontend/admin/src/components/PostEditor.test.tsx
@@ -474,14 +474,16 @@ describe('PostEditor', () => {
     });
   });
 
-  describe('画像ペースト機能', () => {
-    it('画像をペーストするとonImagePasteが呼ばれる', async () => {
-      const mockOnImagePaste = vi.fn().mockResolvedValue(undefined);
+  describe('画像アップロード機能 (UploadImage 拡張)', () => {
+    it('画像をペーストすると uploadFn が呼ばれ、成功 URL が markdown に反映される', async () => {
+      const mockUploadFn = vi
+        .fn<(file: File) => Promise<string>>()
+        .mockResolvedValue('https://cdn.example.com/uploaded.png');
       render(
         <PostEditor
           onSave={mockOnSave}
           onCancel={mockOnCancel}
-          onImagePaste={mockOnImagePaste}
+          uploadFn={mockUploadFn}
           categories={mockCategories}
         />
       );
@@ -509,17 +511,22 @@ describe('PostEditor', () => {
       fireEvent.paste(editorEl, { clipboardData });
 
       await waitFor(() => {
-        expect(mockOnImagePaste).toHaveBeenCalledWith(file);
+        expect(mockUploadFn).toHaveBeenCalledWith(file);
+      });
+
+      await waitFor(async () => {
+        const md = await getEditorMarkdown();
+        expect(md).toContain('https://cdn.example.com/uploaded.png');
       });
     });
 
-    it('テキストペースト時はonImagePasteが呼ばれない', async () => {
-      const mockOnImagePaste = vi.fn();
+    it('テキストペースト時は uploadFn が呼ばれない', async () => {
+      const mockUploadFn = vi.fn();
       render(
         <PostEditor
           onSave={mockOnSave}
           onCancel={mockOnCancel}
-          onImagePaste={mockOnImagePaste}
+          uploadFn={mockUploadFn}
           categories={mockCategories}
         />
       );
@@ -545,16 +552,19 @@ describe('PostEditor', () => {
 
       fireEvent.paste(editorEl, { clipboardData });
 
-      // microtask 待ち
       await new Promise((r) => setTimeout(r, 0));
-      expect(mockOnImagePaste).not.toHaveBeenCalled();
+      expect(mockUploadFn).not.toHaveBeenCalled();
     });
 
-    it('onImagePasteが未定義でも画像ペーストでエラーにならない', async () => {
+    it('uploadFn が失敗するとエラー alert と再試行ボタンが表示される', async () => {
+      const mockUploadFn = vi
+        .fn<(file: File) => Promise<string>>()
+        .mockRejectedValue(new Error('upload failed'));
       render(
         <PostEditor
           onSave={mockOnSave}
           onCancel={mockOnCancel}
+          uploadFn={mockUploadFn}
           categories={mockCategories}
         />
       );
@@ -579,39 +589,53 @@ describe('PostEditor', () => {
         files: [file],
       } as unknown as DataTransfer;
 
-      expect(() => {
-        fireEvent.paste(editorEl, { clipboardData });
-      }).not.toThrow();
-    });
-  });
+      fireEvent.paste(editorEl, { clipboardData });
 
-  describe('ローディング表示', () => {
-    it('isUploadingがtrueの時にローディングオーバーレイが表示される', () => {
+      await waitFor(() => {
+        const alert = screen.getByTestId('image-upload-error');
+        expect(alert).toHaveTextContent(/画像のアップロードに失敗しました/);
+      });
+      expect(screen.getByTestId('image-upload-retry')).toBeInTheDocument();
+    });
+
+    it('未対応 MIME (svg) は uploadFn を呼ばずに validation エラーを表示する', async () => {
+      const mockUploadFn = vi.fn();
       render(
         <PostEditor
           onSave={mockOnSave}
           onCancel={mockOnCancel}
-          isUploading={true}
+          uploadFn={mockUploadFn}
           categories={mockCategories}
         />
       );
 
-      expect(screen.getByText('画像アップロード中...')).toBeInTheDocument();
-    });
+      await waitForTiptap();
+      const editorEl = screen
+        .getByTestId('tiptap-editor')
+        .querySelector('[contenteditable]') as HTMLElement;
 
-    it('isUploadingがfalseの時にローディングオーバーレイが表示されない', () => {
-      render(
-        <PostEditor
-          onSave={mockOnSave}
-          onCancel={mockOnCancel}
-          isUploading={false}
-          categories={mockCategories}
-        />
-      );
+      const file = new File(['<svg/>'], 'bad.svg', { type: 'image/svg+xml' });
+      const clipboardData = {
+        items: [
+          {
+            type: 'image/svg+xml',
+            kind: 'file',
+            getAsFile: () => file,
+            getAsString: () => '',
+          },
+        ],
+        getData: () => '',
+        types: ['Files'],
+        files: [file],
+      } as unknown as DataTransfer;
 
-      expect(
-        screen.queryByText('画像アップロード中...')
-      ).not.toBeInTheDocument();
+      fireEvent.paste(editorEl, { clipboardData });
+
+      await waitFor(() => {
+        const alert = screen.getByTestId('image-upload-error');
+        expect(alert).toHaveTextContent(/対応していない画像形式/);
+      });
+      expect(mockUploadFn).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/admin/src/components/PostEditor.tsx
+++ b/frontend/admin/src/components/PostEditor.tsx
@@ -1,4 +1,6 @@
 import {
+  useCallback,
+  useEffect,
   useState,
   useRef,
   useImperativeHandle,
@@ -12,6 +14,7 @@ import {
   validatePostContent,
   validateCategory,
 } from '../utils/validation';
+import { uploadImage as defaultUploadImage } from '../api/posts';
 import { Button } from './Button';
 import { TiptapEditor, type TiptapEditorHandle } from './editor';
 
@@ -41,8 +44,8 @@ interface PostEditorProps {
   onSave: (data: PostData) => Promise<void>;
   onCancel: () => void;
   initialData?: PostData;
-  onImagePaste?: (file: File) => Promise<void>;
-  isUploading?: boolean;
+  /** 画像アップロード関数 (省略時は api/posts.uploadImage) */
+  uploadFn?: (file: File) => Promise<string>;
   /** 動的カテゴリ一覧 */
   categories: CategoryOption[];
   /** カテゴリローディング状態 */
@@ -68,8 +71,7 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
       onSave,
       onCancel,
       initialData,
-      onImagePaste,
-      isUploading,
+      uploadFn = defaultUploadImage,
       categories,
       categoriesLoading = false,
       categoriesError = null,
@@ -110,6 +112,35 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
     const [categoryError, setCategoryError] = useState<string | null>(null);
 
     const [isSaving, setIsSaving] = useState(false);
+
+    // 画像アップロードのエラー表示 (UploadImage 拡張からのコールバック)
+    const [uploadError, setUploadError] = useState<{
+      message: string;
+      retry: () => void;
+    } | null>(null);
+    const uploadErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+      null
+    );
+
+    const handleUploadError = useCallback(
+      (message: string, retry: () => void) => {
+        setUploadError({ message, retry });
+      },
+      []
+    );
+
+    useEffect(() => {
+      if (!uploadError) return;
+      uploadErrorTimerRef.current = setTimeout(() => {
+        setUploadError(null);
+      }, 8000);
+      return () => {
+        if (uploadErrorTimerRef.current) {
+          clearTimeout(uploadErrorTimerRef.current);
+          uploadErrorTimerRef.current = null;
+        }
+      };
+    }, [uploadError]);
 
     // ref経由でinsertAtCursor, removeImageUrlメソッドを公開
     useImperativeHandle(
@@ -176,12 +207,6 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
     // タグ削除ハンドラ
     const removeTag = (indexToRemove: number) => {
       setTags(tags.filter((_, index) => index !== indexToRemove));
-    };
-
-    const handleEditorImagePaste = async (file: File) => {
-      if (onImagePaste) {
-        await onImagePaste(file);
-      }
     };
 
     const handleSubmit = async (e: FormEvent) => {
@@ -306,13 +331,45 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
               )}
             </div>
           </div>
+          {uploadError && (
+            <div
+              role="alert"
+              data-testid="image-upload-error"
+              className="mb-2 flex items-start justify-between gap-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              <span>{uploadError.message}</span>
+              <div className="flex shrink-0 gap-2">
+                <button
+                  type="button"
+                  data-testid="image-upload-retry"
+                  className="text-red-700 underline hover:text-red-900"
+                  onClick={() => {
+                    const retry = uploadError.retry;
+                    setUploadError(null);
+                    retry();
+                  }}
+                >
+                  再試行
+                </button>
+                <button
+                  type="button"
+                  aria-label="エラーを閉じる"
+                  className="text-red-700 hover:text-red-900"
+                  onClick={() => setUploadError(null)}
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+          )}
           <div className="relative">
             <div hidden={editorMode !== 'edit'}>
               <TiptapEditor
                 ref={tiptapRef}
                 value={contentMarkdown}
                 onChange={setContentMarkdown}
-                onImagePaste={handleEditorImagePaste}
+                uploadFn={uploadFn}
+                onUploadError={handleUploadError}
                 disabled={isSaving}
               />
             </div>
@@ -324,13 +381,6 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>
                   {contentMarkdown || '*プレビューがここに表示されます*'}
                 </ReactMarkdown>
-              </div>
-            )}
-            {isUploading && (
-              <div className="absolute inset-0 bg-gray-100 bg-opacity-50 flex items-center justify-center rounded-md pointer-events-none">
-                <span className="text-sm text-gray-600">
-                  画像アップロード中...
-                </span>
               </div>
             )}
           </div>

--- a/frontend/admin/src/components/editor/TiptapEditor.tsx
+++ b/frontend/admin/src/components/editor/TiptapEditor.tsx
@@ -24,9 +24,13 @@ import { Link } from '@tiptap/extension-link';
 import { Placeholder } from '@tiptap/extension-placeholder';
 import { Typography } from '@tiptap/extension-typography';
 import { History } from '@tiptap/extension-history';
-import { Image } from '@tiptap/extension-image';
 import { Markdown } from 'tiptap-markdown';
 import { TiptapToolbar } from './TiptapToolbar';
+import {
+  UploadImage,
+  type UploadFn,
+  type UploadErrorHandler,
+} from './extensions/UploadImage';
 
 export interface TiptapEditorHandle {
   getEditor: () => Editor | null;
@@ -35,13 +39,21 @@ export interface TiptapEditorHandle {
 export interface TiptapEditorProps {
   value: string;
   onChange: (markdown: string) => void;
-  onImagePaste?: (file: File) => Promise<void>;
+  uploadFn?: UploadFn;
+  onUploadError?: UploadErrorHandler;
   placeholder?: string;
   disabled?: boolean;
   toolbarSlot?: ReactNode;
 }
 
-const buildExtensions = (placeholder: string) => [
+const defaultUploadFn: UploadFn = () =>
+  Promise.reject(new Error('uploadFn が設定されていません'));
+
+const buildExtensions = (
+  placeholder: string,
+  uploadFn: UploadFn,
+  onError: UploadErrorHandler | null
+) => [
   Document,
   Paragraph,
   Text,
@@ -58,7 +70,7 @@ const buildExtensions = (placeholder: string) => [
   HorizontalRule,
   HardBreak,
   Link.configure({ openOnClick: false, autolink: true }),
-  Image.configure({ inline: false, allowBase64: false }),
+  UploadImage.configure({ uploadFn, onError }),
   Placeholder.configure({ placeholder }),
   Typography,
   History,
@@ -78,7 +90,8 @@ export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
     {
       value,
       onChange,
-      onImagePaste,
+      uploadFn,
+      onUploadError,
       placeholder = '本文を入力...',
       disabled = false,
     },
@@ -88,40 +101,42 @@ export const TiptapEditor = forwardRef<TiptapEditorHandle, TiptapEditorProps>(
     // changes (e.g. async load) can be applied without bouncing through onUpdate.
     const internalValueRef = useRef(value);
     const onChangeRef = useRef(onChange);
-    const onImagePasteRef = useRef(onImagePaste);
+    const uploadFnRef = useRef<UploadFn>(uploadFn ?? defaultUploadFn);
+    const onUploadErrorRef = useRef<UploadErrorHandler | undefined>(
+      onUploadError
+    );
 
     useEffect(() => {
       onChangeRef.current = onChange;
     }, [onChange]);
 
     useEffect(() => {
-      onImagePasteRef.current = onImagePaste;
-    }, [onImagePaste]);
+      uploadFnRef.current = uploadFn ?? defaultUploadFn;
+    }, [uploadFn]);
+
+    useEffect(() => {
+      onUploadErrorRef.current = onUploadError;
+    }, [onUploadError]);
+
+    // Stable wrappers so the extension always sees the latest props without
+    // being rebuilt (rebuilding the extension list resets editor state).
+    const stableUploadFn = useRef<UploadFn>((file: File) =>
+      uploadFnRef.current(file)
+    ).current;
+    const stableOnError = useRef<UploadErrorHandler>(
+      (message: string, retry: () => void) => {
+        onUploadErrorRef.current?.(message, retry);
+      }
+    ).current;
 
     const editor = useEditor({
-      extensions: buildExtensions(placeholder),
+      extensions: buildExtensions(placeholder, stableUploadFn, stableOnError),
       content: value,
       editable: !disabled,
       editorProps: {
         attributes: {
           class:
             'prose prose-sm max-w-none focus:outline-none min-h-[360px] px-3 py-2 font-sans text-sm',
-        },
-        handlePaste: (_view, event) => {
-          if (!onImagePasteRef.current) return false;
-          const items = event.clipboardData?.items;
-          if (!items) return false;
-          for (const item of Array.from(items)) {
-            if (item.type.startsWith('image/')) {
-              const file = item.getAsFile();
-              if (file) {
-                event.preventDefault();
-                void onImagePasteRef.current(file);
-                return true;
-              }
-            }
-          }
-          return false;
         },
       },
       onUpdate: ({ editor }) => {

--- a/frontend/admin/src/components/editor/TiptapToolbar.tsx
+++ b/frontend/admin/src/components/editor/TiptapToolbar.tsx
@@ -1,5 +1,6 @@
 import type { Editor } from '@tiptap/core';
-import { useCallback } from 'react';
+import { useCallback, useRef, type ChangeEvent } from 'react';
+import { ALLOWED_IMAGE_MIME_TYPES } from '../../utils/imageValidation';
 
 interface TiptapToolbarProps {
   editor: Editor | null;
@@ -47,6 +48,8 @@ export function TiptapToolbar({
   editor,
   disabled = false,
 }: TiptapToolbarProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
   const handleSetLink = useCallback(() => {
     if (!editor) return;
     const previousUrl = editor.getAttributes('link').href as string | undefined;
@@ -58,6 +61,25 @@ export function TiptapToolbar({
     }
     editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
   }, [editor]);
+
+  const handleImageButtonClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileInputChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (!files || !editor) {
+        e.target.value = '';
+        return;
+      }
+      for (const file of Array.from(files)) {
+        editor.commands.uploadImage(file);
+      }
+      e.target.value = '';
+    },
+    [editor]
+  );
 
   if (!editor) {
     return (
@@ -206,6 +228,22 @@ export function TiptapToolbar({
       >
         🔗
       </ToolbarButton>
+      <ToolbarButton
+        onClick={handleImageButtonClick}
+        disabled={isDisabled}
+        testId="toolbar-image-button"
+        ariaLabel="画像を挿入"
+      >
+        🖼
+      </ToolbarButton>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ALLOWED_IMAGE_MIME_TYPES.join(',')}
+        className="hidden"
+        data-testid="toolbar-image-input"
+        onChange={handleFileInputChange}
+      />
       <span className="w-px h-5 bg-gray-300 mx-1" aria-hidden />
       <ToolbarButton
         onClick={() => editor.chain().focus().undo().run()}

--- a/frontend/admin/src/components/editor/UploadImageNodeView.tsx
+++ b/frontend/admin/src/components/editor/UploadImageNodeView.tsx
@@ -1,0 +1,36 @@
+import type { NodeViewProps } from '@tiptap/react';
+import { NodeViewWrapper } from '@tiptap/react';
+
+export function UploadImageNodeView({ node }: NodeViewProps) {
+  const src = node.attrs.src as string | null;
+  const alt = (node.attrs.alt as string | null) ?? '';
+  const title = (node.attrs.title as string | null) ?? undefined;
+  const uploading = node.attrs.uploading === true;
+  const uploadId = (node.attrs.uploadId as string | null) ?? undefined;
+
+  return (
+    <NodeViewWrapper
+      as="figure"
+      className="relative inline-block my-2"
+      data-upload-id={uploadId}
+      data-uploading={uploading ? 'true' : undefined}
+    >
+      {src ? (
+        <img
+          src={src}
+          alt={alt}
+          title={title}
+          className={uploading ? 'opacity-50 max-w-full' : 'max-w-full'}
+        />
+      ) : null}
+      {uploading ? (
+        <div
+          data-testid="image-upload-spinner"
+          className="absolute inset-0 flex items-center justify-center pointer-events-none"
+        >
+          <span className="block w-6 h-6 rounded-full border-2 border-blue-500 border-t-transparent animate-spin" />
+        </div>
+      ) : null}
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/admin/src/components/editor/extensions/UploadImage.ts
+++ b/frontend/admin/src/components/editor/extensions/UploadImage.ts
@@ -1,0 +1,251 @@
+import type { Editor } from '@tiptap/core';
+import { Image } from '@tiptap/extension-image';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import { Plugin, TextSelection } from '@tiptap/pm/state';
+import { UploadImageNodeView } from '../UploadImageNodeView';
+import {
+  validateImageFile,
+  type ImageValidationResult,
+} from '../../../utils/imageValidation';
+
+export type UploadFn = (file: File) => Promise<string>;
+export type UploadErrorHandler = (message: string, retry: () => void) => void;
+
+export interface UploadImageOptions {
+  inline: boolean;
+  allowBase64: boolean;
+  HTMLAttributes: Record<string, unknown>;
+  uploadFn: UploadFn;
+  onError: UploadErrorHandler | null;
+  validate: (file: File) => ImageValidationResult;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    uploadImage: {
+      uploadImage: (file: File) => ReturnType;
+    };
+  }
+}
+
+const newUploadId = (): string => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      /* ignore (crypto.randomUUID is restricted to secure contexts) */
+    }
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+};
+
+const findImageByUploadId = (
+  editor: Editor,
+  uploadId: string
+): { pos: number; size: number } | null => {
+  let found: { pos: number; size: number } | null = null;
+  editor.state.doc.descendants((node, pos) => {
+    if (found) return false;
+    if (node.type.name === 'image' && node.attrs.uploadId === uploadId) {
+      found = { pos, size: node.nodeSize };
+      return false;
+    }
+    return true;
+  });
+  return found;
+};
+
+const replaceImageAttrs = (
+  editor: Editor,
+  uploadId: string,
+  attrs: Record<string, unknown>
+): boolean => {
+  if (editor.isDestroyed) return false;
+  const target = findImageByUploadId(editor, uploadId);
+  if (!target) return false;
+  const { state, view } = editor;
+  const node = state.doc.nodeAt(target.pos);
+  if (!node) return false;
+  const tr = state.tr.setNodeMarkup(target.pos, undefined, {
+    ...node.attrs,
+    ...attrs,
+  });
+  view.dispatch(tr);
+  return true;
+};
+
+const removeImageNode = (editor: Editor, uploadId: string): boolean => {
+  if (editor.isDestroyed) return false;
+  const target = findImageByUploadId(editor, uploadId);
+  if (!target) return false;
+  const tr = editor.state.tr.delete(target.pos, target.pos + target.size);
+  editor.view.dispatch(tr);
+  return true;
+};
+
+const startUpload = (
+  editor: Editor,
+  options: UploadImageOptions,
+  file: File
+): void => {
+  const validation = options.validate(file);
+  if (!validation.ok) {
+    options.onError?.(validation.reason, () =>
+      startUpload(editor, options, file)
+    );
+    return;
+  }
+
+  const uploadId = newUploadId();
+  const blobUrl = URL.createObjectURL(file);
+
+  editor
+    .chain()
+    .focus()
+    .insertContent({
+      type: 'image',
+      attrs: {
+        src: blobUrl,
+        alt: file.name,
+        uploading: true,
+        uploadId,
+      },
+    })
+    .run();
+
+  options
+    .uploadFn(file)
+    .then((finalUrl) => {
+      const replaced = replaceImageAttrs(editor, uploadId, {
+        src: finalUrl,
+        uploading: false,
+        uploadId: null,
+      });
+      URL.revokeObjectURL(blobUrl);
+      if (!replaced) {
+        // Node was removed (e.g. user undo) — nothing to update.
+      }
+    })
+    .catch((err: unknown) => {
+      removeImageNode(editor, uploadId);
+      URL.revokeObjectURL(blobUrl);
+      const message =
+        err instanceof Error && err.message
+          ? `画像のアップロードに失敗しました: ${err.message}`
+          : '画像のアップロードに失敗しました';
+      options.onError?.(message, () => startUpload(editor, options, file));
+    });
+};
+
+const extractImageFiles = (transfer: DataTransfer | null): File[] => {
+  if (!transfer) return [];
+  const files: File[] = [];
+  if (transfer.items && transfer.items.length > 0) {
+    for (const item of Array.from(transfer.items)) {
+      if (item.kind === 'file' && item.type.startsWith('image/')) {
+        const f = item.getAsFile();
+        if (f) files.push(f);
+      }
+    }
+  }
+  if (files.length === 0 && transfer.files && transfer.files.length > 0) {
+    for (const f of Array.from(transfer.files)) {
+      if (f.type.startsWith('image/')) files.push(f);
+    }
+  }
+  return files;
+};
+
+export const UploadImage = Image.extend<UploadImageOptions>({
+  name: 'image',
+
+  addOptions() {
+    const parent = this.parent?.() as Partial<UploadImageOptions> | undefined;
+    return {
+      inline: false,
+      allowBase64: false,
+      HTMLAttributes: {},
+      ...(parent ?? {}),
+      uploadFn: async () => {
+        throw new Error('UploadImage: uploadFn is not configured');
+      },
+      onError: null,
+      validate: validateImageFile,
+    };
+  },
+
+  addAttributes() {
+    const parent = this.parent?.();
+    return {
+      ...(parent ?? {}),
+      uploading: {
+        default: false,
+        rendered: false,
+      },
+      uploadId: {
+        default: null,
+        rendered: false,
+      },
+    };
+  },
+
+  addCommands() {
+    return {
+      uploadImage:
+        (file: File) =>
+        ({ editor }) => {
+          // Defer the actual insertion to the next microtask so we do not
+          // collide with the wrapping CommandManager transaction. Inserting
+          // a node inside the command body can leave CommandManager holding
+          // a stale tr (built from the pre-insert state), which then throws
+          // "Applying a mismatched transaction" on dispatch.
+          queueMicrotask(() => startUpload(editor, this.options, file));
+          return true;
+        },
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(UploadImageNodeView);
+  },
+
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+    const options = this.options;
+    return [
+      new Plugin({
+        props: {
+          handlePaste(_view, event) {
+            const clipboardEvent = event as ClipboardEvent;
+            const files = extractImageFiles(
+              clipboardEvent.clipboardData ?? null
+            );
+            if (files.length === 0) return false;
+            event.preventDefault();
+            for (const f of files) startUpload(editor, options, f);
+            return true;
+          },
+          handleDrop(view, event, _slice, moved) {
+            if (moved) return false;
+            const dragEvent = event as DragEvent;
+            const files = extractImageFiles(dragEvent.dataTransfer ?? null);
+            if (files.length === 0) return false;
+            event.preventDefault();
+
+            const coords = view.posAtCoords({
+              left: dragEvent.clientX,
+              top: dragEvent.clientY,
+            });
+            if (coords) {
+              const $pos = view.state.doc.resolve(coords.pos);
+              const tr = view.state.tr.setSelection(TextSelection.near($pos));
+              view.dispatch(tr);
+            }
+            for (const f of files) startUpload(editor, options, f);
+            return true;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/frontend/admin/src/pages/PostCreatePage.test.tsx
+++ b/frontend/admin/src/pages/PostCreatePage.test.tsx
@@ -109,7 +109,7 @@ describe('PostCreatePage', () => {
     expect(screen.getByText('New Article')).toBeInTheDocument();
   });
 
-  it('画像アップロードセクションが表示される', () => {
+  it('ツールバーに画像挿入ボタンが表示される', () => {
     render(
       <BrowserRouter>
         <AuthProvider>
@@ -118,8 +118,8 @@ describe('PostCreatePage', () => {
       </BrowserRouter>
     );
 
-    expect(screen.getByText('画像アップロード')).toBeInTheDocument();
-    expect(screen.getByLabelText(/画像を選択/i)).toBeInTheDocument();
+    expect(screen.getByTestId('toolbar-image-button')).toBeInTheDocument();
+    expect(screen.queryByText('画像アップロード')).not.toBeInTheDocument();
   });
 
   it('記事エディタコンポーネントが表示される', () => {
@@ -256,10 +256,8 @@ describe('PostCreatePage', () => {
     expect(postsApi.createPost).not.toHaveBeenCalled();
   });
 
-  // 画像アップロード統合
-  it('画像アップロード成功時にエディタに image ノードが挿入される', async () => {
-    const user = userEvent.setup();
-
+  // 画像アップロード統合 (Tiptap UploadImage 拡張経由)
+  it('ツールバー経由でアップロードした画像が markdown に反映される', async () => {
     vi.mocked(postsApi.uploadImage).mockResolvedValue(
       'https://example.com/image.png'
     );
@@ -272,84 +270,20 @@ describe('PostCreatePage', () => {
       </BrowserRouter>
     );
 
-    const file = new File(['dummy content'], 'test-image.png', {
-      type: 'image/png',
-    });
-    const input = screen.getByLabelText(/画像を選択/i) as HTMLInputElement;
+    const file = new File(['dummy'], 'test-image.png', { type: 'image/png' });
+    const input = screen.getByTestId('toolbar-image-input') as HTMLInputElement;
 
-    Object.defineProperty(input, 'files', {
-      value: [file],
-      writable: false,
-    });
-    input.dispatchEvent(new Event('change', { bubbles: true }));
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /アップロード/i })
-      ).toBeInTheDocument();
-    });
-
-    const uploadButton = screen.getByRole('button', { name: /アップロード/i });
-    await user.click(uploadButton);
+    fireEvent.change(input, { target: { files: [file] } });
 
     await waitFor(() => {
       expect(postsApi.uploadImage).toHaveBeenCalledWith(file);
     });
 
-    // エディタに画像ノードが挿入されていることを markdown 出力で確認
     await waitFor(async () => {
       const editor = await waitForTiptap();
       const md = editor.storage.markdown.getMarkdown() as string;
       expect(md).toContain('https://example.com/image.png');
     });
-  });
-
-  it('画像アップロード後もエディタは操作可能', async () => {
-    const user = userEvent.setup();
-
-    vi.mocked(postsApi.uploadImage).mockResolvedValue(
-      'https://example.com/image.png'
-    );
-
-    render(
-      <BrowserRouter>
-        <AuthProvider>
-          <PostCreatePage />
-        </AuthProvider>
-      </BrowserRouter>
-    );
-
-    const file = new File(['dummy content'], 'test-image.png', {
-      type: 'image/png',
-    });
-    const input = screen.getByLabelText(/画像を選択/i) as HTMLInputElement;
-
-    Object.defineProperty(input, 'files', {
-      value: [file],
-      writable: false,
-    });
-    input.dispatchEvent(new Event('change', { bubbles: true }));
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /アップロード/i })
-      ).toBeInTheDocument();
-    });
-
-    const uploadButton = screen.getByRole('button', { name: /アップロード/i });
-    await user.click(uploadButton);
-
-    await waitFor(async () => {
-      expect(postsApi.uploadImage).toHaveBeenCalled();
-      const editor = await waitForTiptap();
-      const md = editor.storage.markdown.getMarkdown() as string;
-      expect(md).toContain('https://example.com/image.png');
-    });
-
-    // タイトル入力欄は引き続き操作可能 (アップロード時に焦点を奪われない)
-    const titleInput = screen.getByLabelText<HTMLInputElement>(/タイトル/i);
-    fireEvent.change(titleInput, { target: { value: 'タイトル' } });
-    expect(titleInput.value).toBe('タイトル');
   });
 
   // バリデーション

--- a/frontend/admin/src/pages/PostCreatePage.tsx
+++ b/frontend/admin/src/pages/PostCreatePage.tsx
@@ -1,17 +1,14 @@
 import { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PostEditor, type PostEditorHandle } from '../components/PostEditor';
-import { ImageUploader } from '../components/ImageUploader';
 import MindmapPickerModal from '../components/MindmapPickerModal';
-import { createPost, uploadImage, deleteImage } from '../api/posts';
+import { createPost } from '../api/posts';
 import AdminLayout from '../components/AdminLayout';
 import { useCategories } from '../hooks/useCategories';
 
 const PostCreatePage = () => {
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
-  const [isUploading, setIsUploading] = useState(false);
-  const [uploadedImages, setUploadedImages] = useState<string[]>([]);
   const [isMindmapPickerOpen, setIsMindmapPickerOpen] = useState(false);
   const editorRef = useRef<PostEditorHandle>(null);
 
@@ -45,47 +42,11 @@ const PostCreatePage = () => {
     navigate('/posts');
   };
 
-  // ImageUploaderからの画像アップロード完了時
-  const handleImageUpload = (imageUrl: string) => {
-    setUploadedImages((prev) => [...prev, imageUrl]);
-    const markdownImage = `![image](${imageUrl})`;
-    editorRef.current?.insertAtCursor(markdownImage);
-  };
-
-  // 画像削除ハンドラー
-  const handleImageDelete = async (imageUrl: string) => {
-    try {
-      await deleteImage(imageUrl);
-      setUploadedImages((prev) => prev.filter((url) => url !== imageUrl));
-      // エディタからも画像タグを削除
-      editorRef.current?.removeImageUrl(imageUrl);
-    } catch (err) {
-      console.error('画像削除エラー:', err);
-      setError('画像の削除に失敗しました');
-    }
-  };
-
   // マインドマップ選択ハンドラー
   const handleMindmapSelect = (mindmapId: string) => {
     const marker = `\n{{mindmap:${mindmapId}}}\n`;
     editorRef.current?.insertAtCursor(marker);
     setIsMindmapPickerOpen(false);
-  };
-
-  // ペーストによる画像アップロード
-  const handleImagePaste = async (file: File) => {
-    setIsUploading(true);
-    try {
-      const imageUrl = await uploadImage(file);
-      setUploadedImages((prev) => [...prev, imageUrl]);
-      const markdownImage = `![image](${imageUrl})`;
-      editorRef.current?.insertAtCursor(markdownImage);
-    } catch (err) {
-      console.error('Image paste upload failed:', err);
-      setError('画像のアップロードに失敗しました');
-    } finally {
-      setIsUploading(false);
-    }
   };
 
   return (
@@ -100,22 +61,10 @@ const PostCreatePage = () => {
       )}
 
       <div className="admin-card">
-        <h2 className="admin-card-title">画像アップロード</h2>
-        <ImageUploader
-          onUploadComplete={handleImageUpload}
-          uploadFunction={uploadImage}
-          uploadedImages={uploadedImages}
-          onDelete={handleImageDelete}
-        />
-      </div>
-
-      <div className="admin-card">
         <PostEditor
           ref={editorRef}
           onSave={handleSave}
           onCancel={handleCancel}
-          onImagePaste={handleImagePaste}
-          isUploading={isUploading}
           categories={categories}
           categoriesLoading={categoriesLoading}
           categoriesError={categoriesError}

--- a/frontend/admin/src/pages/PostEditPage.test.tsx
+++ b/frontend/admin/src/pages/PostEditPage.test.tsx
@@ -83,27 +83,8 @@ vi.mock('../components/PostEditor', () => ({
     </div>
   ),
 }));
-vi.mock('../components/ImageUploader', () => ({
-  ImageUploader: ({ onUploadComplete, onDelete }: any) => (
-    <div data-testid="image-uploader">
-      <button onClick={() => onUploadComplete('https://example.com/image.jpg')}>
-        Upload Image
-      </button>
-      {onDelete && (
-        <button
-          data-testid="mock-delete-image-button"
-          onClick={() => onDelete('https://example.com/image.jpg')}
-        >
-          Delete Image
-        </button>
-      )}
-    </div>
-  ),
-}));
-
 const mockGetPost = postsApi.getPost as ReturnType<typeof vi.fn>;
 const mockUpdatePost = postsApi.updatePost as ReturnType<typeof vi.fn>;
-const mockDeleteImage = postsApi.deleteImage as ReturnType<typeof vi.fn>;
 
 // MemoryRouter版のヘルパー
 const renderWithRouter = (postId: string = '1') => {
@@ -198,31 +179,6 @@ describe('PostEditPage', () => {
         expect(
           screen.getByRole('heading', { name: /記事編集/i })
         ).toBeInTheDocument();
-      });
-    });
-
-    it('画像アップロードセクションを表示する', async () => {
-      const mockPost = {
-        id: '1',
-        title: 'Test Post',
-        contentMarkdown: 'Test content',
-        contentHtml: '<p>Test content</p>',
-        category: 'tech',
-        tags: [],
-        publishStatus: 'draft' as const,
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      mockGetPost.mockResolvedValue(mockPost);
-
-      renderWithRouter('1');
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole('heading', { name: /画像アップロード/i })
-        ).toBeInTheDocument();
-        expect(screen.getByTestId('image-uploader')).toBeInTheDocument();
       });
     });
   });
@@ -330,61 +286,6 @@ describe('PostEditPage', () => {
     });
   });
 
-  describe('画像アップロード機能', () => {
-    it('画像アップロード成功時にエラーなくhandleImageUploadが呼ばれる', async () => {
-      const mockPost = {
-        id: '1',
-        title: 'Test Post',
-        contentMarkdown: 'Test content',
-        contentHtml: '<p>Test content</p>',
-        category: 'tech',
-        tags: [],
-        publishStatus: 'draft' as const,
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      mockGetPost.mockResolvedValue(mockPost);
-
-      renderWithRouter('1');
-
-      await waitFor(() => {
-        expect(screen.getByTestId('image-uploader')).toBeInTheDocument();
-      });
-
-      const uploadButton = screen.getByRole('button', {
-        name: /Upload Image/i,
-      });
-
-      // エラーなくクリックできることを確認
-      expect(() => {
-        fireEvent.click(uploadButton);
-      }).not.toThrow();
-    });
-
-    it('ImageUploaderにuploadImage関数を渡す', async () => {
-      const mockPost = {
-        id: '1',
-        title: 'Test Post',
-        contentMarkdown: 'Test content',
-        contentHtml: '<p>Test content</p>',
-        category: 'tech',
-        tags: [],
-        publishStatus: 'draft' as const,
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      mockGetPost.mockResolvedValue(mockPost);
-
-      renderWithRouter('1');
-
-      await waitFor(() => {
-        expect(screen.getByTestId('image-uploader')).toBeInTheDocument();
-      });
-    });
-  });
-
   describe('エラーハンドリング', () => {
     it('記事IDが指定されていない場合エラーを表示する', async () => {
       const { MemoryRouter } = require('react-router-dom');
@@ -446,38 +347,6 @@ describe('PostEditPage', () => {
       await waitFor(() => {
         expect(
           screen.getByText(/記事の更新に失敗しました/i)
-        ).toBeInTheDocument();
-      });
-    });
-
-    it('画像削除に失敗した場合エラーメッセージを表示する', async () => {
-      const mockPost = {
-        id: '1',
-        title: 'Test Post',
-        contentMarkdown: 'Test content',
-        contentHtml: '<p>Test content</p>',
-        category: 'tech',
-        tags: [],
-        publishStatus: 'draft' as const,
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      mockGetPost.mockResolvedValue(mockPost);
-      mockDeleteImage.mockRejectedValue(new Error('Delete failed'));
-
-      renderWithRouter('1');
-
-      await waitFor(() => {
-        expect(screen.getByTestId('image-uploader')).toBeInTheDocument();
-      });
-
-      const deleteButton = screen.getByTestId('mock-delete-image-button');
-      fireEvent.click(deleteButton);
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(/画像の削除に失敗しました/i)
         ).toBeInTheDocument();
       });
     });

--- a/frontend/admin/src/pages/PostEditPage.tsx
+++ b/frontend/admin/src/pages/PostEditPage.tsx
@@ -5,9 +5,8 @@ import {
   type PostData,
   type PostEditorHandle,
 } from '../components/PostEditor';
-import { ImageUploader } from '../components/ImageUploader';
 import MindmapPickerModal from '../components/MindmapPickerModal';
-import { getPost, updatePost, uploadImage, deleteImage } from '../api/posts';
+import { getPost, updatePost } from '../api/posts';
 import AdminLayout from '../components/AdminLayout';
 import { PostEditSkeleton } from '../components/skeleton';
 import { useCategories } from '../hooks/useCategories';
@@ -18,8 +17,6 @@ const PostEditPage = () => {
   const [initialData, setInitialData] = useState<PostData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [isUploading, setIsUploading] = useState(false);
-  const [uploadedImages, setUploadedImages] = useState<string[]>([]);
   const [isMindmapPickerOpen, setIsMindmapPickerOpen] = useState(false);
   const editorRef = useRef<PostEditorHandle>(null);
 
@@ -77,47 +74,11 @@ const PostEditPage = () => {
     navigate('/posts');
   };
 
-  // ImageUploaderからの画像アップロード完了時
-  const handleImageUpload = (imageUrl: string) => {
-    setUploadedImages((prev) => [...prev, imageUrl]);
-    const markdownImage = `![image](${imageUrl})`;
-    editorRef.current?.insertAtCursor(markdownImage);
-  };
-
-  // 画像削除ハンドラー
-  const handleImageDelete = async (imageUrl: string) => {
-    try {
-      await deleteImage(imageUrl);
-      setUploadedImages((prev) => prev.filter((url) => url !== imageUrl));
-      // エディタからも画像タグを削除
-      editorRef.current?.removeImageUrl(imageUrl);
-    } catch (err) {
-      console.error('画像削除エラー:', err);
-      setError('画像の削除に失敗しました');
-    }
-  };
-
   // マインドマップ選択ハンドラー
   const handleMindmapSelect = (mindmapId: string) => {
     const marker = `\n{{mindmap:${mindmapId}}}\n`;
     editorRef.current?.insertAtCursor(marker);
     setIsMindmapPickerOpen(false);
-  };
-
-  // ペーストによる画像アップロード
-  const handleImagePaste = async (file: File) => {
-    setIsUploading(true);
-    try {
-      const imageUrl = await uploadImage(file);
-      setUploadedImages((prev) => [...prev, imageUrl]);
-      const markdownImage = `![image](${imageUrl})`;
-      editorRef.current?.insertAtCursor(markdownImage);
-    } catch (err) {
-      console.error('Image paste upload failed:', err);
-      setError('画像のアップロードに失敗しました');
-    } finally {
-      setIsUploading(false);
-    }
   };
 
   if (loading) {
@@ -141,16 +102,6 @@ const PostEditPage = () => {
       {error && <div className="admin-alert admin-alert-error">{error}</div>}
 
       <div className="admin-card">
-        <h2 className="admin-card-title">画像アップロード</h2>
-        <ImageUploader
-          onUploadComplete={handleImageUpload}
-          uploadFunction={uploadImage}
-          uploadedImages={uploadedImages}
-          onDelete={handleImageDelete}
-        />
-      </div>
-
-      <div className="admin-card">
         {initialData && (
           <PostEditor
             key={id}
@@ -158,8 +109,6 @@ const PostEditPage = () => {
             onSave={handleSave}
             onCancel={handleCancel}
             initialData={initialData}
-            onImagePaste={handleImagePaste}
-            isUploading={isUploading}
             categories={categories}
             categoriesLoading={categoriesLoading}
             categoriesError={categoriesError}

--- a/frontend/admin/src/test/setup.ts
+++ b/frontend/admin/src/test/setup.ts
@@ -33,6 +33,18 @@ if (typeof document !== 'undefined' && !document.elementFromPoint) {
   document.elementFromPoint = () => null;
 }
 
+// jsdom does not implement URL.createObjectURL / revokeObjectURL,
+// which the UploadImage Tiptap extension uses for placeholder previews.
+if (typeof URL !== 'undefined') {
+  if (typeof URL.createObjectURL !== 'function') {
+    URL.createObjectURL = () =>
+      'blob:mock-' + Math.random().toString(36).slice(2);
+  }
+  if (typeof URL.revokeObjectURL !== 'function') {
+    URL.revokeObjectURL = () => {};
+  }
+}
+
 afterEach(() => {
   cleanup();
 });

--- a/frontend/admin/src/utils/imageValidation.test.ts
+++ b/frontend/admin/src/utils/imageValidation.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALLOWED_IMAGE_MIME_TYPES,
+  MAX_IMAGE_BYTES,
+  validateImageFile,
+} from './imageValidation';
+
+const makeFile = (size: number, type: string, name = 'test.bin'): File => {
+  const buf = new Uint8Array(size);
+  return new File([buf], name, { type });
+};
+
+describe('validateImageFile', () => {
+  it.each(ALLOWED_IMAGE_MIME_TYPES)('accepts %s', (type) => {
+    const result = validateImageFile(makeFile(1024, type));
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts a file at exactly 5MB', () => {
+    const result = validateImageFile(makeFile(MAX_IMAGE_BYTES, 'image/png'));
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a file that exceeds 5MB by 1 byte', () => {
+    const result = validateImageFile(
+      makeFile(MAX_IMAGE_BYTES + 1, 'image/png')
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/5MB/);
+  });
+
+  it('rejects image/svg+xml as not whitelisted', () => {
+    const result = validateImageFile(makeFile(100, 'image/svg+xml'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/対応していない/);
+  });
+
+  it('rejects non-image MIME types', () => {
+    const result = validateImageFile(makeFile(100, 'application/pdf'));
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects empty MIME type', () => {
+    const result = validateImageFile(makeFile(100, ''));
+    expect(result.ok).toBe(false);
+  });
+});

--- a/frontend/admin/src/utils/imageValidation.ts
+++ b/frontend/admin/src/utils/imageValidation.ts
@@ -1,0 +1,35 @@
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+export const ALLOWED_IMAGE_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+] as const;
+
+const ALLOWED = new Set<string>(ALLOWED_IMAGE_MIME_TYPES);
+
+export interface ImageValidationOk {
+  ok: true;
+}
+export interface ImageValidationErr {
+  ok: false;
+  reason: string;
+}
+export type ImageValidationResult = ImageValidationOk | ImageValidationErr;
+
+export function validateImageFile(file: File): ImageValidationResult {
+  if (!ALLOWED.has(file.type)) {
+    return {
+      ok: false,
+      reason: '対応していない画像形式です（JPEG / PNG / GIF / WebP のみ対応）',
+    };
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return {
+      ok: false,
+      reason: 'ファイルサイズは 5MB 以下にしてください',
+    };
+  }
+  return { ok: true };
+}

--- a/tests/e2e/mocks/handlers.ts
+++ b/tests/e2e/mocks/handlers.ts
@@ -312,7 +312,7 @@ export const handlers = [
   }),
 
   // 管理画面: 画像アップロードURL取得
-  http.post(`${API_BASE_URL}/images/upload-url`, async ({ request }) => {
+  http.post(`${API_BASE_URL}/admin/images/upload-url`, async ({ request }) => {
     // 認証チェック
     if (!checkAuth(request)) {
       return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
@@ -324,11 +324,29 @@ export const handlers = [
       fileSize?: number;
     };
 
+    // E2E 失敗系テスト用: ファイル名 prefix で 500 を強制する。
+    // (page.route は SW intercept を上書きできないため、MSW 側で発火する)
+    if (body.fileName.startsWith('__force_500__')) {
+      return HttpResponse.json(
+        { message: 'forced internal server error (test fixture)' },
+        { status: 500 }
+      );
+    }
+
+    // MSW SW は cross-origin (amazonaws.com など) を intercept できないため、
+    // E2E では同 origin の擬似 S3 パスを返す。実環境の挙動とは異なるが、
+    // フロントエンド側の挙動 (URL を受け取って PUT する) は同等に検証できる。
+    // 注: バックエンドは "url" フィールドで最終 URL を返す (posts.ts getUploadUrl 参照)。
     return HttpResponse.json({
-      uploadUrl: `https://mock-s3-bucket.s3.amazonaws.com/images/${body.fileName}?mock-signed-url`,
-      imageUrl: `https://mock-cdn.cloudfront.net/images/${body.fileName}`,
+      uploadUrl: `${API_BASE_URL}/_mock_s3_put/${body.fileName}`,
+      url: `https://mock-cdn.cloudfront.net/images/${body.fileName}`,
       expiresIn: 900,
     });
+  }),
+
+  // 管理画面: 同 origin S3 PUT スタブ
+  http.put(`${API_BASE_URL}/_mock_s3_put/:filename`, () => {
+    return new HttpResponse(null, { status: 200 });
   }),
 
   // 記事作成（認証必須）- `/api/posts` POST

--- a/tests/e2e/specs/admin-image-drag.spec.ts
+++ b/tests/e2e/specs/admin-image-drag.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '../fixtures';
+import { resetMockPosts } from '../mocks/mockData';
+import {
+  getTiptapEditor,
+  getEditorMarkdown,
+  dropImage,
+} from '../utils/tiptapHelpers';
+import { fixtureJpeg } from '../utils/imageFixtures';
+
+/**
+ * Admin Tiptap Editor — Image Drag & Drop
+ *
+ * ファイルドラッグ&ドロップで UploadImage が起動し、
+ * 最終 URL が markdown に挿入されることを確認する。
+ */
+
+test.describe('Admin Tiptap Editor - image drop', () => {
+  const testCredentials = {
+    email: process.env.TEST_ADMIN_EMAIL || 'admin@example.com',
+    password: process.env.TEST_ADMIN_PASSWORD || 'testpassword',
+  };
+
+  // MSW のデフォルト upload-url ハンドラが返す imageUrl 形式
+  const FINAL_IMAGE_URL =
+    'https://mock-cdn.cloudfront.net/images/drop-test.jpg';
+
+  test.beforeEach(async ({ adminLoginPage, page }) => {
+    resetMockPosts();
+    await adminLoginPage.navigate();
+    await adminLoginPage.clearCredentials();
+    await adminLoginPage.login(testCredentials.email, testCredentials.password);
+
+    await page.route(/mock-s3-bucket\.s3\.amazonaws\.com/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'access-control-allow-origin': '*',
+          'access-control-allow-methods': 'PUT, OPTIONS',
+          'access-control-allow-headers': '*',
+        },
+        body: '',
+      });
+    });
+  });
+
+  test('画像をドロップすると UploadImage が S3 PUT を経て最終 URL を markdown に挿入する', async ({
+    page,
+  }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    await dropImage(page, fixtureJpeg({ name: 'drop-test.jpg' }));
+
+    await expect
+      .poll(async () => getEditorMarkdown(page), { timeout: 5000 })
+      .toContain(FINAL_IMAGE_URL);
+
+    await expect(page.getByTestId('image-upload-error')).toHaveCount(0);
+    await expect(page.getByTestId('image-upload-spinner')).toHaveCount(0);
+  });
+});

--- a/tests/e2e/specs/admin-image-drag.spec.ts
+++ b/tests/e2e/specs/admin-image-drag.spec.ts
@@ -24,23 +24,12 @@ test.describe('Admin Tiptap Editor - image drop', () => {
   const FINAL_IMAGE_URL =
     'https://mock-cdn.cloudfront.net/images/drop-test.jpg';
 
-  test.beforeEach(async ({ adminLoginPage, page }) => {
+  test.beforeEach(async ({ adminLoginPage }) => {
     resetMockPosts();
     await adminLoginPage.navigate();
     await adminLoginPage.clearCredentials();
     await adminLoginPage.login(testCredentials.email, testCredentials.password);
-
-    await page.route(/mock-s3-bucket\.s3\.amazonaws\.com/, async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          'access-control-allow-origin': '*',
-          'access-control-allow-methods': 'PUT, OPTIONS',
-          'access-control-allow-headers': '*',
-        },
-        body: '',
-      });
-    });
+    // 画像 PUT は MSW handlers.ts の `_mock_s3_put/:filename` ハンドラが処理する。
   });
 
   test('画像をドロップすると UploadImage が S3 PUT を経て最終 URL を markdown に挿入する', async ({

--- a/tests/e2e/specs/admin-image-fail.spec.ts
+++ b/tests/e2e/specs/admin-image-fail.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '../fixtures';
+import { resetMockPosts } from '../mocks/mockData';
+import {
+  getTiptapEditor,
+  getEditorMarkdown,
+  pasteImage,
+} from '../utils/tiptapHelpers';
+import { fixturePng } from '../utils/imageFixtures';
+
+/**
+ * Admin Tiptap Editor — Image Failure & Validation
+ *
+ * - upload-url が 500 を返す場合: プレースホルダが除去され、再試行ボタン付き alert が表示される
+ * - サイズ超過 (>5MB): バリデーションエラーが alert に表示され、アップロードは試行されない
+ */
+
+test.describe('Admin Tiptap Editor - image failure', () => {
+  const testCredentials = {
+    email: process.env.TEST_ADMIN_EMAIL || 'admin@example.com',
+    password: process.env.TEST_ADMIN_PASSWORD || 'testpassword',
+  };
+
+  test.beforeEach(async ({ adminLoginPage }) => {
+    resetMockPosts();
+    await adminLoginPage.navigate();
+    await adminLoginPage.clearCredentials();
+    await adminLoginPage.login(testCredentials.email, testCredentials.password);
+  });
+
+  test('upload-url が 500 を返すとプレースホルダが除去され再試行 alert が表示される', async ({
+    page,
+  }) => {
+    // MSW handler は __force_500__ prefix のファイル名で 500 を返す
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    await pasteImage(page, fixturePng({ name: '__force_500__paste.png' }));
+
+    const alert = page.getByTestId('image-upload-error');
+    await expect(alert).toBeVisible({ timeout: 5000 });
+    await expect(alert).toContainText('画像のアップロードに失敗しました');
+    await expect(page.getByTestId('image-upload-retry')).toBeVisible();
+
+    // プレースホルダ画像 (blob: URL) も最終 URL も入っていない
+    await expect
+      .poll(async () => getEditorMarkdown(page), { timeout: 3000 })
+      .not.toMatch(/!\[[^\]]*\]\(blob:/);
+    // spinner も残っていない
+    await expect(page.getByTestId('image-upload-spinner')).toHaveCount(0);
+  });
+
+  test('5MB を超える画像は validation で拒否されアップロードが行われない', async ({
+    page,
+  }) => {
+    let uploadUrlCalled = 0;
+    page.on('request', (req) => {
+      if (req.url().includes('/admin/images/upload-url')) {
+        uploadUrlCalled += 1;
+      }
+    });
+
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    // 6MB のファイル (5MB cap を超える)
+    await pasteImage(page, fixturePng({ name: 'oversize.png', sizeKB: 6000 }));
+
+    const alert = page.getByTestId('image-upload-error');
+    await expect(alert).toBeVisible({ timeout: 3000 });
+    await expect(alert).toContainText('5MB');
+    expect(uploadUrlCalled).toBe(0);
+    // ノードは挿入されていない
+    await expect(page.getByTestId('image-upload-spinner')).toHaveCount(0);
+  });
+});

--- a/tests/e2e/specs/admin-image-paste.spec.ts
+++ b/tests/e2e/specs/admin-image-paste.spec.ts
@@ -24,25 +24,12 @@ test.describe('Admin Tiptap Editor - image paste', () => {
   const FINAL_IMAGE_URL =
     'https://mock-cdn.cloudfront.net/images/paste-test.png';
 
-  test.beforeEach(async ({ adminLoginPage, page }) => {
+  test.beforeEach(async ({ adminLoginPage }) => {
     resetMockPosts();
     await adminLoginPage.navigate();
     await adminLoginPage.clearCredentials();
     await adminLoginPage.login(testCredentials.email, testCredentials.password);
-
-    // S3 PUT (mock-s3-bucket.s3.amazonaws.com への直送) を同 origin リダイレクトで処理。
-    // CORS preflight 回避のため、CORS 許可ヘッダ付きで 200 を返す。
-    await page.route(/mock-s3-bucket\.s3\.amazonaws\.com/, async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          'access-control-allow-origin': '*',
-          'access-control-allow-methods': 'PUT, OPTIONS',
-          'access-control-allow-headers': '*',
-        },
-        body: '',
-      });
-    });
+    // 画像 PUT は MSW handlers.ts の `_mock_s3_put/:filename` ハンドラが処理する。
   });
 
   test('画像を貼り付けると UploadImage が S3 PUT を経て最終 URL を markdown に挿入する', async ({

--- a/tests/e2e/specs/admin-image-paste.spec.ts
+++ b/tests/e2e/specs/admin-image-paste.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '../fixtures';
+import { resetMockPosts } from '../mocks/mockData';
+import {
+  getTiptapEditor,
+  getEditorMarkdown,
+  pasteImage,
+} from '../utils/tiptapHelpers';
+import { fixturePng } from '../utils/imageFixtures';
+
+/**
+ * Admin Tiptap Editor — Image Paste
+ *
+ * クリップボードペースト経由で画像が UploadImage 拡張に取り込まれ、
+ * S3 PUT 完了後に最終 URL が markdown に反映されることを確認する。
+ */
+
+test.describe('Admin Tiptap Editor - image paste', () => {
+  const testCredentials = {
+    email: process.env.TEST_ADMIN_EMAIL || 'admin@example.com',
+    password: process.env.TEST_ADMIN_PASSWORD || 'testpassword',
+  };
+
+  // MSW のデフォルト upload-url ハンドラが返す imageUrl 形式
+  const FINAL_IMAGE_URL =
+    'https://mock-cdn.cloudfront.net/images/paste-test.png';
+
+  test.beforeEach(async ({ adminLoginPage, page }) => {
+    resetMockPosts();
+    await adminLoginPage.navigate();
+    await adminLoginPage.clearCredentials();
+    await adminLoginPage.login(testCredentials.email, testCredentials.password);
+
+    // S3 PUT (mock-s3-bucket.s3.amazonaws.com への直送) を同 origin リダイレクトで処理。
+    // CORS preflight 回避のため、CORS 許可ヘッダ付きで 200 を返す。
+    await page.route(/mock-s3-bucket\.s3\.amazonaws\.com/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'access-control-allow-origin': '*',
+          'access-control-allow-methods': 'PUT, OPTIONS',
+          'access-control-allow-headers': '*',
+        },
+        body: '',
+      });
+    });
+  });
+
+  test('画像を貼り付けると UploadImage が S3 PUT を経て最終 URL を markdown に挿入する', async ({
+    page,
+  }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    await pasteImage(page, fixturePng({ name: 'paste-test.png' }));
+
+    // 最終 URL が markdown に出るまで待つ
+    await expect
+      .poll(async () => getEditorMarkdown(page), { timeout: 5000 })
+      .toContain(FINAL_IMAGE_URL);
+
+    // エラー alert は出ていない
+    await expect(page.getByTestId('image-upload-error')).toHaveCount(0);
+    // アップロード完了後に spinner が残っていない
+    await expect(page.getByTestId('image-upload-spinner')).toHaveCount(0);
+  });
+});

--- a/tests/e2e/specs/admin-image-toolbar.spec.ts
+++ b/tests/e2e/specs/admin-image-toolbar.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '../fixtures';
+import { resetMockPosts } from '../mocks/mockData';
+import { getTiptapEditor, getEditorMarkdown } from '../utils/tiptapHelpers';
+import { fixturePng } from '../utils/imageFixtures';
+
+/**
+ * Admin Tiptap Editor — Toolbar Image Insert
+ *
+ * ツールバーの画像挿入ボタン → 隠し file input → UploadImage 命令経由で
+ * 最終 URL が markdown に挿入される一連を確認する。
+ */
+
+test.describe('Admin Tiptap Editor - toolbar image button', () => {
+  const testCredentials = {
+    email: process.env.TEST_ADMIN_EMAIL || 'admin@example.com',
+    password: process.env.TEST_ADMIN_PASSWORD || 'testpassword',
+  };
+
+  // MSW のデフォルト upload-url ハンドラが返す imageUrl 形式
+  const FINAL_IMAGE_URL =
+    'https://mock-cdn.cloudfront.net/images/toolbar-test.png';
+
+  test.beforeEach(async ({ adminLoginPage, page }) => {
+    resetMockPosts();
+    await adminLoginPage.navigate();
+    await adminLoginPage.clearCredentials();
+    await adminLoginPage.login(testCredentials.email, testCredentials.password);
+
+    await page.route(/mock-s3-bucket\.s3\.amazonaws\.com/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'access-control-allow-origin': '*',
+          'access-control-allow-methods': 'PUT, OPTIONS',
+          'access-control-allow-headers': '*',
+        },
+        body: '',
+      });
+    });
+  });
+
+  test('ツールバーの画像ボタンから選んだファイルが markdown に挿入される', async ({
+    page,
+  }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    await expect(page.getByTestId('toolbar-image-button')).toBeVisible();
+
+    const png = fixturePng({ name: 'toolbar-test.png' });
+    await page.getByTestId('toolbar-image-input').setInputFiles({
+      name: png.name,
+      mimeType: png.mimeType,
+      buffer: png.buffer,
+    });
+
+    await expect
+      .poll(async () => getEditorMarkdown(page), { timeout: 5000 })
+      .toContain(FINAL_IMAGE_URL);
+
+    await expect(page.getByTestId('image-upload-error')).toHaveCount(0);
+  });
+});

--- a/tests/e2e/specs/admin-image-toolbar.spec.ts
+++ b/tests/e2e/specs/admin-image-toolbar.spec.ts
@@ -20,23 +20,12 @@ test.describe('Admin Tiptap Editor - toolbar image button', () => {
   const FINAL_IMAGE_URL =
     'https://mock-cdn.cloudfront.net/images/toolbar-test.png';
 
-  test.beforeEach(async ({ adminLoginPage, page }) => {
+  test.beforeEach(async ({ adminLoginPage }) => {
     resetMockPosts();
     await adminLoginPage.navigate();
     await adminLoginPage.clearCredentials();
     await adminLoginPage.login(testCredentials.email, testCredentials.password);
-
-    await page.route(/mock-s3-bucket\.s3\.amazonaws\.com/, async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          'access-control-allow-origin': '*',
-          'access-control-allow-methods': 'PUT, OPTIONS',
-          'access-control-allow-headers': '*',
-        },
-        body: '',
-      });
-    });
+    // 画像 PUT は MSW handlers.ts の `_mock_s3_put/:filename` ハンドラが処理する。
   });
 
   test('ツールバーの画像ボタンから選んだファイルが markdown に挿入される', async ({


### PR DESCRIPTION
## Summary

- Replace standalone \`<ImageUploader>\` card flow with a Tiptap-native \`UploadImage\` extension that handles **paste**, **drag-and-drop**, and **toolbar** insertion via a single pipeline.
- Show inline placeholder + spinner while uploading; surface failures with a retry-able alert above the editor.
- Add validation utility (5MB cap, JPEG/PNG/GIF/WebP), 4 new Playwright specs, and Vitest jsdom polyfills for \`URL.createObjectURL\`.

This is **PR4** of the writer-experience refresh series following PR3 (#240). \`<ImageUploader>\` UI is removed in this PR; the file itself will be deleted in PR8 cleanup.

## Key changes

- \`frontend/admin/src/components/editor/extensions/UploadImage.ts\` — new Tiptap extension subclassing \`@tiptap/extension-image\`. Adds \`uploading\` / \`uploadId\` attrs (not serialized), a \`uploadImage(file)\` command, and ProseMirror plugins for paste/drop. Inserts a blob-URL placeholder, then swaps to the final URL on success or removes the node on failure.
- \`frontend/admin/src/components/editor/UploadImageNodeView.tsx\` — React node view rendering a spinner overlay while uploading.
- \`frontend/admin/src/utils/imageValidation.ts\` — \`validateImageFile()\` (5MB / MIME whitelist).
- \`frontend/admin/src/components/editor/TiptapEditor.tsx\` — swap \`Image\` → \`UploadImage\`; drop \`onImagePaste\` prop and \`editorProps.handlePaste\`; add \`uploadFn\` / \`onUploadError\` props with stable refs.
- \`frontend/admin/src/components/editor/TiptapToolbar.tsx\` — add image button + hidden file input.
- \`frontend/admin/src/components/PostEditor.tsx\` — drop \`onImagePaste\` / \`isUploading\` props; add inline error alert with 「再試行」 button (auto-dismiss 8s).
- \`frontend/admin/src/pages/PostCreatePage.tsx\` and \`PostEditPage.tsx\` — remove \`<ImageUploader>\` card and related state/handlers.

### MSW handler fixes (incidental)

\`tests/e2e/mocks/handlers.ts\` had a pre-existing path bug (\`/images/upload-url\` instead of \`/admin/images/upload-url\`) and returned \`imageUrl\` while the frontend reads \`url\`. Fixed both, plus replaced the cross-origin \`mock-s3-bucket.s3.amazonaws.com\` upload URL with a same-origin stub (\`/_mock_s3_put/:filename\`) since MSW SW cannot intercept cross-origin requests. Added a \`__force_500__\` filename trigger so the failure spec can exercise the upload-url 500 path (Playwright \`page.route\` cannot override SW responses).

## Test plan

- [x] \`bun run lint\` — 0 errors
- [x] \`bun run type-check\` — 0 errors
- [x] \`bun run test --run\` — 710 passed / 5 skipped
- [x] \`bun run test:e2e:admin\` — 18 passed (4 new image specs + 14 existing, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)