### PR TITLE
chore(security): align codeql-action SHA across security-scan.yml

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -78,7 +78,7 @@ jobs:
         # Code Scanning API rate limit can fail this step when many Dependabot PRs
         # run concurrently. SARIF visibility is best-effort, so don't fail the job.
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: gitleaks.sarif
           category: gitleaks


### PR DESCRIPTION
## Summary

\`security-scan.yml:81\` pinned \`github/codeql-action/upload-sarif\` to SHA \`7fc6561e…\` with a \`# v4.35.2\` comment, but **that SHA does not exist in the codeql-action repo** (likely a stale paste from a different action). The other 4 invocations (\`security-scan.yml:135 / 142 / 193\` and \`ci.yml:714\`) correctly use the canonical v4.35.2 SHA \`95e58e9a2cdfd71adc6e0353d5c52f41a045d225\`.

GitHub Code Scanning flags this with:
> Not all workflow steps that use \`github/codeql-action\` actions use the same version. Please ensure that all such steps use the same version to avoid compatibility issues.

Aligning all 5 invocations to the canonical SHA clears the warning.

## Test plan

- [x] All 5 codeql-action invocations now pin the same canonical v4.35.2 SHA (verified via grep)
- [ ] CI green; warning disappears from next \`Code Scanning\` summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)