### PR TITLE
feat(admin): autosave + beforeunload/cancel guard for post editor (WX PR5a)

### DIFF
--- a/frontend/admin/src/components/PostEditor.tsx
+++ b/frontend/admin/src/components/PostEditor.tsx
@@ -17,6 +17,7 @@ import {
 import { uploadImage as defaultUploadImage } from '../api/posts';
 import { Button } from './Button';
 import { TiptapEditor, type TiptapEditorHandle } from './editor';
+import { useAutosave } from './editor/hooks/useAutosave';
 
 export interface PostData {
   title: string;
@@ -56,6 +57,12 @@ interface PostEditorProps {
   onCategoriesRefetch?: () => void;
   /** マインドマップ挿入ボタンクリック時のコールバック */
   onMindmapInsertClick?: () => void;
+  /**
+   * 自動保存コールバック (省略時は autosave 機能無効)。
+   * 1.5s デバウンス / window blur / visibility hidden で発火し、
+   * 失敗時は throw する。新規作成時は親側で createPost + URL 置換を行う。
+   */
+  onAutosave?: (data: PostData) => Promise<void>;
 }
 
 const PUBLISH_STATUS = [
@@ -77,6 +84,7 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
       categoriesError = null,
       onCategoriesRefetch,
       onMindmapInsertClick,
+      onAutosave,
     },
     ref
   ) => {
@@ -128,6 +136,37 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
       },
       []
     );
+
+    // 自動保存 (onAutosave が渡された時のみ有効)。
+    // タイトル非空かつ本文非空の場合だけ保存対象にする (空 POST を防ぐ)。
+    const autosaveData: PostData = {
+      title,
+      contentMarkdown,
+      category,
+      tags,
+      publishStatus,
+    };
+    const noopAutosave = useRef(async () => {}).current;
+    const autosave = useAutosave<PostData>({
+      data: autosaveData,
+      save: onAutosave ?? noopAutosave,
+      enabled: !!onAutosave,
+      isReady: (d) =>
+        d.title.trim().length > 0 && d.contentMarkdown.trim().length > 0,
+    });
+
+    // 未保存状態でブラウザ閉じ/リロードを警告 (beforeunload)
+    useEffect(() => {
+      if (!onAutosave) return;
+      const handler = (e: BeforeUnloadEvent) => {
+        if (!autosave.isDirty) return;
+        e.preventDefault();
+        // Modern browsers ignore the message but require returnValue to be set
+        e.returnValue = '';
+      };
+      window.addEventListener('beforeunload', handler);
+      return () => window.removeEventListener('beforeunload', handler);
+    }, [onAutosave, autosave.isDirty]);
 
     useEffect(() => {
       if (!uploadError) return;
@@ -236,9 +275,27 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
           tags,
           publishStatus,
         });
+        // autosave hook の baseline を現在値に揃える
+        // (これがないと explicit save 後も isDirty=true のままになる)
+        if (onAutosave) {
+          autosave.markClean();
+        }
       } finally {
         setIsSaving(false);
       }
+    };
+
+    const handleCancelClick = () => {
+      // autosave 有効かつ未保存変更がある場合のみ確認ダイアログを表示
+      if (onAutosave && autosave.isDirty) {
+        const confirmed = window.confirm(
+          '未保存の変更があります。本当にキャンセルしますか？'
+        );
+        if (!confirmed) {
+          return;
+        }
+      }
+      onCancel();
     };
 
     return (
@@ -539,8 +596,8 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
           </select>
         </div>
 
-        {/* ボタン */}
-        <div className="flex gap-3">
+        {/* ボタン + autosave ステータス */}
+        <div className="flex items-center gap-3">
           <Button
             type="submit"
             variant="primary"
@@ -556,12 +613,30 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
           <Button
             type="button"
             variant="secondary"
-            onClick={onCancel}
+            onClick={handleCancelClick}
             disabled={isSaving}
             data-testid="cancel-button"
           >
             キャンセル
           </Button>
+          {onAutosave && (
+            <span
+              data-testid="autosave-status"
+              data-autosave-status={autosave.status}
+              className={`ml-auto text-sm ${
+                autosave.status === 'error'
+                  ? 'text-red-600'
+                  : autosave.status === 'saving'
+                    ? 'text-blue-600'
+                    : autosave.status === 'saved'
+                      ? 'text-gray-500'
+                      : 'text-gray-400'
+              }`}
+              aria-live="polite"
+            >
+              {autosave.savedAgoLabel}
+            </span>
+          )}
         </div>
       </form>
     );

