### PR TITLE
chore(mcp): replace yanked awslabs CDK/Terraform servers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,9 +8,13 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
     },
-    "awslabs_cdk-mcp-server": {
+    "awslabs_aws-iac-mcp-server": {
       "command": "uvx",
-      "args": ["awslabs.cdk-mcp-server@latest"],
+      "args": [
+        "--from",
+        "awslabs.aws-iac-mcp-server@latest",
+        "awslabs.aws-iac-mcp-server"
+      ],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       }
@@ -28,14 +32,9 @@
         "AWS_REGION=us-west-2"
       ]
     },
-    "awslabs_terraform-mcp-server": {
-      "command": "uvx",
-      "args": ["awslabs.terraform-mcp-server@latest"],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      },
-      "disabled": false,
-      "autoApprove": []
+    "terraform-mcp-server": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "hashicorp/terraform-mcp-server"]
     },
     "playwright-test": {
       "command": "npx",


### PR DESCRIPTION
## Summary
- `awslabs.cdk-mcp-server` と `awslabs.terraform-mcp-server` の PyPI パッケージが両方とも yank（公開停止）されており、`claude mcp list` で接続失敗していた
- それぞれ公式アナウンス通りの後継に差し替え:
  - CDK → `awslabs.aws-iac-mcp-server` (PyPI, uvx)
  - Terraform → `hashicorp/terraform-mcp-server` (Docker, HashiCorp公式)

## Yank メッセージ（実機で再現）
```
awslabs-cdk-mcp-server: Superceeded by awslabs.aws-iac-mcp-server
awslabs-terraform-mcp-server: Superceeded by https://github.com/hashicorp/terraform-mcp-server
```

## Notes
- Terraform 側の Docker 起動は HashiCorp 公式 README 推奨方式。利用時は Docker Desktop の起動が必要
- MCP ツール名のプレフィックスが変わる（`mcp__awslabs_aws-iac-mcp-server__*`, `mcp__terraform-mcp-server__*`）。サブエージェント定義に旧プレフィックスがハードコードされていれば追って対応

## Test plan
- [x] `uvx --from awslabs.aws-iac-mcp-server@latest awslabs.aws-iac-mcp-server` がローカルで stdio 起動することを確認
- [x] PR ブランチに切り替えて `claude mcp list` が両サーバ ✓ Connected を返すことを確認（Terraform 側は `docker pull hashicorp/terraform-mcp-server` 後）
- [ ] マージ後、別開発機でも `claude mcp list` で両サーバが接続できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)