### PR TITLE
feat(frontend): share article typography between admin preview and public site (WX PR2)

### DIFF
--- a/frontend/admin/src/components/PostEditor.tsx
+++ b/frontend/admin/src/components/PostEditor.tsx
@@ -376,7 +376,7 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
             {editorMode === 'preview' && (
               <div
                 data-testid="markdown-preview"
-                className="prose prose-sm max-w-none p-4 border border-gray-300 rounded-md bg-gray-50 min-h-[400px]"
+                className="post-content max-w-none p-4 border border-gray-300 rounded-md bg-gray-50 min-h-[400px]"
               >
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>
                   {contentMarkdown || '*プレビューがここに表示されます*'}

--- a/frontend/admin/src/index.css
+++ b/frontend/admin/src/index.css
@@ -1,4 +1,7 @@
 @import "tailwindcss";
+/* 公開サイト (public-astro) と共有する記事タイポグラフィ。
+   @import は @plugin など他の at-rule より前に置く必要がある (CSS 仕様)。 */
+@import "../../shared-ui/src/article.css";
 @plugin "@tailwindcss/typography";
 
 /* Self-hosted Caveat font - eliminates FOUT */

--- a/frontend/public-astro/src/layouts/Layout.astro
+++ b/frontend/public-astro/src/layouts/Layout.astro
@@ -98,6 +98,7 @@ const {
     <!-- Global Styles -->
     <style>
       @import '../styles/global.css';
+      @import '../../../shared-ui/src/article.css';
     </style>
   </head>
   <body class="min-h-screen bg-gray-50">

--- a/frontend/shared-ui/src/article.css
+++ b/frontend/shared-ui/src/article.css
@@ -1,0 +1,133 @@
+/*
+ * Shared article typography
+ *
+ * Used by:
+ *   - frontend/public-astro/src/layouts/Layout.astro (公開ページ全体に @import)
+ *   - frontend/admin/src/index.css (Tiptap プレビューに @import)
+ *
+ * すべてのルールは `.post-content` 配下にスコープしている。
+ * 各アプリでレンダー結果を class="post-content" でラップすると適用される。
+ *
+ * 純粋 CSS で記述している (Tailwind の `@apply` を使わない) ため、
+ * admin / public-astro いずれの Tailwind バージョンでも追加設定なしで動作する。
+ *
+ * Markdown→HTML エンジンが Goldmark (Astro) と react-markdown (admin) で異なる以上
+ * pixel-perfect な一致は保証しないが、見出しサイズ / コードブロック / 引用枠線 /
+ * リンク色など基本タイポグラフィは同一に揃える。
+ */
+
+.post-content {
+  font-size: 1.125rem;
+  line-height: 1.8;
+  color: #374151;
+}
+
+.post-content h1,
+.post-content h2,
+.post-content h3,
+.post-content h4,
+.post-content h5,
+.post-content h6 {
+  color: #111827;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.post-content h2 {
+  font-size: 1.75rem;
+}
+
+.post-content h3 {
+  font-size: 1.5rem;
+}
+
+.post-content p {
+  margin-bottom: 1.5rem;
+}
+
+.post-content a {
+  color: #c9a857;
+  text-decoration: underline;
+  transition: color 0.2s ease;
+}
+
+.post-content a:hover {
+  color: #2d2a5a;
+}
+
+.post-content ul,
+.post-content ol {
+  margin-bottom: 1.5rem;
+  padding-left: 2rem;
+}
+
+/* `list-style-type` を明示する。Tailwind v4 の preflight が
+   `ul, ol { list-style: none }` でデフォルト bullet を消すため、
+   各アプリで Tailwind reset が入った場合でも bullet を復元する。 */
+.post-content ul {
+  list-style-type: disc;
+}
+
+.post-content ol {
+  list-style-type: decimal;
+}
+
+.post-content li {
+  margin-bottom: 0.5rem;
+}
+
+.post-content blockquote {
+  border-left: 4px solid #c9a857;
+  padding-left: 1.5rem;
+  margin: 1.5rem 0;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.post-content code {
+  background: #f3f4f6;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-family: 'Fira Code', 'Consolas', monospace;
+}
+
+.post-content pre {
+  background: #1f2937;
+  color: #e5e7eb;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 1.5rem 0;
+}
+
+.post-content pre code {
+  background: transparent;
+  padding: 0;
+  font-size: 0.875rem;
+  font-family: 'Fira Code', 'Consolas', monospace;
+}
+
+.post-content img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin: 1.5rem 0;
+}
+
+.post-content strong {
+  font-weight: 600;
+  color: #111827;
+}
+
+.post-content em {
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .post-content {
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- 公開サイト (Astro) と admin の Tiptap プレビューが同一の記事タイポグラフィを参照するよう、`frontend/shared-ui/src/article.css` を新設し両アプリから `@import` で取り込む
- 見出しサイズ・コードブロック背景・引用枠線・リンク色 (`#c9a857`) など本文表示の基本ルールを共有化
- 既存の `[id].astro` スコープスタイル / `global.css` の重複ルールはそのまま残置 (整理は PR8 のクリーンアップで)

## Why this PR
[執筆体験 (Writer Experience) 大刷新プラン](../../) の PR2。admin プレビューが Tailwind の `prose` プラグイン由来で公開サイトと見た目が大きくズレており、執筆中のレイアウト確認が当てにならない問題を解消する。Markdown→HTML エンジンが Goldmark (Astro) と react-markdown (admin) で別物のため pixel-perfect の一致は保証しないが、CSS レベルでは同一ソースを参照することで段差を最小化する。

## Implementation notes
- **純粋 CSS** で記述 (Tailwind `@apply` 不使用) — admin/public-astro いずれの Tailwind バージョンでも追加設定なしで動作する
- **`list-style-type: disc / decimal` を明示** — Tailwind v4 preflight が `ul,ol{list-style:none}` でデフォルト bullet を消すため、reset が入った環境でも bullet を復元する
- admin `index.css` では `@import` を `@plugin "@tailwindcss/typography"` の**前**に配置 (CSS 仕様で `@import` は他の at-rule より前必須。後ろに置くと PostCSS が silent に drop する)
- admin プレビューラッパの class を `prose prose-sm` から `post-content` に切替

## Files
| 種別 | パス | 行数 |
|---|---|---|
| 新規 | `frontend/shared-ui/src/article.css` | +131 |
| 改修 | `frontend/public-astro/src/layouts/Layout.astro` | +1 |
| 改修 | `frontend/admin/src/index.css` | +3 |
| 改修 | `frontend/admin/src/components/PostEditor.tsx` | -1 +1 |

## Test plan
- [x] `bun run test --run` (admin): 710 passed, 5 skipped (回帰なし)
- [x] `bun run lint` (admin): clean
- [x] `bun run build` (admin): success / `.post-content` ルール 19 件混入確認
- [x] `bun run build` (public-astro Vite/CSS フェーズ): success / `_id_` バンドルに article.css ルール混入確認 (※ `getStaticPaths` の API fetch エラーは API_URL 未設定による pre-existing でこの PR と無関係)
- [x] pre-commit hook: admin lint/test + public test (92 pass) 全 OK
- [ ] dev デプロイ後に admin プレビューと `/posts/[id]` を並べてビジュアル一致を目視確認 (本セッションでは未実施)

## Out of scope
- `[id].astro` / `global.css` 内の `.post-content` 重複ルール削除 → PR8 (cleanup)
- Markdown 変換エンジンの統一 → 設計上スコープ外 (許容差として記録済み)
- 改訂履歴 / 共同編集 / 予約公開などの大改修 → 元プランのスコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)