--- a/frontend/admin/src/components/editor/hooks/useAutosave.test.ts
+++ b/frontend/admin/src/components/editor/hooks/useAutosave.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAutosave } from './useAutosave';
+
+interface Data {
+  title: string;
+  content: string;
+}
+
+/**
+ * useAutosave のテストは fake timers を使うため waitFor が回らない。
+ * `await vi.runAllTimersAsync()` で setTimeout + microtask を全て drain
+ * してから同期的にアサーションする。
+ */
+
+describe('useAutosave', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('初期状態は idle で、初回マウントでは save を呼ばない', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const data: Data = { title: '', content: '' };
+    const { result } = renderHook(() =>
+      useAutosave({ data, save, isReady: () => true })
+    );
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.lastSavedAt).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('data 変更後 1.5s で save が呼ばれ status が saved になる', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const { result, rerender } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: 'hello', content: '' } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(save).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith({ title: 'hello', content: '' });
+    expect(result.current.status).toBe('saved');
+    expect(result.current.lastSavedAt).toBeInstanceOf(Date);
+  });
+
+  it('連続変更時はデバウンスされ最後の値で 1 回だけ呼ばれる', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const { rerender } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: 'a', content: '' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    rerender({ data: { title: 'ab', content: '' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    rerender({ data: { title: 'abc', content: '' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith({ title: 'abc', content: '' });
+  });
+
+  it('flush() を呼ぶと debounce 待たずに即座に保存', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const { result, rerender } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: 'hi', content: '' } });
+
+    await act(async () => {
+      await result.current.flush();
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith({ title: 'hi', content: '' });
+  });
+
+  it('window.blur イベントで flush される', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const { rerender } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: 'changed', content: '' } });
+
+    await act(async () => {
+      window.dispatchEvent(new Event('blur'));
+      await vi.runAllTimersAsync();
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it('visibilitychange (hidden) で flush される', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const { rerender } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: 'changed', content: '' } });
+
+    await act(async () => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'hidden',
+      });
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.runAllTimersAsync();
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it('save が失敗すると status=error と error が設定される', async () => {
+    const save = vi.fn().mockRejectedValue(new Error('boom'));
+    const initial: Data = { title: '', content: '' };
+    const { result, rerender } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: 'x', content: '' } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('boom');
+  });
+
+  it('isReady が false の間は save されない', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const isReady = (d: Data) => d.title.trim().length > 0;
+    const { rerender } = renderHook(
+      ({ data }: { data: Data }) => useAutosave({ data, save, isReady }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: '   ', content: '' } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(save).not.toHaveBeenCalled();
+
+    rerender({ data: { title: 'OK', content: '' } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith({ title: 'OK', content: '' });
+  });
+
+  it('enabled=false の間は save されない', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const { rerender } = renderHook(
+      ({ data, enabled }: { data: Data; enabled: boolean }) =>
+        useAutosave({ data, save, isReady: () => true, enabled }),
+      { initialProps: { data: initial, enabled: false } }
+    );
+
+    rerender({ data: { title: 'changed', content: '' }, enabled: false });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('save 中に data が変わると、現在の保存完了後にもう一度 save される', async () => {
+    let resolveFirst: (() => void) | null = null;
+    const save = vi.fn().mockImplementation(() => {
+      return new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+    });
+    const initial: Data = { title: '', content: '' };
+    const { result, rerender } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: 'A', content: '' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenLastCalledWith({ title: 'A', content: '' });
+    expect(result.current.status).toBe('saving');
+
+    rerender({ data: { title: 'AB', content: '' } });
+    expect(save).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirst!();
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(save).toHaveBeenLastCalledWith({ title: 'AB', content: '' });
+  });
+
+  it('unmount で pending タイマーがクリーンアップされる', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const { rerender, unmount } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: 'x', content: '' } });
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('markClean() は現在の data を baseline 化し isDirty=false にする', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const { result, rerender } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    rerender({ data: { title: 'externally-saved', content: '' } });
+    expect(result.current.isDirty).toBe(true);
+
+    act(() => {
+      result.current.markClean();
+    });
+
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.status).toBe('saved');
+    expect(result.current.lastSavedAt).toBeInstanceOf(Date);
+
+    // 後続の自動保存はキックされない (data が baseline と一致)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('savedAgoLabel に日本語の状態が反映される', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const initial: Data = { title: '', content: '' };
+    const { result, rerender } = renderHook(
+      ({ data }: { data: Data }) =>
+        useAutosave({ data, save, isReady: () => true }),
+      { initialProps: { data: initial } }
+    );
+
+    expect(result.current.savedAgoLabel).toBe('未保存');
+
+    rerender({ data: { title: 'x', content: '' } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+
+    expect(result.current.savedAgoLabel).toMatch(/保存済み/);
+  });
+});

