### PR TITLE
feat(admin): show build status badge when deleting published post

### DIFF
--- a/frontend/admin/src/pages/PostListPage.test.tsx
+++ b/frontend/admin/src/pages/PostListPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../api/posts', () => ({
   uploadImage: vi.fn(),
   deleteImage: vi.fn(),
   extractImageKey: vi.fn(),
+  fetchBuildStatus: vi.fn().mockResolvedValue({ status: 'idle' }),
 }));
 
 // Amplifyのモック
@@ -53,6 +54,9 @@ vi.mock('../components/AdminLayout', () => ({
 const mockGetPosts = postsApi.getPosts as ReturnType<typeof vi.fn>;
 const mockDeletePost = postsApi.deletePost as ReturnType<typeof vi.fn>;
 const mockUpdatePost = postsApi.updatePost as ReturnType<typeof vi.fn>;
+const mockFetchBuildStatus = postsApi.fetchBuildStatus as ReturnType<
+  typeof vi.fn
+>;
 
 const renderPostListPage = () => {
   return render(
@@ -67,6 +71,7 @@ const renderPostListPage = () => {
 describe('PostListPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetchBuildStatus.mockResolvedValue({ status: 'idle' });
   });
 
   describe('記事一覧のレンダリング', () => {
@@ -824,6 +829,150 @@ describe('PostListPage', () => {
         expect(
           screen.getByText(/記事のステータス更新に失敗しました/i)
         ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('削除時のビルドステータス表示', () => {
+    it('公開済み記事を削除するとビルドステータスバッジを表示する', async () => {
+      const publishedPost = {
+        id: '1',
+        title: 'Published Post',
+        contentMarkdown: 'Content',
+        contentHtml: '<p>Content</p>',
+        category: 'tech',
+        publishStatus: 'published' as const,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      };
+
+      mockGetPosts.mockResolvedValueOnce({ posts: [publishedPost], total: 1 });
+      mockGetPosts.mockResolvedValueOnce({ posts: [], total: 0 });
+      mockDeletePost.mockResolvedValue(undefined);
+      mockFetchBuildStatus.mockResolvedValue({ status: 'in-progress' });
+
+      renderPostListPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /削除/i })
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /削除/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('confirm-yes'));
+
+      await waitFor(() => {
+        expect(mockDeletePost).toHaveBeenCalledWith('1');
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('build-status-badge')).toBeInTheDocument();
+      });
+      expect(mockFetchBuildStatus).toHaveBeenCalledWith('1');
+    });
+
+    it('下書き記事を削除した場合はビルドステータスバッジを表示しない', async () => {
+      const draftPost = {
+        id: '2',
+        title: 'Draft Post',
+        contentMarkdown: 'Content',
+        contentHtml: '<p>Content</p>',
+        category: 'tech',
+        publishStatus: 'draft' as const,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      };
+
+      // 初期表示（公開記事タブ） → 空、下書きタブ切り替え後 → 1件、削除後 → 空
+      mockGetPosts.mockResolvedValueOnce({ posts: [], total: 0 });
+      mockGetPosts.mockResolvedValueOnce({ posts: [draftPost], total: 1 });
+      mockGetPosts.mockResolvedValueOnce({ posts: [], total: 0 });
+      mockDeletePost.mockResolvedValue(undefined);
+
+      renderPostListPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /下書き/i })
+        ).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByRole('button', { name: /下書き/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Draft Post')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /削除/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('confirm-yes'));
+
+      await waitFor(() => {
+        expect(mockDeletePost).toHaveBeenCalledWith('2');
+      });
+
+      // 成功メッセージは出るがバッジは出ない
+      await waitFor(() => {
+        expect(screen.getByText(/記事を削除しました/i)).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByTestId('build-status-badge')
+      ).not.toBeInTheDocument();
+      expect(mockFetchBuildStatus).not.toHaveBeenCalled();
+    });
+
+    it('タブを切り替えるとビルドステータスバッジが消える', async () => {
+      const publishedPost = {
+        id: '1',
+        title: 'Published Post',
+        contentMarkdown: 'Content',
+        contentHtml: '<p>Content</p>',
+        category: 'tech',
+        publishStatus: 'published' as const,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      };
+
+      mockGetPosts.mockResolvedValueOnce({ posts: [publishedPost], total: 1 });
+      mockGetPosts.mockResolvedValueOnce({ posts: [], total: 0 }); // 削除後リロード
+      mockGetPosts.mockResolvedValueOnce({ posts: [], total: 0 }); // 下書きタブ
+      mockDeletePost.mockResolvedValue(undefined);
+      mockFetchBuildStatus.mockResolvedValue({ status: 'in-progress' });
+
+      renderPostListPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /削除/i })
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /削除/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByTestId('confirm-yes'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('build-status-badge')).toBeInTheDocument();
+      });
+
+      // 下書きタブに切り替え
+      fireEvent.click(screen.getByRole('button', { name: /下書き/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('build-status-badge')
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/frontend/admin/src/pages/PostListPage.tsx
+++ b/frontend/admin/src/pages/PostListPage.tsx
@@ -4,6 +4,7 @@ import { getPosts, deletePost, updatePost } from '../api/posts';
 import type { Post } from '../api/posts';
 import ConfirmDialog from '../components/ConfirmDialog';
 import AdminLayout from '../components/AdminLayout';
+import { BuildStatusBadge } from '../components/BuildStatusBadge';
 import { PostListSkeleton } from '../components/skeleton';
 
 type TabType = 'published' | 'draft';
@@ -21,6 +22,10 @@ const PostListPage = () => {
   // 削除確認ダイアログ用のstate
   const [showConfirmDialog, setShowConfirmDialog] = useState<boolean>(false);
   const [postToDelete, setPostToDelete] = useState<string | null>(null);
+
+  // 公開済み記事を削除した直後にビルドステータスを表示するための postId。
+  // 下書き削除時はサーバー側でビルドが起きないため null のまま。
+  const [deletedPostId, setDeletedPostId] = useState<string | null>(null);
 
   const loadPosts = async (publishStatus: TabType, token?: string) => {
     try {
@@ -49,6 +54,7 @@ const PostListPage = () => {
     setActiveTab(tab);
     setNextToken(undefined);
     setSearchQuery(''); // タブ切り替え時に検索クエリをリセット
+    setDeletedPostId(null); // タブ切り替え時に直前のビルドステータスバッジを消す
   };
 
   const handleNextPage = () => {
@@ -65,11 +71,19 @@ const PostListPage = () => {
   const handleDeleteConfirm = async () => {
     if (!postToDelete) return;
 
+    // 削除前に公開状態をスナップショット。published のみサーバー側で
+    // サイトリビルドが走るため、その場合のみバッジを表示する。
+    const target = posts.find((p) => p.id === postToDelete);
+    const wasPublished = target?.publishStatus === 'published';
+
     try {
       setError(null);
       setSuccessMessage(null);
       await deletePost(postToDelete);
       setSuccessMessage('記事を削除しました');
+      if (wasPublished) {
+        setDeletedPostId(postToDelete);
+      }
       setShowConfirmDialog(false);
       setPostToDelete(null);
       await loadPosts(activeTab);
@@ -163,6 +177,11 @@ const PostListPage = () => {
           {successMessage}
         </div>
       )}
+
+      <BuildStatusBadge
+        postId={deletedPostId ?? undefined}
+        enabled={deletedPostId !== null}
+      />
 
       {/* 検索バー */}
       <div style={{ marginBottom: '24px' }}>


### PR DESCRIPTION
## Summary

- 公開済み記事を削除した直後に `BuildStatusBadge` を表示し、サイトリビルドの完了をユーザーが確認できるようにする
- Delete Lambda（`go-functions/cmd/posts/delete/main.go:138-140`）は公開済み記事削除時に `triggerSiteBuild()` を呼ぶが、Admin UI 側はこれまでフィードバックがなく、削除後に古いキャッシュを見てしまう懸念があった
- 既存の publish フロー（PR5b）と同じ UX を削除フローに揃える

## Implementation

- **`PostListPage.tsx`**: `BuildStatusBadge` を追加。削除前に対象記事の `publishStatus` をスナップショットし、`published` のときだけ `deletedPostId` を設定してバッジを表示。タブ切り替え時に `deletedPostId` をクリア
- **下書き削除ではバッジを表示しない**: バックエンドが `published` のときしか `triggerSiteBuild()` を呼ばないため、出すと「待機中」のまま終わって誤解を招く
- **バックエンド変更なし**: build-status Lambda は CodeBuild の最新ビルドを返すだけで postId の DB 存在チェックを行わず、削除済み postId でもそのまま動作する（`build_status/main.go:11-14` の設計コメントで意図が明記されている）
- **`PostListPage.test.tsx`**: `fetchBuildStatus` モックを追加 + 新規テスト 3 件（公開削除でバッジ表示／下書き削除でバッジ非表示／タブ切替でバッジ消去）

## Test plan

- [x] `bun run test PostListPage` — 31 passed (1 skipped, pre-existing)
- [x] `bun run test BuildStatusBadge` — 7 passed（回帰なし）
- [x] `bun run type-check` — エラーなし
- [x] `bun run lint` — エラーなし
- [ ] 手動: 公開済み記事を削除 → 一覧画面に「ビルド中…」バッジが表示され、CodeBuild 完了時に「ビルド完了」へ遷移すること
- [ ] 手動: 下書き記事を削除 → バッジが表示されないこと
- [ ] 手動: タブ切り替え（公開済み ⇄ 下書き）でバッジが消えること
- [ ] 手動: 既存の publish フロー（PostEditPage / PostCreatePage）に回帰がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)