### PR TITLE
fix(lambda): pass real cloudfront domain so upload-url returns resolvable URLs

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -67,7 +67,8 @@ module "storage" {
 #------------------------------------------------------------------------------
 # Module 4: Lambda Functions
 # Dependencies: database, storage, auth
-# Note: cloudfront_domain will be updated after CDN module is created
+# Note: cloudfront_domain uses var.domain_name (static) to avoid a real cycle
+#       lambda -> cdn -> api -> lambda that would form if we used module.cdn output.
 #------------------------------------------------------------------------------
 
 module "lambda" {
@@ -82,9 +83,12 @@ module "lambda" {
   user_pool_id        = module.auth.user_pool_id
   user_pool_arn       = module.auth.user_pool_arn
   user_pool_client_id = module.auth.user_pool_client_id
-  cloudfront_domain   = ""    # Will be updated after CDN creation (see below)
-  enable_xray         = false # X-Ray disabled for dev
-  go_binary_path      = "${path.module}/../../../go-functions/bin"
+  # Custom domain serves /images/* via CloudFront. When the custom domain is
+  # disabled, the Lambda falls back to direct S3 URLs (handled inside the
+  # lambda module by treating an empty value as "no CloudFront domain").
+  cloudfront_domain = var.enable_custom_domain ? var.domain_name : ""
+  enable_xray       = false # X-Ray disabled for dev
+  go_binary_path    = "${path.module}/../../../go-functions/bin"
 
   # Categories domain
   categories_table_name = module.database.categories_table_name

--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -65,7 +65,8 @@ module "storage" {
 #------------------------------------------------------------------------------
 # Module 4: Lambda Functions
 # Dependencies: database, storage, auth
-# Note: cloudfront_domain will be updated after CDN module is created
+# Note: cloudfront_domain uses var.domain_name (static) to avoid a real cycle
+#       lambda -> cdn -> api -> lambda that would form if we used module.cdn output.
 #------------------------------------------------------------------------------
 
 module "lambda" {
@@ -79,7 +80,10 @@ module "lambda" {
   user_pool_id        = module.auth.user_pool_id
   user_pool_arn       = module.auth.user_pool_arn
   user_pool_client_id = module.auth.user_pool_client_id
-  cloudfront_domain   = "" # Will be updated after CDN creation
+  # Custom domain serves /images/* via CloudFront. When the custom domain is
+  # disabled, the Lambda falls back to direct S3 URLs (handled inside the
+  # lambda module by treating an empty value as "no CloudFront domain").
+  cloudfront_domain   = var.enable_custom_domain ? var.domain_name : ""
   cors_allowed_origin = "https://${var.domain_name}"
   enable_xray         = true # X-Ray enabled for prd
   go_binary_path      = "${path.module}/../../../go-functions/bin"

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -21,8 +21,13 @@ locals {
     BUCKET_NAME         = var.bucket_name
     USER_POOL_ID        = var.user_pool_id
     USER_POOL_CLIENT_ID = var.user_pool_client_id
-    CLOUDFRONT_DOMAIN   = "https://${var.cloudfront_domain}"
-    ALLOWED_ORIGIN      = var.cors_allowed_origin
+    # When cloudfront_domain is empty, leave CLOUDFRONT_DOMAIN empty so the
+    # Lambda falls back to direct S3 URLs. Auto-prefixing "https://" with an
+    # empty value would produce "https://" -> the upload-url Lambda would
+    # then return "https:///images/..." (empty hostname) and the browser
+    # could not resolve it.
+    CLOUDFRONT_DOMAIN = var.cloudfront_domain != "" ? "https://${var.cloudfront_domain}" : ""
+    ALLOWED_ORIGIN    = var.cors_allowed_origin
   }
 
   common_tags = merge(var.tags, {


### PR DESCRIPTION
## 症状

dev 環境（\`https://dev.boneofmyfallacy.net/admin/posts\`）で画像アップロード後、エディタに挿入された画像が表示されない。コンソールに「指定されたホスト名のサーバが見つかりませんでした」が出る。

## 原因

\`get_upload_url\` Lambda が画像 URL を \`https:///images/<userId>/<uuid>.jpg\`（**空 hostname**）として返していた。原因は 2 層：

### Layer 1 — environment 設定

\`environments/dev/main.tf\` と \`environments/prd/main.tf\` のどちらも \`cloudfront_domain = ""\` を lambda モジュールに渡していた。コメントには「Will be updated after CDN creation」とあったが、実際には更新箇所が無かった。\`module.cdn.distribution_domain_name\` を使えばよさそうに見えるが、\`lambda → cdn → api → lambda\` の**実際の循環依存**になるため使えない。\`var.domain_name\`（静的）を \`var.enable_custom_domain\` ゲート付きで渡すのが安全。

### Layer 2 — module 内の盲目的な prefix 付与

\`modules/lambda/main.tf:24\` が \`CLOUDFRONT_DOMAIN = "https://\${var.cloudfront_domain}"\` と無条件に \`https://\` を付けていた。空文字を渡されると \`"https://"\` という非空文字列になり、Go handler の \`if cloudFrontDomain != ""\` を通過して \`https:///images/...\` を生成してしまう。空文字なら空文字のまま渡すよう修正。Lambda 側は空文字なら直接 S3 URL にフォールバックする既存実装が活きる。

## 適用後

dev: \`https://dev.boneofmyfallacy.net/images/<userId>/<uuid>.<ext>\` が返り、CloudFront の既存 \`/images/*\` パスリライタ経由で S3 から配信されます。
prd: \`https://boneofmyfallacy.net/images/...\`

## デプロイ影響

- 共有環境への terraform apply が必要（merge → develop CI が \`Terraform Apply (DEV)\` を自動実行）
- 影響範囲は **Lambda 11 関数の \`CLOUDFRONT_DOMAIN\` 環境変数のみ**（コード ZIP は無変更）。in-place update で完了、ダウンタイムなし
- 既存ポストに既に保存されている壊れた画像 URL は（マークダウン本文に焼き込まれているため）この修正だけでは復旧しない — 該当ポストは手動で再アップロードか URL 書き換えが必要

## Test plan

- [x] \`terraform fmt\` 通過
- [x] go-functions の振る舞いは従来どおり（コード変更なし）
- [ ] CI 緑
- [ ] merge 後の dev apply で Lambda env var が \`https://dev.boneofmyfallacy.net\` に変わる
- [ ] dev でアップロードして \`https://dev.boneofmyfallacy.net/images/...\` が 200 で返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)