--- a/frontend/admin/src/components/editor/hooks/useAutosave.ts
+++ b/frontend/admin/src/components/editor/hooks/useAutosave.ts
@@ -1,0 +1,284 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type AutosaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+export interface UseAutosaveOptions<T> {
+  /** 監視対象のデータ。変更を検知して debounce 後に save が呼ばれる。 */
+  data: T;
+  /** データを永続化する非同期関数。失敗時は例外を投げる。 */
+  save: (data: T) => Promise<void>;
+  /** 自動保存を有効にするか (default: true)。false の間は何もしない。 */
+  enabled?: boolean;
+  /** debounce 待機時間 (ms, default: 1500)。 */
+  debounceMs?: number;
+  /**
+   * 保存可否の述語。新規記事ではタイトル非空時のみ保存する等の用途。
+   * default: () => true
+   */
+  isReady?: (data: T) => boolean;
+}
+
+export interface UseAutosaveResult {
+  status: AutosaveStatus;
+  lastSavedAt: Date | null;
+  /** UI 表示用ラベル ("未保存" / "保存中..." / "保存済み Xs" / "保存失敗") */
+  savedAgoLabel: string;
+  /** Pending な変更を即座に保存する。in-flight 中は完了を待つ。 */
+  flush: () => Promise<void>;
+  /**
+   * 外部で明示保存が完了したときに呼ぶ。現在の data を baseline にし、
+   * isDirty を false に戻す (autosave hook 経由でない保存に対応するため)。
+   */
+  markClean: () => void;
+  error: Error | null;
+  /** dirty (last saved との差分があるか) */
+  isDirty: boolean;
+}
+
+const DEFAULT_DEBOUNCE_MS = 1500;
+const TICK_INTERVAL_MS = 5000;
+
+function serialize<T>(value: T): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return Math.random().toString();
+  }
+}
+
+function formatSavedAgo(savedAt: Date | null, now: number): string {
+  if (!savedAt) return '';
+  const diffSec = Math.max(0, Math.floor((now - savedAt.getTime()) / 1000));
+  if (diffSec < 5) return '保存済み';
+  if (diffSec < 60) return `保存済み ${diffSec}秒前`;
+  const min = Math.floor(diffSec / 60);
+  return `保存済み ${min}分前`;
+}
+
+/**
+ * 自動保存フック。data の変更を監視し、debounce 後に save() を呼ぶ。
+ *
+ * - 同時インフライト 1 (in-flight 中の変更は保存完了後に再 schedule)
+ * - window.blur / document visibilitychange→hidden で flush
+ * - status state machine: idle → saving → saved / error
+ *
+ * 新規記事 (id 未確定) の場合、save コールバック側で createPost → setId →
+ * navigate(replace) を行うパターンを想定。フック自身は id を知らない。
+ */
+export function useAutosave<T>(
+  options: UseAutosaveOptions<T>
+): UseAutosaveResult {
+  const {
+    data,
+    save,
+    enabled = true,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    isReady,
+  } = options;
+
+  const [status, setStatus] = useState<AutosaveStatus>('idle');
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  // 最新の data / callback / config を保持する ref。
+  // クロージャ依存を避け、再レンダー時に最新を参照できるようにする。
+  const dataRef = useRef(data);
+  const saveRef = useRef(save);
+  const isReadyRef = useRef<((d: T) => boolean) | undefined>(isReady);
+  const enabledRef = useRef(enabled);
+
+  // 直近で保存済みのスナップショット (JSON シリアライズ済) と未保存変更の有無
+  const lastSavedSerializedRef = useRef<string>(serialize(data));
+
+  // 保留中の debounce タイマー
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 進行中の save Promise (同時インフライト 1 の鍵)
+  const inFlightRef = useRef<Promise<void> | null>(null);
+
+  // in-flight 中に変更が入った場合のリトライフラグ
+  const pendingAfterFlightRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
+  useEffect(() => {
+    saveRef.current = save;
+  }, [save]);
+  useEffect(() => {
+    isReadyRef.current = isReady;
+  }, [isReady]);
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const performSave = useCallback(async () => {
+    const current = dataRef.current;
+    const serialized = serialize(current);
+    if (serialized === lastSavedSerializedRef.current) {
+      return;
+    }
+    if (enabledRef.current === false) {
+      return;
+    }
+    if (isReadyRef.current && !isReadyRef.current(current)) {
+      return;
+    }
+
+    // 既存 in-flight があれば「完了後に再保存」を予約
+    if (inFlightRef.current) {
+      pendingAfterFlightRef.current = true;
+      return inFlightRef.current;
+    }
+
+    setStatus('saving');
+    setError(null);
+
+    const promise = (async () => {
+      try {
+        await saveRef.current(current);
+        // 保存成功時点で baseline を「呼び出し時点の値」に固定 (in-flight 中の追加変更は dirty 扱い継続)
+        lastSavedSerializedRef.current = serialized;
+        setLastSavedAt(new Date());
+        setStatus('saved');
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setStatus('error');
+        throw err;
+      }
+    })();
+
+    inFlightRef.current = promise;
+
+    try {
+      await promise;
+    } catch {
+      // 上位 catch でハンドリング済み (status=error)。
+    } finally {
+      inFlightRef.current = null;
+      // in-flight 中に変更があれば再保存をキック
+      if (pendingAfterFlightRef.current) {
+        pendingAfterFlightRef.current = false;
+        const stillDirty =
+          serialize(dataRef.current) !== lastSavedSerializedRef.current;
+        if (stillDirty) {
+          // 短い debounce 経由で再 schedule (連続変更時も同様にデバウンスされる)
+          clearTimer();
+          timerRef.current = setTimeout(() => {
+            timerRef.current = null;
+            performSave();
+          }, debounceMs);
+        }
+      }
+    }
+  }, [clearTimer, debounceMs]);
+
+  const flush = useCallback(async () => {
+    clearTimer();
+    await performSave();
+  }, [clearTimer, performSave]);
+
+  const markClean = useCallback(() => {
+    clearTimer();
+    pendingAfterFlightRef.current = false;
+    lastSavedSerializedRef.current = serialize(dataRef.current);
+    setLastSavedAt(new Date());
+    setStatus('saved');
+    setError(null);
+  }, [clearTimer]);
+
+  // data 変更を検知して debounce タイマーをセット
+  useEffect(() => {
+    if (!enabled) {
+      clearTimer();
+      return;
+    }
+    const serialized = serialize(data);
+    if (serialized === lastSavedSerializedRef.current) {
+      // 変更なし
+      return;
+    }
+    if (isReady && !isReady(data)) {
+      // 未準備 (例: タイトル空) → タイマーは張らない
+      clearTimer();
+      return;
+    }
+
+    clearTimer();
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      performSave();
+    }, debounceMs);
+
+    return () => {
+      // 次の effect 起動時に既存タイマーをクリア (clearTimer で吸収)
+    };
+  }, [data, enabled, debounceMs, isReady, clearTimer, performSave]);
+
+  // window.blur / visibilitychange→hidden で flush
+  useEffect(() => {
+    const handleBlur = () => {
+      if (!enabledRef.current) return;
+      void flush();
+    };
+    const handleVisibility = () => {
+      if (!enabledRef.current) return;
+      if (document.visibilityState === 'hidden') {
+        void flush();
+      }
+    };
+    window.addEventListener('blur', handleBlur);
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      window.removeEventListener('blur', handleBlur);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [flush]);
+
+  // unmount 時にタイマーを片付ける (in-flight Promise は残す: 完了させる)
+  useEffect(() => {
+    return () => {
+      clearTimer();
+    };
+  }, [clearTimer]);
+
+  // "保存済み Xs前" を 5 秒ごとに更新
+  useEffect(() => {
+    if (status !== 'saved') return;
+    const handle = setInterval(() => {
+      setNow(Date.now());
+    }, TICK_INTERVAL_MS);
+    return () => clearInterval(handle);
+  }, [status]);
+
+  const isDirty = serialize(data) !== lastSavedSerializedRef.current;
+
+  let savedAgoLabel: string;
+  if (status === 'saving') {
+    savedAgoLabel = '保存中...';
+  } else if (status === 'error') {
+    savedAgoLabel = '保存失敗';
+  } else if (status === 'saved' && lastSavedAt) {
+    savedAgoLabel = formatSavedAgo(lastSavedAt, now);
+  } else {
+    savedAgoLabel = '未保存';
+  }
+
+  return {
+    status,
+    lastSavedAt,
+    savedAgoLabel,
+    flush,
+    markClean,
+    error,
+    isDirty,
+  };
+}

--- a/frontend/admin/src/pages/PostCreatePage.tsx
+++ b/frontend/admin/src/pages/PostCreatePage.tsx
@@ -1,8 +1,12 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { PostEditor, type PostEditorHandle } from '../components/PostEditor';
+import {
+  PostEditor,
+  type PostData,
+  type PostEditorHandle,
+} from '../components/PostEditor';
 import MindmapPickerModal from '../components/MindmapPickerModal';
-import { createPost } from '../api/posts';
+import { createPost, updatePost } from '../api/posts';
 import AdminLayout from '../components/AdminLayout';
 import { useCategories } from '../hooks/useCategories';
 
@@ -11,6 +15,8 @@ const PostCreatePage = () => {
   const [error, setError] = useState<string | null>(null);
   const [isMindmapPickerOpen, setIsMindmapPickerOpen] = useState(false);
   const editorRef = useRef<PostEditorHandle>(null);
+  // autosave で記事が初回作成された後の id。これ以降の保存は updatePost を使う。
+  const [postId, setPostId] = useState<string | null>(null);
 
   // カテゴリを動的に取得
   const {
@@ -20,16 +26,14 @@ const PostCreatePage = () => {
     refetch: refetchCategories,
   } = useCategories();
 
-  const handleSave = async (data: {
-    title: string;
-    contentMarkdown: string;
-    category: string;
-    tags: string[];
-    publishStatus: 'draft' | 'published';
-  }) => {
+  const handleSave = async (data: PostData) => {
     try {
       setError(null);
-      await createPost(data);
+      if (postId) {
+        await updatePost(postId, data);
+      } else {
+        await createPost(data);
+      }
       navigate('/posts');
     } catch (err) {
       console.error('記事作成エラー:', err);
@@ -37,6 +41,27 @@ const PostCreatePage = () => {
       // エラーを再スローしない（unhandled promiseエラーを防ぐ）
     }
   };
+
+  // 自動保存ハンドラ。
+  // - 初回 (postId 未確定): createPost → 返却 id を保持し URL を /posts/edit/{id} に
+  //   置換 (history.replaceState のみ。navigate を使うとコンポーネント unmount で
+  //   ローカル state を失う)。
+  // - 2 回目以降: updatePost(id, data)。
+  // 失敗時は throw → useAutosave が status='error' に遷移させる。
+  const handleAutosave = useCallback(
+    async (data: PostData) => {
+      if (postId) {
+        await updatePost(postId, data);
+        return;
+      }
+      const created = await createPost(data);
+      setPostId(created.id);
+      const adminBase = import.meta.env.BASE_URL.replace(/\/$/, '');
+      const newUrl = `${adminBase}/posts/edit/${created.id}`;
+      window.history.replaceState(null, '', newUrl);
+    },
+    [postId]
+  );
 
   const handleCancel = () => {
     navigate('/posts');
@@ -65,6 +90,7 @@ const PostCreatePage = () => {
           ref={editorRef}
           onSave={handleSave}
           onCancel={handleCancel}
+          onAutosave={handleAutosave}
           categories={categories}
           categoriesLoading={categoriesLoading}
           categoriesError={categoriesError}

--- a/frontend/admin/src/pages/PostEditPage.tsx
+++ b/frontend/admin/src/pages/PostEditPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   PostEditor,
@@ -70,6 +70,15 @@ const PostEditPage = () => {
     }
   };
 
+  // 自動保存: 既存記事なので常に updatePost
+  const handleAutosave = useCallback(
+    async (data: PostData) => {
+      if (!id) return;
+      await updatePost(id, data);
+    },
+    [id]
+  );
+
   const handleCancel = () => {
     navigate('/posts');
   };
@@ -108,6 +117,7 @@ const PostEditPage = () => {
             ref={editorRef}
             onSave={handleSave}
             onCancel={handleCancel}
+            onAutosave={handleAutosave}
             initialData={initialData}
             categories={categories}
             categoriesLoading={categoriesLoading}

--- a/tests/e2e/specs/admin-autosave.spec.ts
+++ b/tests/e2e/specs/admin-autosave.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '../fixtures';
+import { resetMockPosts } from '../mocks/mockData';
+import { getTiptapEditor, setEditorContent } from '../utils/tiptapHelpers';
+
+/**
+ * Admin Autosave (PR5a)
+ *
+ * - 入力停止後 1.5s 程度で `保存済み` ラベルに遷移する
+ * - 新規記事は最初の autosave 完了で URL が /posts/edit/{id} に置換される
+ * - 既存記事の編集中も 1.5s で保存される
+ *
+ * MSW モック環境前提。リロードを跨ぐ復元検証は MSW 側の state が
+ * 初期化されてしまうため、本 spec のスコープ外。
+ */
+
+test.describe('Admin Autosave', () => {
+  const testCredentials = {
+    email: process.env.TEST_ADMIN_EMAIL || 'admin@example.com',
+    password: process.env.TEST_ADMIN_PASSWORD || 'testpassword',
+  };
+
+  test.beforeEach(async ({ adminLoginPage }) => {
+    resetMockPosts();
+    await adminLoginPage.navigate();
+    await adminLoginPage.clearCredentials();
+    await adminLoginPage.login(testCredentials.email, testCredentials.password);
+  });
+
+  test('新規記事: タイトル+本文入力後、autosave で URL が /posts/edit/{id} に置換される', async ({
+    page,
+  }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    // 初期状態: 未保存
+    const status = page.getByTestId('autosave-status');
+    await expect(status).toHaveText(/未保存/);
+
+    await page.getByTestId('post-title-input').fill('Autosave Test Title');
+    await setEditorContent(page, '# Autosave\n\n本文サンプルです。');
+
+    // 1.5s debounce 後に保存され URL が変わる
+    await expect(page).toHaveURL(/\/posts\/edit\/[^/]+$/, { timeout: 5000 });
+
+    // ステータスが "保存済み" になる
+    await expect(status).toHaveText(/保存済み/, { timeout: 3000 });
+  });
+
+  test('既存記事の編集: 本文変更後 autosave で saved に遷移する', async ({
+    page,
+  }) => {
+    // 既存記事を編集 (mockData の post-1 を利用)
+    await page.goto('/posts/edit/post-1');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    const status = page.getByTestId('autosave-status');
+    // 初期状態は未保存 (load 時点では autosave hook の baseline と
+    // 一致しているが、useState の初期化タイミングで dirty 扱いになる
+    // 可能性がある。saved or 未保存のどちらでも許容)。
+
+    // 本文を編集
+    await setEditorContent(page, '# 変更後の見出し\n\n編集された本文。');
+
+    // 1.5s debounce + αで saving → saved
+    await expect(status).toHaveText(/保存済み/, { timeout: 5000 });
+  });
+
+  test('タイトルのみで本文が空の場合 autosave は走らない (isReady ガード)', async ({
+    page,
+  }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    await page.getByTestId('post-title-input').fill('Title Only');
+    // 本文は空のまま
+
+    // 3 秒待っても URL は変わらず、saved にもならない
+    await page.waitForTimeout(3000);
+    await expect(page).toHaveURL(/\/posts\/new$/);
+    const status = page.getByTestId('autosave-status');
+    await expect(status).toHaveText(/未保存/);
+  });
+});

--- a/tests/e2e/specs/admin-unsaved-guard.spec.ts
+++ b/tests/e2e/specs/admin-unsaved-guard.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '../fixtures';
+import { resetMockPosts } from '../mocks/mockData';
+import { getTiptapEditor, setEditorContent } from '../utils/tiptapHelpers';
+
+/**
+ * Admin Unsaved-Guard (PR5a)
+ *
+ * autosave がまだ走っていない状態でキャンセルボタンを押すと
+ * window.confirm が出る。
+ *
+ * 注: React Router 7 の useBlocker は Data Router (createBrowserRouter)
+ * 必須だが、本 admin app は BrowserRouter を使っているため、サイドバー
+ * リンクなど任意の遷移をブロックする機能は本 PR ではスコープ外。
+ * 本 PR では:
+ *  - beforeunload (ブラウザ閉じ・リロード) → ブラウザ標準の警告
+ *  - キャンセルボタン → window.confirm で明示確認
+ * の 2 経路をカバーする。
+ */
+
+test.describe('Admin Unsaved-Guard', () => {
+  const testCredentials = {
+    email: process.env.TEST_ADMIN_EMAIL || 'admin@example.com',
+    password: process.env.TEST_ADMIN_PASSWORD || 'testpassword',
+  };
+
+  test.beforeEach(async ({ adminLoginPage }) => {
+    resetMockPosts();
+    await adminLoginPage.navigate();
+    await adminLoginPage.clearCredentials();
+    await adminLoginPage.login(testCredentials.email, testCredentials.password);
+  });
+
+  test('未保存のままキャンセル → confirm が出る (dismiss で留まる)', async ({
+    page,
+  }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    // タイトルだけ入力 (本文空 → autosave は走らない → isDirty のまま)
+    await page.getByTestId('post-title-input').fill('Dirty Title');
+
+    let dialogMessage: string | null = null;
+    page.once('dialog', async (dialog) => {
+      dialogMessage = dialog.message();
+      await dialog.dismiss();
+    });
+
+    await page.getByTestId('cancel-button').click();
+
+    // dialog が出て、dismiss したので URL は変わらない
+    await expect.poll(() => dialogMessage).toMatch(/未保存の変更/);
+    await expect(page).toHaveURL(/\/posts\/new$/);
+  });
+
+  test('未保存のままキャンセル → confirm を accept で離脱する', async ({
+    page,
+  }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    await page.getByTestId('post-title-input').fill('Dirty Title');
+
+    page.once('dialog', async (dialog) => {
+      await dialog.accept();
+    });
+
+    await page.getByTestId('cancel-button').click();
+
+    // accept したので /posts に遷移
+    await expect(page).toHaveURL(/\/posts$/);
+  });
+
+  test('autosave 完了後にキャンセル → confirm 無しで遷移', async ({ page }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    // タイトル + 本文を入れて autosave 完走を待つ
+    await page.getByTestId('post-title-input').fill('Will Autosave');
+    await setEditorContent(page, '# 本文\n\nautosave 確認');
+
+    // URL 置換を待つ = autosave 完了
+    await expect(page).toHaveURL(/\/posts\/edit\/[^/]+$/, { timeout: 5000 });
+    await expect(page.getByTestId('autosave-status')).toHaveText(/保存済み/, {
+      timeout: 3000,
+    });
+
+    // confirm が出たら fail させる (出るべきでない)
+    let dialogShown = false;
+    page.on('dialog', async (dialog) => {
+      dialogShown = true;
+      await dialog.dismiss();
+    });
+
+    await page.getByTestId('cancel-button').click();
+
+    await expect(page).toHaveURL(/\/posts$/);
+    expect(dialogShown).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

執筆体験 (Writer Experience) 改善プランの **PR5a** (PR5 を 5a / 5b に分割した前半)。
Tiptap エディタに自動保存を追加し、保存忘れ・確認往復を解消する。

- 1.5s デバウンスの autosave hook (`useAutosave`) 新設、`window.blur` /
  `visibilitychange→hidden` で flush、同時インフライト 1
- PostEditor: opt-in `onAutosave` プロップ、保存ステータスラベル、
  `beforeunload` 警告、キャンセルボタンの `window.confirm` 確認
- PostCreatePage: 初回 autosave で `createPost` → `history.replaceState` で
  URL を `/posts/edit/{id}` に置換 (リロード耐性)
- PostEditPage: autosave で `updatePost(id, data)`
- E2E spec 6 件 (autosave 3 / unsaved-guard 3)

## Why this PR

執筆中に \`保存\` ボタンを押すまでデータが永続化されない現状の UX は、
ブラウザクラッシュ・誤操作・タブ閉じで容易にデータを失う。
1.5s デバウンスの autosave で常時バックグラウンド保存し、未保存変更がある
場合のみ離脱を確認することで、執筆フローを途切れさせず保存忘れを防ぐ。

## Files

| 種別 | パス | 行数 |
|---|---|---|
| 新規 | \`frontend/admin/src/components/editor/hooks/useAutosave.ts\` | +279 |
| 新規 | \`frontend/admin/src/components/editor/hooks/useAutosave.test.ts\` | +331 |
| 改修 | \`frontend/admin/src/components/PostEditor.tsx\` | +73 -3 |
| 改修 | \`frontend/admin/src/pages/PostCreatePage.tsx\` | +47 -7 |
| 改修 | \`frontend/admin/src/pages/PostEditPage.tsx\` | +12 -1 |
| 新規 | \`tests/e2e/specs/admin-autosave.spec.ts\` | +69 |
| 新規 | \`tests/e2e/specs/admin-unsaved-guard.spec.ts\` | +96 |

## Implementation notes

- **isReady ガード**: 新規記事は \`title.trim().length > 0 && content.trim().length > 0\` の時のみ autosave 発火。空 POST を防ぐ。
- **history.replaceState 採用**: \`navigate('/posts/edit/{id}', {replace:true})\` を使うと PostCreatePage が unmount → PostEditPage が mount し、編集中の local state (typing) が失われる。\`window.history.replaceState\` で URL のみ更新し、コンポーネントツリーを保つ方針に変更。
- **markClean()**: 明示保存ボタン (\`保存\`) 経由の保存後に hook の baseline をリセット。これがないと \`isDirty\` が true のままで beforeunload/cancel-confirm が誤発火する。
- **同時インフライト 1**: in-flight 中の data 変更は \`pendingAfterFlightRef\` フラグで予約し、resolve 後に再 schedule。DynamoDB 上書き競合の防御。

## Out of scope (PR5b で対応)

- CodeBuild ビルドステータスバッジ + Lambda + Terraform → **PR5b** で別 PR
- 保存ボタン群の \`[Save draft]\` \`[Publish now]\` \`[Unpublish]\` \`[Cancel]\` 再構成 → 既存 50+ tests への影響回避のため、本 PR では既存 \`保存\`/\`キャンセル\` UI に autosave を重ねる方式を採用
- React Router 7 \`useBlocker\` ベースの **in-app nav guard** → Data Router (\`createBrowserRouter\`) 必須で App.tsx (\`BrowserRouter\`) との整合性確保がスコープ超過。本 PR では \`beforeunload\` (ブラウザリロード/閉じ) と cancel-confirm (キャンセルボタン) のみカバー。サイドバーリンク経由の遷移ガードは follow-up
- ブラウザリロード後の本文復元 E2E 検証 → MSW 側 state がリセットされるため検証不能。実機 dev/prd で目視確認

## Test plan

- [x] \`bun run test --run\` (admin): **723 passed | 5 skipped** (useAutosave で +13、回帰なし)
- [x] \`bun run lint\` (admin): clean
- [x] \`bun run build\` (admin): success (1280 modules, +1.4KB CSS)
- [x] pre-commit hook (admin lint/test + public test): 全 pass
- [ ] E2E spec 実行 → reviewer 環境で確認 (本セッション未実行)
- [ ] 実機 dev デプロイで autosave + URL 置換 + リロード復元の目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)