### PR TITLE
feat(admin): metadata sidebar (slug/excerpt/cover) + server-side persistence (WX PR6)

### DIFF
--- a/frontend/admin/src/components/MetadataSidebar.test.tsx
+++ b/frontend/admin/src/components/MetadataSidebar.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
+import {
+  MetadataSidebar,
+  type MetadataSidebarValue,
+  type CategoryOption,
+} from './MetadataSidebar';
+
+const baseCategories: CategoryOption[] = [
+  { slug: 'tech', name: '技術', sortOrder: 1 },
+  { slug: 'life', name: '生活', sortOrder: 2 },
+];
+
+const baseValue: MetadataSidebarValue = {
+  slug: '',
+  excerpt: '',
+  coverImageUrl: '',
+  category: '',
+  tags: [],
+  publishStatus: 'draft',
+  slugLocked: false,
+};
+
+describe('MetadataSidebar', () => {
+  it('タイトル入力で slug が自動更新される', () => {
+    function Driver() {
+      const [title, setTitle] = useState('');
+      const [v, setV] = useState<MetadataSidebarValue>(baseValue);
+      return (
+        <>
+          <input
+            data-testid="title-input"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <MetadataSidebar
+            value={v}
+            onChange={(p) => setV((prev) => ({ ...prev, ...p }))}
+            title={title}
+            contentMarkdown=""
+            categories={baseCategories}
+          />
+        </>
+      );
+    }
+    render(<Driver />);
+    const titleInput = screen.getByTestId('title-input') as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: 'Hello World' } });
+    const slug = screen.getByTestId('metadata-slug-input') as HTMLInputElement;
+    expect(slug.value).toBe('hello-world');
+  });
+
+  it('ロック中はタイトル変更でslugが更新されない', () => {
+    function Driver() {
+      const [title, setTitle] = useState('initial');
+      const [v, setV] = useState<MetadataSidebarValue>({
+        ...baseValue,
+        slug: 'manual-slug',
+        slugLocked: true,
+      });
+      return (
+        <>
+          <input
+            data-testid="title-input"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <MetadataSidebar
+            value={v}
+            onChange={(p) => setV((prev) => ({ ...prev, ...p }))}
+            title={title}
+            contentMarkdown=""
+            categories={baseCategories}
+          />
+        </>
+      );
+    }
+    render(<Driver />);
+    fireEvent.change(screen.getByTestId('title-input'), {
+      target: { value: 'New Title' },
+    });
+    const slug = screen.getByTestId('metadata-slug-input') as HTMLInputElement;
+    expect(slug.value).toBe('manual-slug');
+  });
+
+  it('ロック解除→ロックで isPressed が反映される', () => {
+    const onChange = vi.fn();
+    render(
+      <MetadataSidebar
+        value={baseValue}
+        onChange={onChange}
+        title=""
+        contentMarkdown=""
+        categories={baseCategories}
+      />
+    );
+    const lock = screen.getByTestId('metadata-slug-lock');
+    expect(lock.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(lock);
+    expect(onChange).toHaveBeenCalledWith({ slugLocked: true });
+  });
+
+  it('excerpt が161文字でカウンターが赤になる', () => {
+    function Driver() {
+      const [v, setV] = useState<MetadataSidebarValue>(baseValue);
+      return (
+        <MetadataSidebar
+          value={v}
+          onChange={(p) => setV((prev) => ({ ...prev, ...p }))}
+          title=""
+          contentMarkdown=""
+          categories={baseCategories}
+        />
+      );
+    }
+    render(<Driver />);
+    const excerpt = screen.getByTestId(
+      'metadata-excerpt-input'
+    ) as HTMLTextAreaElement;
+    fireEvent.change(excerpt, { target: { value: 'x'.repeat(161) } });
+    const counter = screen.getByTestId('metadata-excerpt-counter');
+    expect(counter.className).toContain('text-red-600');
+  });
+
+  it('「本文先頭画像から」で coverImageUrl が埋まる', () => {
+    function Driver() {
+      const [v, setV] = useState<MetadataSidebarValue>(baseValue);
+      return (
+        <MetadataSidebar
+          value={v}
+          onChange={(p) => setV((prev) => ({ ...prev, ...p }))}
+          title=""
+          contentMarkdown="text ![](https://cdn/x.jpg) more"
+          categories={baseCategories}
+        />
+      );
+    }
+    render(<Driver />);
+    fireEvent.click(screen.getByTestId('metadata-cover-autofill'));
+    expect(
+      (screen.getByTestId('metadata-cover-input') as HTMLInputElement).value
+    ).toBe('https://cdn/x.jpg');
+  });
+
+  it('カテゴリ select に options が表示される', () => {
+    render(
+      <MetadataSidebar
+        value={baseValue}
+        onChange={() => {}}
+        title=""
+        contentMarkdown=""
+        categories={baseCategories}
+      />
+    );
+    const select = screen.getByTestId(
+      'post-category-select'
+    ) as HTMLSelectElement;
+    expect(select.options.length).toBeGreaterThan(2);
+    expect(Array.from(select.options).map((o) => o.value)).toContain('tech');
+  });
+
+  it('Enterキーでタグを追加できる', () => {
+    function Driver() {
+      const [v, setV] = useState<MetadataSidebarValue>(baseValue);
+      return (
+        <MetadataSidebar
+          value={v}
+          onChange={(p) => setV((prev) => ({ ...prev, ...p }))}
+          title=""
+          contentMarkdown=""
+          categories={baseCategories}
+        />
+      );
+    }
+    render(<Driver />);
+    const input = screen.getByTestId('tag-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'go' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.getByTestId('tags-list').textContent).toContain('go');
+  });
+});

--- a/frontend/admin/src/components/MetadataSidebar.tsx
+++ b/frontend/admin/src/components/MetadataSidebar.tsx
@@ -1,0 +1,404 @@
+// PR6: Metadata sidebar that pulls slug / excerpt / cover-image / tags /
+// category / publishStatus out of the main editor flow so writers can focus
+// on title + body and configure the rest in one panel.
+//
+// Slug auto-fills from the title (slugify) when the lock is open. Once the
+// writer clicks the lock, the slug is theirs to edit; it doesn't track title
+// changes anymore. Excerpt and cover-image have one-click "fill from body"
+// helpers but never auto-overwrite existing input.
+
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { Button } from './Button';
+import {
+  slugify,
+  excerptFromMarkdown,
+  coverFromMarkdown,
+} from '../utils/postDefaults';
+import { validateSlug, validateExcerpt } from '../utils/validation';
+
+export interface CategoryOption {
+  slug: string;
+  name: string;
+  sortOrder: number;
+}
+
+export interface MetadataSidebarValue {
+  slug: string;
+  excerpt: string;
+  coverImageUrl: string;
+  category: string;
+  tags: string[];
+  publishStatus: 'draft' | 'published';
+  slugLocked: boolean;
+}
+
+export interface MetadataSidebarProps {
+  value: MetadataSidebarValue;
+  onChange: (patch: Partial<MetadataSidebarValue>) => void;
+  /** タイトル — slug 自動生成のソース (ロック OFF のとき) */
+  title: string;
+  /** 本文 — excerpt/cover の自動充填ボタンが参照 */
+  contentMarkdown: string;
+  categories: CategoryOption[];
+  categoriesLoading?: boolean;
+  categoriesError?: string | null;
+  onCategoriesRefetch?: () => void;
+  disabled?: boolean;
+  /** initialData 由来でこのカテゴリが現在 categories に存在しないことを表示 */
+  isCategoryMissing?: boolean;
+  initialCategoryName?: string;
+}
+
+const PUBLISH_STATUS_LABEL: Record<'draft' | 'published', string> = {
+  draft: '下書き',
+  published: '公開',
+};
+
+const EXCERPT_MAX = 160;
+const SLUG_MAX = 80;
+
+export const MetadataSidebar = ({
+  value,
+  onChange,
+  title,
+  contentMarkdown,
+  categories,
+  categoriesLoading = false,
+  categoriesError = null,
+  onCategoriesRefetch,
+  disabled = false,
+  isCategoryMissing = false,
+  initialCategoryName,
+}: MetadataSidebarProps) => {
+  const sortedCategories = [...categories].sort(
+    (a, b) => a.sortOrder - b.sortOrder
+  );
+
+  // Auto-derive slug from title when unlocked. Skip the very first render so
+  // we don't clobber `value.slug` provided via initialData.
+  const firstSlugSyncRef = useRef(true);
+  useEffect(() => {
+    if (firstSlugSyncRef.current) {
+      firstSlugSyncRef.current = false;
+      return;
+    }
+    if (value.slugLocked) return;
+    const next = title.trim() ? slugify(title) : '';
+    if (next !== value.slug) {
+      onChange({ slug: next });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [title, value.slugLocked]);
+
+  const slugError = validateSlug(value.slug);
+  const excerptError = validateExcerpt(value.excerpt);
+
+  const [tagInput, setTagInput] = useState('');
+
+  const addTag = () => {
+    const t = tagInput.trim();
+    if (!t || value.tags.includes(t)) return;
+    onChange({ tags: [...value.tags, t] });
+    setTagInput('');
+  };
+
+  const handleTagKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      addTag();
+    }
+  };
+
+  const removeTag = (idx: number) => {
+    onChange({ tags: value.tags.filter((_, i) => i !== idx) });
+  };
+
+  const fillCoverFromBody = () => {
+    const url = coverFromMarkdown(contentMarkdown);
+    if (url) onChange({ coverImageUrl: url });
+  };
+
+  const fillExcerptFromBody = () => {
+    const ex = excerptFromMarkdown(contentMarkdown);
+    if (ex) onChange({ excerpt: ex });
+  };
+
+  return (
+    <aside
+      data-testid="metadata-sidebar"
+      className="space-y-6 lg:sticky lg:top-4 lg:self-start"
+    >
+      {/* 公開状態 */}
+      <section className="rounded-md border border-gray-200 p-4">
+        <label
+          htmlFor="publishStatus"
+          className="mb-1 block text-sm font-semibold text-gray-700"
+        >
+          公開状態
+        </label>
+        <select
+          id="publishStatus"
+          data-testid="metadata-publish-status"
+          value={value.publishStatus}
+          onChange={(e) =>
+            onChange({
+              publishStatus: e.target.value as 'draft' | 'published',
+            })
+          }
+          disabled={disabled}
+          className="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+        >
+          {(['draft', 'published'] as const).map((s) => (
+            <option key={s} value={s}>
+              {PUBLISH_STATUS_LABEL[s]}
+            </option>
+          ))}
+        </select>
+      </section>
+
+      {/* Slug */}
+      <section className="rounded-md border border-gray-200 p-4">
+        <div className="mb-1 flex items-center justify-between">
+          <label
+            htmlFor="metadata-slug"
+            className="text-sm font-semibold text-gray-700"
+          >
+            Slug
+          </label>
+          <button
+            type="button"
+            data-testid="metadata-slug-lock"
+            aria-pressed={value.slugLocked}
+            onClick={() => onChange({ slugLocked: !value.slugLocked })}
+            className="text-xs text-blue-600 hover:underline"
+            disabled={disabled}
+          >
+            {value.slugLocked ? '🔒 手動編集中' : '🔓 自動生成中'}
+          </button>
+        </div>
+        <input
+          id="metadata-slug"
+          type="text"
+          data-testid="metadata-slug-input"
+          value={value.slug}
+          onChange={(e) => onChange({ slug: e.target.value })}
+          readOnly={!value.slugLocked}
+          maxLength={SLUG_MAX}
+          className={`w-full rounded border px-2 py-1 font-mono text-sm ${
+            slugError ? 'border-red-400' : 'border-gray-300'
+          } ${!value.slugLocked ? 'bg-gray-50 text-gray-600' : 'bg-white'}`}
+          disabled={disabled}
+        />
+        <p className="mt-1 text-xs text-gray-500">
+          {value.slug ? `/posts/${value.slug}` : '— (未設定)'}
+        </p>
+        {slugError && (
+          <p
+            className="mt-1 text-xs text-red-600"
+            data-testid="metadata-slug-error"
+          >
+            {slugError}
+          </p>
+        )}
+      </section>
+
+      {/* Excerpt */}
+      <section className="rounded-md border border-gray-200 p-4">
+        <div className="mb-1 flex items-center justify-between">
+          <label
+            htmlFor="metadata-excerpt"
+            className="text-sm font-semibold text-gray-700"
+          >
+            概要 (excerpt)
+          </label>
+          <button
+            type="button"
+            onClick={fillExcerptFromBody}
+            className="text-xs text-blue-600 hover:underline"
+            data-testid="metadata-excerpt-autofill"
+            disabled={disabled}
+          >
+            本文から自動
+          </button>
+        </div>
+        <textarea
+          id="metadata-excerpt"
+          data-testid="metadata-excerpt-input"
+          value={value.excerpt}
+          onChange={(e) => onChange({ excerpt: e.target.value })}
+          rows={3}
+          className={`w-full rounded border px-2 py-1 text-sm ${
+            excerptError ? 'border-red-400' : 'border-gray-300'
+          }`}
+          disabled={disabled}
+        />
+        <p
+          className={`mt-1 text-right text-xs ${
+            value.excerpt.length > EXCERPT_MAX
+              ? 'text-red-600'
+              : 'text-gray-500'
+          }`}
+          data-testid="metadata-excerpt-counter"
+        >
+          {value.excerpt.length} / {EXCERPT_MAX}
+        </p>
+        {excerptError && (
+          <p
+            className="mt-1 text-xs text-red-600"
+            data-testid="metadata-excerpt-error"
+          >
+            {excerptError}
+          </p>
+        )}
+      </section>
+
+      {/* Cover image */}
+      <section className="rounded-md border border-gray-200 p-4">
+        <div className="mb-1 flex items-center justify-between">
+          <label
+            htmlFor="metadata-cover"
+            className="text-sm font-semibold text-gray-700"
+          >
+            カバー画像
+          </label>
+          <button
+            type="button"
+            onClick={fillCoverFromBody}
+            className="text-xs text-blue-600 hover:underline"
+            data-testid="metadata-cover-autofill"
+            disabled={disabled}
+          >
+            本文先頭画像から
+          </button>
+        </div>
+        <input
+          id="metadata-cover"
+          type="url"
+          data-testid="metadata-cover-input"
+          value={value.coverImageUrl}
+          onChange={(e) => onChange({ coverImageUrl: e.target.value })}
+          placeholder="https://..."
+          className="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+          disabled={disabled}
+        />
+        {value.coverImageUrl && (
+          <div className="mt-2 overflow-hidden rounded border border-gray-200">
+            <img
+              src={value.coverImageUrl}
+              alt="カバー画像プレビュー"
+              data-testid="metadata-cover-preview"
+              className="block h-24 w-full object-cover"
+            />
+          </div>
+        )}
+      </section>
+
+      {/* Category */}
+      <section className="rounded-md border border-gray-200 p-4">
+        <label
+          htmlFor="metadata-category"
+          className="mb-1 block text-sm font-semibold text-gray-700"
+        >
+          カテゴリ
+        </label>
+        <select
+          id="metadata-category"
+          data-testid="post-category-select"
+          value={value.category}
+          onChange={(e) => onChange({ category: e.target.value })}
+          className="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+          disabled={disabled || categoriesLoading}
+        >
+          {categoriesLoading ? (
+            <option value="">読み込み中...</option>
+          ) : sortedCategories.length === 0 ? (
+            <option value="">カテゴリがありません</option>
+          ) : (
+            <>
+              <option value="">選択してください</option>
+              {sortedCategories.map((c) => (
+                <option key={c.slug} value={c.slug}>
+                  {c.name}
+                </option>
+              ))}
+            </>
+          )}
+        </select>
+        {categoriesError && (
+          <div className="mt-1">
+            <p className="text-xs text-red-600">{categoriesError}</p>
+            {onCategoriesRefetch && (
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={onCategoriesRefetch}
+                className="mt-1 text-xs"
+              >
+                再試行
+              </Button>
+            )}
+          </div>
+        )}
+        {isCategoryMissing && (
+          <p className="mt-1 text-xs text-yellow-600">
+            選択されているカテゴリ「{initialCategoryName}
+            」は現在利用できません。別のカテゴリを選択してください。
+          </p>
+        )}
+      </section>
+
+      {/* Tags */}
+      <section className="rounded-md border border-gray-200 p-4">
+        <label
+          htmlFor="tags"
+          className="mb-1 block text-sm font-semibold text-gray-700"
+        >
+          タグ
+        </label>
+        {value.tags.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-1" data-testid="tags-list">
+            {value.tags.map((tag, index) => (
+              <span
+                key={index}
+                className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => removeTag(index)}
+                  aria-label={`${tag}を削除`}
+                  data-testid={`remove-tag-${index}`}
+                  className="ml-1 inline-flex h-4 w-4 items-center justify-center rounded-full text-blue-400 hover:bg-blue-200 hover:text-blue-600"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="flex gap-2">
+          <input
+            id="tags"
+            type="text"
+            data-testid="tag-input"
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onKeyDown={handleTagKeyDown}
+            placeholder="Enterで追加"
+            className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm"
+            disabled={disabled}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={addTag}
+            disabled={disabled || !tagInput.trim()}
+            data-testid="add-tag-button"
+          >
+            追加
+          </Button>
+        </div>
+      </section>
+    </aside>
+  );
+};

--- a/frontend/admin/src/components/PostEditor.tsx
+++ b/frontend/admin/src/components/PostEditor.tsx
@@ -13,11 +13,14 @@ import {
   validatePostTitle,
   validatePostContent,
   validateCategory,
+  validateSlug,
+  validateExcerpt,
 } from '../utils/validation';
 import { uploadImage as defaultUploadImage } from '../api/posts';
 import { Button } from './Button';
 import { TiptapEditor, type TiptapEditorHandle } from './editor';
 import { useAutosave } from './editor/hooks/useAutosave';
+import { MetadataSidebar, type MetadataSidebarValue } from './MetadataSidebar';
 
 export interface PostData {
   title: string;
@@ -25,6 +28,11 @@ export interface PostData {
   category: string;
   tags: string[];
   publishStatus: 'draft' | 'published';
+  // PR6: writer-experience metadata. Optional so older callers/initialData
+  // shapes still type-check; PostEditor coerces to '' when absent.
+  slug?: string;
+  excerpt?: string;
+  coverImageUrl?: string;
 }
 
 export interface PostEditorHandle {
@@ -65,11 +73,6 @@ interface PostEditorProps {
   onAutosave?: (data: PostData) => Promise<void>;
 }
 
-const PUBLISH_STATUS = [
-  { value: 'draft', label: '下書き' },
-  { value: 'published', label: '公開' },
-];
-
 const MINDMAP_MARKER_PATTERN = /^\{\{mindmap:[0-9a-zA-Z-]+\}\}$/;
 
 export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
@@ -90,11 +93,6 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
   ) => {
     const tiptapRef = useRef<TiptapEditorHandle>(null);
 
-    // カテゴリをsortOrder順でソート
-    const sortedCategories = [...categories].sort(
-      (a, b) => a.sortOrder - b.sortOrder
-    );
-
     // 記事のカテゴリが一覧に存在するかチェック
     const isCategoryMissing =
       initialData?.category &&
@@ -107,17 +105,25 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
     const [contentMarkdown, setContentMarkdown] = useState(
       initialData?.contentMarkdown || ''
     );
-    const [category, setCategory] = useState(initialData?.category || '');
-    const [publishStatus, setPublishStatus] = useState<'draft' | 'published'>(
-      initialData?.publishStatus || 'draft'
-    );
-    const [tags, setTags] = useState<string[]>(initialData?.tags || []);
-    const [tagInput, setTagInput] = useState('');
     const [editorMode, setEditorMode] = useState<'edit' | 'preview'>('edit');
+
+    // PR6: metadata fields managed alongside title/body. The MetadataSidebar
+    // is a controlled component; PostEditor owns the state.
+    const [meta, setMeta] = useState<MetadataSidebarValue>(() => ({
+      slug: initialData?.slug ?? '',
+      excerpt: initialData?.excerpt ?? '',
+      coverImageUrl: initialData?.coverImageUrl ?? '',
+      category: initialData?.category ?? '',
+      tags: initialData?.tags ?? [],
+      publishStatus: initialData?.publishStatus ?? 'draft',
+      // Lock slug if initialData provided one (writer already chose it).
+      slugLocked: Boolean(initialData?.slug),
+    }));
 
     const [titleError, setTitleError] = useState<string | null>(null);
     const [contentError, setContentError] = useState<string | null>(null);
     const [categoryError, setCategoryError] = useState<string | null>(null);
+    const [metadataError, setMetadataError] = useState<string | null>(null);
 
     const [isSaving, setIsSaving] = useState(false);
 
@@ -142,9 +148,12 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
     const autosaveData: PostData = {
       title,
       contentMarkdown,
-      category,
-      tags,
-      publishStatus,
+      category: meta.category,
+      tags: meta.tags,
+      publishStatus: meta.publishStatus,
+      slug: meta.slug || undefined,
+      excerpt: meta.excerpt || undefined,
+      coverImageUrl: meta.coverImageUrl || undefined,
     };
     const noopAutosave = useRef(async () => {}).current;
     const autosave = useAutosave<PostData>({
@@ -226,42 +235,29 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
       []
     );
 
-    // タグ追加ハンドラ
-    const addTag = () => {
-      const trimmedTag = tagInput.trim();
-      if (trimmedTag && !tags.includes(trimmedTag)) {
-        setTags([...tags, trimmedTag]);
-        setTagInput('');
-      }
-    };
-
-    // タグ入力キーダウンハンドラ
-    const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter' || e.key === ',') {
-        e.preventDefault();
-        addTag();
-      }
-    };
-
-    // タグ削除ハンドラ
-    const removeTag = (indexToRemove: number) => {
-      setTags(tags.filter((_, index) => index !== indexToRemove));
-    };
-
     const handleSubmit = async (e: FormEvent) => {
       e.preventDefault();
 
       // バリデーション
       const titleValidation = validatePostTitle(title);
       const contentValidation = validatePostContent(contentMarkdown);
-      const categoryValidation = validateCategory(category);
+      const categoryValidation = validateCategory(meta.category);
+      const slugValidation = validateSlug(meta.slug);
+      const excerptValidation = validateExcerpt(meta.excerpt);
 
       setTitleError(titleValidation);
       setContentError(contentValidation);
       setCategoryError(categoryValidation);
+      setMetadataError(slugValidation || excerptValidation);
 
       // エラーがある場合は送信しない
-      if (titleValidation || contentValidation || categoryValidation) {
+      if (
+        titleValidation ||
+        contentValidation ||
+        categoryValidation ||
+        slugValidation ||
+        excerptValidation
+      ) {
         return;
       }
 
@@ -271,9 +267,12 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
         await onSave({
           title,
           contentMarkdown,
-          category,
-          tags,
-          publishStatus,
+          category: meta.category,
+          tags: meta.tags,
+          publishStatus: meta.publishStatus,
+          slug: meta.slug || undefined,
+          excerpt: meta.excerpt || undefined,
+          coverImageUrl: meta.coverImageUrl || undefined,
         });
         // autosave hook の baseline を現在値に揃える
         // (これがないと explicit save 後も isDirty=true のままになる)
@@ -299,210 +298,162 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
     };
 
     return (
-      <form onSubmit={handleSubmit} className="space-y-6">
-        {/* タイトル */}
-        <div>
-          <label
-            htmlFor="title"
-            className="block text-sm font-medium text-gray-700 mb-1"
-          >
-            タイトル
-          </label>
-          <input
-            id="title"
-            data-testid="post-title-input"
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            disabled={isSaving}
-          />
-          {titleError && (
-            <p
-              className="mt-1 text-sm text-red-600"
-              data-testid="validation-error"
-            >
-              {titleError}
-            </p>
-          )}
-        </div>
-
-        {/* 本文 */}
-        <div>
-          <div className="flex items-center justify-between mb-1">
+      <form
+        onSubmit={handleSubmit}
+        className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]"
+      >
+        <div className="space-y-6">
+          {/* タイトル */}
+          <div>
             <label
-              htmlFor="content"
-              className="block text-sm font-medium text-gray-700"
+              htmlFor="title"
+              className="block text-sm font-medium text-gray-700 mb-1"
             >
-              本文
+              タイトル
             </label>
-            <div className="flex items-center gap-2">
-              {/* Edit / Preview タブ */}
-              <div
-                role="tablist"
-                aria-label="本文表示モード"
-                className="inline-flex border border-gray-300 rounded-md overflow-hidden"
+            <input
+              id="title"
+              data-testid="post-title-input"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              disabled={isSaving}
+            />
+            {titleError && (
+              <p
+                className="mt-1 text-sm text-red-600"
+                data-testid="validation-error"
               >
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={editorMode === 'edit'}
-                  data-testid="editor-tab-edit"
-                  onClick={() => setEditorMode('edit')}
-                  className={`px-3 py-1 text-sm ${
-                    editorMode === 'edit'
-                      ? 'bg-blue-500 text-white'
-                      : 'bg-white text-gray-700 hover:bg-gray-50'
-                  }`}
-                  disabled={isSaving}
-                >
-                  編集
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={editorMode === 'preview'}
-                  data-testid="editor-tab-preview"
-                  onClick={() => setEditorMode('preview')}
-                  className={`px-3 py-1 text-sm ${
-                    editorMode === 'preview'
-                      ? 'bg-blue-500 text-white'
-                      : 'bg-white text-gray-700 hover:bg-gray-50'
-                  }`}
-                  disabled={isSaving}
-                >
-                  プレビュー
-                </button>
-              </div>
-              {onMindmapInsertClick && (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={onMindmapInsertClick}
-                  disabled={isSaving}
-                  data-testid="mindmap-insert-button"
-                  className="text-sm"
-                >
-                  マインドマップ挿入
-                </Button>
-              )}
-            </div>
-          </div>
-          {uploadError && (
-            <div
-              role="alert"
-              data-testid="image-upload-error"
-              className="mb-2 flex items-start justify-between gap-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700"
-            >
-              <span>{uploadError.message}</span>
-              <div className="flex shrink-0 gap-2">
-                <button
-                  type="button"
-                  data-testid="image-upload-retry"
-                  className="text-red-700 underline hover:text-red-900"
-                  onClick={() => {
-                    const retry = uploadError.retry;
-                    setUploadError(null);
-                    retry();
-                  }}
-                >
-                  再試行
-                </button>
-                <button
-                  type="button"
-                  aria-label="エラーを閉じる"
-                  className="text-red-700 hover:text-red-900"
-                  onClick={() => setUploadError(null)}
-                >
-                  ×
-                </button>
-              </div>
-            </div>
-          )}
-          <div className="relative">
-            <div hidden={editorMode !== 'edit'}>
-              <TiptapEditor
-                ref={tiptapRef}
-                value={contentMarkdown}
-                onChange={setContentMarkdown}
-                uploadFn={uploadFn}
-                onUploadError={handleUploadError}
-                disabled={isSaving}
-              />
-            </div>
-            {editorMode === 'preview' && (
-              <div
-                data-testid="markdown-preview"
-                className="post-content max-w-none p-4 border border-gray-300 rounded-md bg-gray-50 min-h-[400px]"
-              >
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                  {contentMarkdown || '*プレビューがここに表示されます*'}
-                </ReactMarkdown>
-              </div>
+                {titleError}
+              </p>
             )}
           </div>
-          {contentError && (
-            <p
-              className="mt-1 text-sm text-red-600"
-              data-testid="validation-error"
-            >
-              {contentError}
-            </p>
-          )}
-        </div>
 
-        {/* カテゴリ */}
-        <div>
-          <label
-            htmlFor="category"
-            className="block text-sm font-medium text-gray-700 mb-1"
-          >
-            カテゴリ
-          </label>
-          <select
-            id="category"
-            data-testid="post-category-select"
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            disabled={isSaving || categoriesLoading}
-          >
-            {categoriesLoading ? (
-              <option value="">読み込み中...</option>
-            ) : sortedCategories.length === 0 ? (
-              <option value="">カテゴリがありません</option>
-            ) : (
-              <>
-                <option value="">選択してください</option>
-                {sortedCategories.map((cat) => (
-                  <option key={cat.slug} value={cat.slug}>
-                    {cat.name}
-                  </option>
-                ))}
-              </>
-            )}
-          </select>
-          {categoriesError && (
-            <div className="mt-1">
-              <p className="text-sm text-red-600">{categoriesError}</p>
-              {onCategoriesRefetch && (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={onCategoriesRefetch}
-                  className="mt-1 text-sm"
+          {/* 本文 */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label
+                htmlFor="content"
+                className="block text-sm font-medium text-gray-700"
+              >
+                本文
+              </label>
+              <div className="flex items-center gap-2">
+                {/* Edit / Preview タブ */}
+                <div
+                  role="tablist"
+                  aria-label="本文表示モード"
+                  className="inline-flex border border-gray-300 rounded-md overflow-hidden"
                 >
-                  再試行
-                </Button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={editorMode === 'edit'}
+                    data-testid="editor-tab-edit"
+                    onClick={() => setEditorMode('edit')}
+                    className={`px-3 py-1 text-sm ${
+                      editorMode === 'edit'
+                        ? 'bg-blue-500 text-white'
+                        : 'bg-white text-gray-700 hover:bg-gray-50'
+                    }`}
+                    disabled={isSaving}
+                  >
+                    編集
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={editorMode === 'preview'}
+                    data-testid="editor-tab-preview"
+                    onClick={() => setEditorMode('preview')}
+                    className={`px-3 py-1 text-sm ${
+                      editorMode === 'preview'
+                        ? 'bg-blue-500 text-white'
+                        : 'bg-white text-gray-700 hover:bg-gray-50'
+                    }`}
+                    disabled={isSaving}
+                  >
+                    プレビュー
+                  </button>
+                </div>
+                {onMindmapInsertClick && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={onMindmapInsertClick}
+                    disabled={isSaving}
+                    data-testid="mindmap-insert-button"
+                    className="text-sm"
+                  >
+                    マインドマップ挿入
+                  </Button>
+                )}
+              </div>
+            </div>
+            {uploadError && (
+              <div
+                role="alert"
+                data-testid="image-upload-error"
+                className="mb-2 flex items-start justify-between gap-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700"
+              >
+                <span>{uploadError.message}</span>
+                <div className="flex shrink-0 gap-2">
+                  <button
+                    type="button"
+                    data-testid="image-upload-retry"
+                    className="text-red-700 underline hover:text-red-900"
+                    onClick={() => {
+                      const retry = uploadError.retry;
+                      setUploadError(null);
+                      retry();
+                    }}
+                  >
+                    再試行
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="エラーを閉じる"
+                    className="text-red-700 hover:text-red-900"
+                    onClick={() => setUploadError(null)}
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+            )}
+            <div className="relative">
+              <div hidden={editorMode !== 'edit'}>
+                <TiptapEditor
+                  ref={tiptapRef}
+                  value={contentMarkdown}
+                  onChange={setContentMarkdown}
+                  uploadFn={uploadFn}
+                  onUploadError={handleUploadError}
+                  disabled={isSaving}
+                />
+              </div>
+              {editorMode === 'preview' && (
+                <div
+                  data-testid="markdown-preview"
+                  className="post-content max-w-none p-4 border border-gray-300 rounded-md bg-gray-50 min-h-[400px]"
+                >
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {contentMarkdown || '*プレビューがここに表示されます*'}
+                  </ReactMarkdown>
+                </div>
               )}
             </div>
-          )}
-          {isCategoryMissing && (
-            <p className="mt-1 text-sm text-yellow-600">
-              選択されているカテゴリ「{initialData?.category}
-              」は現在利用できません。別のカテゴリを選択してください。
-            </p>
-          )}
+            {contentError && (
+              <p
+                className="mt-1 text-sm text-red-600"
+                data-testid="validation-error"
+              >
+                {contentError}
+              </p>
+            )}
+          </div>
+
           {categoryError && (
             <p
               className="mt-1 text-sm text-red-600"
@@ -511,133 +462,71 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
               {categoryError}
             </p>
           )}
-        </div>
-
-        {/* タグ */}
-        <div>
-          <label
-            htmlFor="tags"
-            className="block text-sm font-medium text-gray-700 mb-1"
-          >
-            タグ
-          </label>
-          {/* タグ一覧 */}
-          {tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mb-2" data-testid="tags-list">
-              {tags.map((tag, index) => (
-                <span
-                  key={index}
-                  className="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-blue-100 text-blue-800"
-                >
-                  {tag}
-                  <button
-                    type="button"
-                    onClick={() => removeTag(index)}
-                    className="ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-blue-400 hover:bg-blue-200 hover:text-blue-600 focus:outline-none"
-                    aria-label={`${tag}を削除`}
-                    data-testid={`remove-tag-${index}`}
-                  >
-                    ×
-                  </button>
-                </span>
-              ))}
-            </div>
+          {metadataError && (
+            <p
+              className="mt-1 text-sm text-red-600"
+              data-testid="validation-error"
+            >
+              {metadataError}
+            </p>
           )}
-          {/* タグ入力 */}
-          <div className="flex gap-2">
-            <input
-              id="tags"
-              type="text"
-              value={tagInput}
-              onChange={(e) => setTagInput(e.target.value)}
-              onKeyDown={handleTagKeyDown}
-              placeholder="タグを入力してEnterで追加"
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+
+          {/* ボタン + autosave ステータス */}
+          <div className="flex items-center gap-3">
+            <Button
+              type="submit"
+              variant="primary"
               disabled={isSaving}
-              data-testid="tag-input"
-            />
+              data-testid={
+                meta.publishStatus === 'published'
+                  ? 'publish-button'
+                  : 'save-draft-button'
+              }
+            >
+              {isSaving ? '保存中...' : '保存'}
+            </Button>
             <Button
               type="button"
               variant="secondary"
-              onClick={addTag}
-              disabled={isSaving || !tagInput.trim()}
-              data-testid="add-tag-button"
+              onClick={handleCancelClick}
+              disabled={isSaving}
+              data-testid="cancel-button"
             >
-              追加
+              キャンセル
             </Button>
+            {onAutosave && (
+              <span
+                data-testid="autosave-status"
+                data-autosave-status={autosave.status}
+                className={`ml-auto text-sm ${
+                  autosave.status === 'error'
+                    ? 'text-red-600'
+                    : autosave.status === 'saving'
+                      ? 'text-blue-600'
+                      : autosave.status === 'saved'
+                        ? 'text-gray-500'
+                        : 'text-gray-400'
+                }`}
+                aria-live="polite"
+              >
+                {autosave.savedAgoLabel}
+              </span>
+            )}
           </div>
-          <p className="mt-1 text-xs text-gray-500">
-            Enterキーまたはカンマで追加
-          </p>
         </div>
-
-        {/* 公開状態 */}
-        <div>
-          <label
-            htmlFor="publishStatus"
-            className="block text-sm font-medium text-gray-700 mb-1"
-          >
-            公開状態
-          </label>
-          <select
-            id="publishStatus"
-            value={publishStatus}
-            onChange={(e) =>
-              setPublishStatus(e.target.value as 'draft' | 'published')
-            }
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            disabled={isSaving}
-          >
-            {PUBLISH_STATUS.map((status) => (
-              <option key={status.value} value={status.value}>
-                {status.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        {/* ボタン + autosave ステータス */}
-        <div className="flex items-center gap-3">
-          <Button
-            type="submit"
-            variant="primary"
-            disabled={isSaving}
-            data-testid={
-              publishStatus === 'published'
-                ? 'publish-button'
-                : 'save-draft-button'
-            }
-          >
-            {isSaving ? '保存中...' : '保存'}
-          </Button>
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={handleCancelClick}
-            disabled={isSaving}
-            data-testid="cancel-button"
-          >
-            キャンセル
-          </Button>
-          {onAutosave && (
-            <span
-              data-testid="autosave-status"
-              data-autosave-status={autosave.status}
-              className={`ml-auto text-sm ${
-                autosave.status === 'error'
-                  ? 'text-red-600'
-                  : autosave.status === 'saving'
-                    ? 'text-blue-600'
-                    : autosave.status === 'saved'
-                      ? 'text-gray-500'
-                      : 'text-gray-400'
-              }`}
-              aria-live="polite"
-            >
-              {autosave.savedAgoLabel}
-            </span>
-          )}
-        </div>
+        <MetadataSidebar
+          value={meta}
+          onChange={(p) => setMeta((prev) => ({ ...prev, ...p }))}
+          title={title}
+          contentMarkdown={contentMarkdown}
+          categories={categories}
+          categoriesLoading={categoriesLoading}
+          categoriesError={categoriesError}
+          onCategoriesRefetch={onCategoriesRefetch}
+          disabled={isSaving}
+          isCategoryMissing={Boolean(isCategoryMissing)}
+          initialCategoryName={initialData?.category}
+        />
       </form>
     );
   }

--- a/frontend/admin/src/main.tsx
+++ b/frontend/admin/src/main.tsx
@@ -24,6 +24,14 @@ async function enableMocking() {
     const { worker } = await import('./mocks/browser');
     console.log('[main.tsx] MSW worker imported successfully');
 
+    // PR6: expose mockPosts to Playwright for tests that need to seed
+    // browser-side mock state (e.g. slug uniqueness conflict). Only available
+    // when MSW is enabled, so it's safe to leave in the bundle.
+    const mockData = await import('../../../tests/e2e/mocks/mockData');
+    (
+      window as unknown as { __e2eMockPosts?: typeof mockData.mockPosts }
+    ).__e2eMockPosts = mockData.mockPosts;
+
     // MSWワーカーを起動（コンソール警告を抑制）
     await worker.start({
       onUnhandledRequest: 'bypass', // モックされていないリクエストは通過させる

--- a/frontend/admin/src/pages/PostCreatePage.tsx
+++ b/frontend/admin/src/pages/PostCreatePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import {
   PostEditor,
   type PostData,
@@ -53,6 +54,13 @@ const PostCreatePage = () => {
       navigate('/posts');
     } catch (err) {
       console.error('記事作成エラー:', err);
+      // PR6: surface server-side slug conflict so the writer knows to change it.
+      if (axios.isAxiosError(err) && err.response?.status === 409) {
+        setError(
+          err.response.data?.message ?? 'この slug は既に使われています'
+        );
+        return;
+      }
       setError('記事の作成に失敗しました');
       // エラーを再スローしない（unhandled promiseエラーを防ぐ）
     }

--- a/frontend/admin/src/pages/PostEditPage.tsx
+++ b/frontend/admin/src/pages/PostEditPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import {
   PostEditor,
   type PostData,
@@ -48,6 +49,9 @@ const PostEditPage = () => {
           category: post.category,
           tags: post.tags || [],
           publishStatus: post.publishStatus,
+          slug: post.slug ?? '',
+          excerpt: post.excerpt ?? '',
+          coverImageUrl: post.coverImageUrl ?? '',
         });
       } catch (err) {
         console.error('記事取得エラー:', err);
@@ -73,6 +77,12 @@ const PostEditPage = () => {
       navigate('/posts');
     } catch (err) {
       console.error('記事更新エラー:', err);
+      if (axios.isAxiosError(err) && err.response?.status === 409) {
+        setError(
+          err.response.data?.message ?? 'この slug は既に使われています'
+        );
+        return;
+      }
       setError('記事の更新に失敗しました');
       // エラーは再スローしない（UIでエラーメッセージを表示するのみ）
     }

--- a/frontend/admin/src/utils/postDefaults.test.ts
+++ b/frontend/admin/src/utils/postDefaults.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  slugify,
+  excerptFromMarkdown,
+  coverFromMarkdown,
+} from './postDefaults';
+
+describe('slugify', () => {
+  it('plainなASCIIタイトルをkebab-caseに変換', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('連続したスペース・記号は単一ハイフンに正規化', () => {
+    expect(slugify('Hello   World!?')).toBe('hello-world');
+  });
+
+  it('80文字制限で切り詰め', () => {
+    const long = 'a-'.repeat(60); // 120 chars
+    const out = slugify(long);
+    expect(out.length).toBeLessThanOrEqual(80);
+    expect(out).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it('空タイトルでは6文字のフォールバックトークンを返す', () => {
+    const out = slugify('');
+    expect(out).toMatch(/^[a-z0-9]{6}$/);
+  });
+
+  it('日本語のみのタイトルではフォールバックトークン', () => {
+    const out = slugify('こんにちは世界');
+    expect(out).toMatch(/^[a-z0-9]{6}$/);
+  });
+
+  it('日本語と英字の混在タイトルは英字部分を採用', () => {
+    expect(slugify('Hello 世界')).toBe('hello');
+  });
+});
+
+describe('excerptFromMarkdown', () => {
+  it('空文字列は空のまま', () => {
+    expect(excerptFromMarkdown('')).toBe('');
+  });
+
+  it('見出しと段落から本文だけを残す', () => {
+    expect(excerptFromMarkdown('# Title\n\nThis is **bold** body.')).toBe(
+      'Title This is bold body.'
+    );
+  });
+
+  it('画像とリンクを処理する', () => {
+    expect(
+      excerptFromMarkdown(
+        'Look at ![alt](http://x/y.png) and [click](http://z)'
+      )
+    ).toBe('Look at and click');
+  });
+
+  it('コードブロックは除去', () => {
+    expect(excerptFromMarkdown('Hi\n\n```js\nconst a = 1;\n```\n\nbye')).toBe(
+      'Hi bye'
+    );
+  });
+
+  it('160文字を超えると切り詰め', () => {
+    const long = 'a '.repeat(120);
+    const out = excerptFromMarkdown(long);
+    expect(out.length).toBeLessThanOrEqual(160);
+  });
+
+  it('インラインコードは中身を残す', () => {
+    expect(excerptFromMarkdown('use `bun` not `npm`')).toBe('use bun not npm');
+  });
+});
+
+describe('coverFromMarkdown', () => {
+  it('画像が無いとnull', () => {
+    expect(coverFromMarkdown('plain text only')).toBeNull();
+  });
+
+  it('最初の画像URLを抽出', () => {
+    expect(coverFromMarkdown('a ![cap](https://cdn/x.jpg) b')).toBe(
+      'https://cdn/x.jpg'
+    );
+  });
+
+  it('複数あっても最初のURLだけ返す', () => {
+    const md = '![](a.jpg)\n\n![](b.jpg)';
+    expect(coverFromMarkdown(md)).toBe('a.jpg');
+  });
+
+  it('空文字列はnull', () => {
+    expect(coverFromMarkdown('')).toBeNull();
+  });
+});

--- a/frontend/admin/src/utils/postDefaults.ts
+++ b/frontend/admin/src/utils/postDefaults.ts
@@ -1,0 +1,104 @@
+// PR6: defaults derived from a draft's title / contentMarkdown so the editor
+// can pre-fill metadata sidebar fields (slug / excerpt / cover) without the
+// writer having to do it manually.
+//
+// These helpers run client-side only. The server (`internal/domain.GenerateSlug`)
+// is the canonical normalizer, but this TS slugify is good enough for live UI
+// preview: it ASCII-folds, lowercases, kebab-cases, and falls back to a short
+// random token when the title is non-Latin (Japanese, etc.).
+
+const SLUG_MAX_LENGTH = 80;
+const EXCERPT_MAX_LENGTH = 160;
+const FALLBACK_TOKEN_LENGTH = 6;
+
+const NON_SLUG_CHAR = /[^a-z0-9-]+/g;
+const MULTI_HYPHEN = /-+/g;
+const TRIM_HYPHEN = /^-+|-+$/g;
+
+const MARKDOWN_HEADING = /^#{1,6}\s+/gm;
+const MARKDOWN_FENCED_CODE = /```[\s\S]*?```/g;
+const MARKDOWN_INLINE_CODE = /`([^`]+)`/g;
+const MARKDOWN_IMAGE = /!\[[^\]]*\]\([^)]+\)/g;
+const MARKDOWN_LINK = /\[([^\]]+)\]\([^)]+\)/g;
+const MARKDOWN_BOLD_ITALIC = /(\*\*|__|\*|_)/g;
+const MARKDOWN_BLOCKQUOTE = /^>\s?/gm;
+const MARKDOWN_LIST_MARKER = /^\s*[-*+]\s+/gm;
+const MARKDOWN_HORIZONTAL_RULE = /^\s*-{3,}\s*$/gm;
+const COLLAPSE_WHITESPACE = /\s+/g;
+
+const FIRST_IMAGE = /!\[[^\]]*\]\(([^)\s]+)/;
+
+/**
+ * Generate a small random token to use when the title produces no usable
+ * ASCII characters. Uses crypto.randomUUID when available; otherwise falls
+ * back to Math.random (e.g. http dev server, jsdom).
+ */
+const randomToken = (): string => {
+  const cryptoObj =
+    typeof globalThis !== 'undefined'
+      ? (globalThis as { crypto?: Crypto }).crypto
+      : undefined;
+  if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+    return cryptoObj
+      .randomUUID()
+      .replace(/-/g, '')
+      .slice(0, FALLBACK_TOKEN_LENGTH);
+  }
+  return Math.random()
+    .toString(36)
+    .slice(2, 2 + FALLBACK_TOKEN_LENGTH);
+};
+
+/**
+ * Convert a title to a kebab-case slug suitable as a URL path segment.
+ * Non-Latin titles fold to nothing → return a 6-char random token so the
+ * writer always has *some* default they can edit or regenerate.
+ */
+export const slugify = (title: string): string => {
+  if (!title) return randomToken();
+  const folded = title
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '') // strip combining marks
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(NON_SLUG_CHAR, '-')
+    .replace(MULTI_HYPHEN, '-')
+    .replace(TRIM_HYPHEN, '');
+  if (!folded) return randomToken();
+  return folded.length > SLUG_MAX_LENGTH
+    ? folded.slice(0, SLUG_MAX_LENGTH).replace(TRIM_HYPHEN, '')
+    : folded;
+};
+
+/**
+ * Strip Markdown markup and return the leading 160 chars of plain text.
+ * Used to pre-fill the excerpt sidebar field. Empty input returns ''.
+ */
+export const excerptFromMarkdown = (md: string): string => {
+  if (!md) return '';
+  const stripped = md
+    .replace(MARKDOWN_FENCED_CODE, '')
+    .replace(MARKDOWN_HORIZONTAL_RULE, '')
+    .replace(MARKDOWN_HEADING, '')
+    .replace(MARKDOWN_BLOCKQUOTE, '')
+    .replace(MARKDOWN_LIST_MARKER, '')
+    .replace(MARKDOWN_IMAGE, '')
+    .replace(MARKDOWN_LINK, '$1')
+    .replace(MARKDOWN_INLINE_CODE, '$1')
+    .replace(MARKDOWN_BOLD_ITALIC, '')
+    .replace(COLLAPSE_WHITESPACE, ' ')
+    .trim();
+  return stripped.length > EXCERPT_MAX_LENGTH
+    ? stripped.slice(0, EXCERPT_MAX_LENGTH).trimEnd()
+    : stripped;
+};
+
+/**
+ * Extract the URL of the first inline image in markdown, or null if absent.
+ * Used to pre-fill the cover image sidebar field.
+ */
+export const coverFromMarkdown = (md: string): string | null => {
+  if (!md) return null;
+  const m = FIRST_IMAGE.exec(md);
+  return m && m[1] ? m[1] : null;
+};

--- a/frontend/admin/src/utils/validation.test.ts
+++ b/frontend/admin/src/utils/validation.test.ts
@@ -3,6 +3,8 @@ import {
   validatePostTitle,
   validatePostContent,
   validateCategory,
+  validateSlug,
+  validateExcerpt,
 } from './validation';
 
 describe('validatePostTitle', () => {
@@ -65,5 +67,55 @@ describe('validateCategory', () => {
     expect(validateCategory('tech')).toBeNull();
     expect(validateCategory('Think')).toBeNull();
     expect(validateCategory('custom-category')).toBeNull();
+  });
+});
+
+describe('validateSlug', () => {
+  it('空文字列はnullを返す（自動生成フォールバック）', () => {
+    expect(validateSlug('')).toBeNull();
+  });
+
+  it('kebab-caseの正しいslugはnullを返す', () => {
+    expect(validateSlug('hello-world')).toBeNull();
+    expect(validateSlug('post-2026')).toBeNull();
+    expect(validateSlug('a')).toBeNull();
+  });
+
+  it('大文字を含むslugはエラーを返す', () => {
+    expect(validateSlug('Hello-World')).toBe(
+      'slug は英小文字・数字・ハイフンのみ使用できます'
+    );
+  });
+
+  it('スペースを含むslugはエラーを返す', () => {
+    expect(validateSlug('hello world')).toBe(
+      'slug は英小文字・数字・ハイフンのみ使用できます'
+    );
+  });
+
+  it('80文字を超えるslugはエラーを返す', () => {
+    expect(validateSlug('a'.repeat(81))).toBe(
+      'slug は 80 文字以内で入力してください'
+    );
+  });
+
+  it('80文字ちょうどはnullを返す', () => {
+    expect(validateSlug('a'.repeat(80))).toBeNull();
+  });
+});
+
+describe('validateExcerpt', () => {
+  it('空文字列はnullを返す', () => {
+    expect(validateExcerpt('')).toBeNull();
+  });
+
+  it('160文字以内はnullを返す', () => {
+    expect(validateExcerpt('a'.repeat(160))).toBeNull();
+  });
+
+  it('161文字以上はエラーを返す', () => {
+    expect(validateExcerpt('a'.repeat(161))).toBe(
+      '概要は 160 文字以内で入力してください'
+    );
   });
 });

--- a/frontend/admin/src/utils/validation.ts
+++ b/frontend/admin/src/utils/validation.ts
@@ -40,3 +40,34 @@ export const validateCategory = (category: string): string | null => {
   }
   return null;
 };
+
+// kebab-case (lowercase a-z, digits, hyphen). Mirror of go domain.slugPattern.
+const SLUG_PATTERN = /^[a-z0-9-]+$/;
+const SLUG_MAX_LENGTH = 80;
+const EXCERPT_MAX_LENGTH = 160;
+
+/**
+ * Slug のバリデーション。空欄は許容（未入力 = 自動生成にフォールバック）。
+ */
+export const validateSlug = (slug: string): string | null => {
+  if (slug === '') {
+    return null;
+  }
+  if (slug.length > SLUG_MAX_LENGTH) {
+    return `slug は ${SLUG_MAX_LENGTH} 文字以内で入力してください`;
+  }
+  if (!SLUG_PATTERN.test(slug)) {
+    return 'slug は英小文字・数字・ハイフンのみ使用できます';
+  }
+  return null;
+};
+
+/**
+ * 概要文 (excerpt) のバリデーション。空欄は許容。
+ */
+export const validateExcerpt = (excerpt: string): string | null => {
+  if (excerpt.length > EXCERPT_MAX_LENGTH) {
+    return `概要は ${EXCERPT_MAX_LENGTH} 文字以内で入力してください`;
+  }
+  return null;
+};

--- a/go-functions/cmd/posts/create/main.go
+++ b/go-functions/cmd/posts/create/main.go
@@ -18,8 +18,10 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/google/uuid"
 
 	"serverless-blog/go-functions/internal/buildtrigger"
@@ -32,6 +34,15 @@ import (
 // DynamoDBClientInterface defines the interface for DynamoDB operations (for testing)
 type DynamoDBClientInterface interface {
 	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+// slugIndexName returns the SlugIndex GSI name (overridable via env for tests).
+func slugIndexName() string {
+	if v := os.Getenv("SLUG_INDEX_NAME"); v != "" {
+		return v
+	}
+	return "SlugIndex"
 }
 
 // dynamoClientGetter is a function that returns the DynamoDB client
@@ -54,7 +65,9 @@ var uuidGenerator = func() string {
 	return uuid.New().String()
 }
 
-// Handler handles POST /posts requests
+// Handler handles POST /posts requests.
+//
+//nolint:gocyclo // validates auth, body, slug uniqueness, and triggers CodeBuild — branches add up but flow is linear.
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Extract author ID from Cognito claims (authentication check)
 	authorID := extractAuthorID(request)
@@ -89,6 +102,18 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	dynamoClient, err := dynamoClientGetter()
 	if err != nil {
 		return errorResponse(500, "server error")
+	}
+
+	// PR6: enforce slug uniqueness server-side. Slug regex was already
+	// validated by req.Validate(); now reject if another post owns it.
+	if req.Slug != nil {
+		exists, slugErr := checkSlugExists(ctx, dynamoClient, tableName, *req.Slug)
+		if slugErr != nil {
+			return errorResponse(500, "failed to check slug uniqueness")
+		}
+		if exists {
+			return errorResponse(409, "post with this slug already exists")
+		}
 	}
 
 	// Generate UUID and timestamps
@@ -127,6 +152,9 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		UpdatedAt:       now,
 		PublishedAt:     publishedAt,
 		ImageURLs:       imageURLs,
+		Slug:            req.Slug,
+		Excerpt:         req.Excerpt,
+		CoverImageURL:   req.CoverImageURL,
 	}
 
 	// Marshal to DynamoDB attribute value
@@ -214,6 +242,24 @@ func triggerSiteBuild(ctx context.Context) {
 
 	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
+}
+
+// checkSlugExists returns true if any BlogPost item already owns the given slug.
+// Uses the SlugIndex GSI for an O(1) point lookup.
+func checkSlugExists(ctx context.Context, client DynamoDBClientInterface, tableName, slug string) (bool, error) {
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		IndexName:              aws.String(slugIndexName()),
+		KeyConditionExpression: aws.String("slug = :slug"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":slug": &types.AttributeValueMemberS{Value: slug},
+		},
+		Limit: aws.Int32(1),
+	})
+	if err != nil {
+		return false, err
+	}
+	return out.Count > 0, nil
 }
 
 func main() {

--- a/go-functions/cmd/posts/create/main_test.go
+++ b/go-functions/cmd/posts/create/main_test.go
@@ -24,6 +24,7 @@ const (
 // MockDynamoDBClient is a mock implementation of DynamoDBClientInterface
 type MockDynamoDBClient struct {
 	PutItemFunc func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	QueryFunc   func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
 }
 
 func (m *MockDynamoDBClient) PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
@@ -31,6 +32,15 @@ func (m *MockDynamoDBClient) PutItem(ctx context.Context, params *dynamodb.PutIt
 		return m.PutItemFunc(ctx, params, optFns...)
 	}
 	return nil, errors.New("PutItemFunc not set")
+}
+
+// Query returns an empty result by default so tests that don't exercise slug
+// uniqueness don't have to wire it up.
+func (m *MockDynamoDBClient) Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	if m.QueryFunc != nil {
+		return m.QueryFunc(ctx, params, optFns...)
+	}
+	return &dynamodb.QueryOutput{Count: 0}, nil
 }
 
 // MockMarkdownConverter is a mock implementation of MarkdownConverterFunc
@@ -1799,4 +1809,185 @@ func TestTriggerSiteBuild_CodeBuildClientInitError(t *testing.T) {
 	// triggerSiteBuild should not panic and should handle error gracefully
 	triggerSiteBuild(context.Background())
 	// No error expected - just an error log
+}
+
+// =============================================================================
+// PR6: Slug uniqueness + Slug/Excerpt/CoverImageURL persistence
+// =============================================================================
+
+func ptr[T any](v T) *T { return &v }
+
+// TestHandler_SlugProvided_QueriesSlugIndex verifies that supplying a slug
+// triggers a SlugIndex Query before PutItem.
+func TestHandler_SlugProvided_QueriesSlugIndex(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	queryCalled := false
+	mockClient := &MockDynamoDBClient{
+		PutItemFunc: func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			return &dynamodb.PutItemOutput{}, nil
+		},
+		QueryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			queryCalled = true
+			if params.IndexName == nil || *params.IndexName != "SlugIndex" {
+				t.Errorf("expected IndexName SlugIndex, got %v", params.IndexName)
+			}
+			return &dynamodb.QueryOutput{Count: 0}, nil
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+	uuidGenerator = func() string { return "uid" }
+
+	body, _ := json.Marshal(domain.CreatePostRequest{
+		Title: "T", ContentMarkdown: "B", Category: "tech",
+		Slug: ptr("my-slug"),
+	})
+	resp, _ := Handler(context.Background(), events.APIGatewayProxyRequest{
+		Body: string(body),
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{"claims": map[string]interface{}{"sub": testAuthorID}},
+		},
+	})
+	if resp.StatusCode != 201 {
+		t.Fatalf("expected 201, got %d (body=%s)", resp.StatusCode, resp.Body)
+	}
+	if !queryCalled {
+		t.Error("expected Query to be called when slug is provided")
+	}
+}
+
+// TestHandler_SlugConflict_Returns409 verifies that an existing slug yields 409.
+func TestHandler_SlugConflict_Returns409(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	mockClient := &MockDynamoDBClient{
+		PutItemFunc: func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			t.Error("PutItem should not be called when slug conflicts")
+			return &dynamodb.PutItemOutput{}, nil
+		},
+		QueryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return &dynamodb.QueryOutput{Count: 1, Items: []map[string]types.AttributeValue{
+				{"id": &types.AttributeValueMemberS{Value: "other-id"}},
+			}}, nil
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+	uuidGenerator = func() string { return "uid" }
+
+	body, _ := json.Marshal(domain.CreatePostRequest{
+		Title: "T", ContentMarkdown: "B", Category: "tech",
+		Slug: ptr("taken-slug"),
+	})
+	resp, _ := Handler(context.Background(), events.APIGatewayProxyRequest{
+		Body: string(body),
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{"claims": map[string]interface{}{"sub": testAuthorID}},
+		},
+	})
+	if resp.StatusCode != 409 {
+		t.Errorf("expected 409, got %d (body=%s)", resp.StatusCode, resp.Body)
+	}
+}
+
+// TestHandler_SlugQueryError_Returns500 verifies error path.
+func TestHandler_SlugQueryError_Returns500(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	mockClient := &MockDynamoDBClient{
+		QueryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return nil, errors.New("ddb down")
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+	uuidGenerator = func() string { return "uid" }
+
+	body, _ := json.Marshal(domain.CreatePostRequest{
+		Title: "T", ContentMarkdown: "B", Category: "tech",
+		Slug: ptr("my-slug"),
+	})
+	resp, _ := Handler(context.Background(), events.APIGatewayProxyRequest{
+		Body: string(body),
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{"claims": map[string]interface{}{"sub": testAuthorID}},
+		},
+	})
+	if resp.StatusCode != 500 {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+// TestHandler_PersistsSlugExcerptCover verifies the three optional fields
+// are written into the DynamoDB item.
+func TestHandler_PersistsSlugExcerptCover(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	var captured map[string]types.AttributeValue
+	mockClient := &MockDynamoDBClient{
+		PutItemFunc: func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			captured = params.Item
+			return &dynamodb.PutItemOutput{}, nil
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+	uuidGenerator = func() string { return "uid" }
+
+	body, _ := json.Marshal(domain.CreatePostRequest{
+		Title: "T", ContentMarkdown: "B", Category: "tech",
+		Slug:          ptr("hello-world"),
+		Excerpt:       ptr("a short summary"),
+		CoverImageURL: ptr("https://cdn.example.com/cover.jpg"),
+	})
+	resp, _ := Handler(context.Background(), events.APIGatewayProxyRequest{
+		Body: string(body),
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{"claims": map[string]interface{}{"sub": testAuthorID}},
+		},
+	})
+	if resp.StatusCode != 201 {
+		t.Fatalf("expected 201, got %d (body=%s)", resp.StatusCode, resp.Body)
+	}
+	if captured == nil {
+		t.Fatal("expected item to be captured")
+	}
+	var saved domain.BlogPost
+	if err := attributevalue.UnmarshalMap(captured, &saved); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if saved.Slug == nil || *saved.Slug != "hello-world" {
+		t.Errorf("slug not persisted: %+v", saved.Slug)
+	}
+	if saved.Excerpt == nil || *saved.Excerpt != "a short summary" {
+		t.Errorf("excerpt not persisted: %+v", saved.Excerpt)
+	}
+	if saved.CoverImageURL == nil || *saved.CoverImageURL != "https://cdn.example.com/cover.jpg" {
+		t.Errorf("coverImageUrl not persisted: %+v", saved.CoverImageURL)
+	}
+}
+
+// TestHandler_InvalidSlug_Returns400 verifies the domain Validate path is exercised.
+func TestHandler_InvalidSlug_Returns400(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(domain.CreatePostRequest{
+		Title: "T", ContentMarkdown: "B", Category: "tech",
+		Slug: ptr("Bad Slug!"), // spaces + uppercase + punctuation
+	})
+	resp, _ := Handler(context.Background(), events.APIGatewayProxyRequest{
+		Body: string(body),
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{"claims": map[string]interface{}{"sub": testAuthorID}},
+		},
+	})
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
 }

--- a/go-functions/cmd/posts/update/main.go
+++ b/go-functions/cmd/posts/update/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
@@ -34,9 +35,20 @@ import (
 )
 
 // DynamoDBClientInterface defines the interface for DynamoDB operations (for testing)
+//
+//nolint:dupl // mirror of test mock; categories/update follows the same pattern.
 type DynamoDBClientInterface interface {
 	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
 	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+// slugIndexName returns the SlugIndex GSI name (overridable via env for tests).
+func slugIndexName() string {
+	if v := os.Getenv("SLUG_INDEX_NAME"); v != "" {
+		return v
+	}
+	return "SlugIndex"
 }
 
 // dynamoClientGetter is a function that returns the DynamoDB client
@@ -81,6 +93,22 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	// Validate update fields
 	if validateErr := validateUpdateRequest(req); validateErr != nil {
 		return errorResponse(400, validateErr.Error())
+	}
+
+	// PR6: domain-level validation (slug regex/format)
+	if validateErr := req.Validate(); validateErr != nil {
+		return errorResponse(400, validateErr.Error())
+	}
+
+	// PR6: enforce slug uniqueness across other posts when slug changes.
+	if shouldCheckSlug(existingPost, req) {
+		exists, err := checkSlugExistsForOther(ctx, dynamoClient, tableName, *req.Slug, postID)
+		if err != nil {
+			return errorResponse(500, "failed to check slug uniqueness")
+		}
+		if exists {
+			return errorResponse(409, "post with this slug already exists")
+		}
 	}
 
 	// Build updated post
@@ -344,7 +372,65 @@ func applyUpdates(existing *domain.BlogPost, req *domain.UpdatePostRequest) doma
 		updated.PublishStatus = *req.PublishStatus
 	}
 
+	// PR6: writer-experience metadata. Pointers are forwarded as-is so
+	// "explicit empty string" is rejected upstream by domain.UpdatePostRequest.Validate
+	// for slug, while excerpt/coverImageUrl accept any string (including empty
+	// to clear a value — pointer-nil leaves the existing value untouched).
+	if req.Slug != nil {
+		updated.Slug = req.Slug
+	}
+	if req.Excerpt != nil {
+		updated.Excerpt = req.Excerpt
+	}
+	if req.CoverImageURL != nil {
+		updated.CoverImageURL = req.CoverImageURL
+	}
+
 	return updated
+}
+
+// shouldCheckSlug reports whether the request changes the slug to a non-current
+// value. If the request's slug equals the existing slug, no Query is needed.
+func shouldCheckSlug(existing *domain.BlogPost, req *domain.UpdatePostRequest) bool {
+	if req.Slug == nil {
+		return false
+	}
+	if existing.Slug != nil && *existing.Slug == *req.Slug {
+		return false
+	}
+	return true
+}
+
+// checkSlugExistsForOther returns true if a different BlogPost (id != currentPostID)
+// already owns the given slug. Uses the SlugIndex GSI.
+func checkSlugExistsForOther(ctx context.Context, client DynamoDBClientInterface, tableName, slug, currentPostID string) (bool, error) {
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		IndexName:              aws.String(slugIndexName()),
+		KeyConditionExpression: aws.String("slug = :slug"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":slug": &types.AttributeValueMemberS{Value: slug},
+		},
+		// We need to inspect items to compare id; cap to a small page since slug
+		// is intended-unique (Limit:2 lets us detect a duplicate without paging).
+		Limit: aws.Int32(2),
+	})
+	if err != nil {
+		return false, err
+	}
+	if out.Count == 0 {
+		return false, nil
+	}
+	for _, item := range out.Items {
+		var bp domain.BlogPost
+		if err := attributevalue.UnmarshalMap(item, &bp); err != nil {
+			continue
+		}
+		if bp.ID != currentPostID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // validationError represents a validation error

--- a/go-functions/cmd/posts/update/main_test.go
+++ b/go-functions/cmd/posts/update/main_test.go
@@ -36,6 +36,7 @@ const (
 type MockDynamoDBClient struct {
 	GetItemFunc func(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
 	PutItemFunc func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	QueryFunc   func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
 }
 
 func (m *MockDynamoDBClient) GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
@@ -50,6 +51,15 @@ func (m *MockDynamoDBClient) PutItem(ctx context.Context, params *dynamodb.PutIt
 		return m.PutItemFunc(ctx, params, optFns...)
 	}
 	return nil, errors.New("PutItemFunc not set")
+}
+
+// Query returns an empty result by default so tests that don't exercise slug
+// uniqueness don't have to wire it up.
+func (m *MockDynamoDBClient) Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	if m.QueryFunc != nil {
+		return m.QueryFunc(ctx, params, optFns...)
+	}
+	return &dynamodb.QueryOutput{Count: 0}, nil
 }
 
 func setupTest(t *testing.T) func() {
@@ -1695,5 +1705,210 @@ func TestShouldTriggerBuild_AllScenarios(t *testing.T) {
 					tt.expectedTrigger, tt.name, result)
 			}
 		})
+	}
+}
+
+// =============================================================================
+// PR6: Slug uniqueness + Slug/Excerpt/CoverImageURL persistence
+// =============================================================================
+
+func ptrStr(s string) *string { return &s }
+
+func makeGetItemFunc(post domain.BlogPost) func(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	return func(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+		item, err := attributevalue.MarshalMap(post)
+		if err != nil {
+			return nil, err
+		}
+		return &dynamodb.GetItemOutput{Item: item}, nil
+	}
+}
+
+// TestHandler_SlugChange_QueriesSlugIndex verifies that when slug changes,
+// the SlugIndex is queried for uniqueness.
+func TestHandler_SlugChange_QueriesSlugIndex(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	existing := createTestPost()
+	existing.Slug = ptrStr("old-slug")
+
+	queryCalled := false
+	mockClient := &MockDynamoDBClient{
+		GetItemFunc: makeGetItemFunc(existing),
+		PutItemFunc: func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			return &dynamodb.PutItemOutput{}, nil
+		},
+		QueryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			queryCalled = true
+			if params.IndexName == nil || *params.IndexName != "SlugIndex" {
+				t.Errorf("expected SlugIndex, got %v", params.IndexName)
+			}
+			return &dynamodb.QueryOutput{Count: 0}, nil
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+
+	body, _ := json.Marshal(domain.UpdatePostRequest{Slug: ptrStr("new-slug")})
+	resp, _ := Handler(context.Background(), createAuthenticatedRequest(testPostID, string(body)))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d (body=%s)", resp.StatusCode, resp.Body)
+	}
+	if !queryCalled {
+		t.Error("expected Query to be called for slug change")
+	}
+}
+
+// TestHandler_SlugUnchanged_SkipsQuery verifies no Query when slug equals existing.
+func TestHandler_SlugUnchanged_SkipsQuery(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	existing := createTestPost()
+	existing.Slug = ptrStr("same-slug")
+
+	mockClient := &MockDynamoDBClient{
+		GetItemFunc: makeGetItemFunc(existing),
+		PutItemFunc: func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			return &dynamodb.PutItemOutput{}, nil
+		},
+		QueryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			t.Error("Query should not be called when slug is unchanged")
+			return &dynamodb.QueryOutput{}, nil
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+
+	body, _ := json.Marshal(domain.UpdatePostRequest{Slug: ptrStr("same-slug")})
+	resp, _ := Handler(context.Background(), createAuthenticatedRequest(testPostID, string(body)))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d (body=%s)", resp.StatusCode, resp.Body)
+	}
+}
+
+// TestHandler_SlugConflict_ReturnsConflict409 verifies 409 when slug collides
+// with another post.
+func TestHandler_SlugConflict_ReturnsConflict409(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	existing := createTestPost()
+	existing.Slug = ptrStr("old-slug")
+
+	otherItem, _ := attributevalue.MarshalMap(domain.BlogPost{ID: "other-id", Slug: ptrStr("taken-slug")})
+
+	mockClient := &MockDynamoDBClient{
+		GetItemFunc: makeGetItemFunc(existing),
+		PutItemFunc: func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			t.Error("PutItem should not run on conflict")
+			return &dynamodb.PutItemOutput{}, nil
+		},
+		QueryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return &dynamodb.QueryOutput{Count: 1, Items: []map[string]types.AttributeValue{otherItem}}, nil
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+
+	body, _ := json.Marshal(domain.UpdatePostRequest{Slug: ptrStr("taken-slug")})
+	resp, _ := Handler(context.Background(), createAuthenticatedRequest(testPostID, string(body)))
+	if resp.StatusCode != 409 {
+		t.Fatalf("expected 409, got %d (body=%s)", resp.StatusCode, resp.Body)
+	}
+}
+
+// TestHandler_SlugSelfMatch_NotConflict ensures Query returning the same post id
+// is not treated as a conflict.
+func TestHandler_SlugSelfMatch_NotConflict(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	existing := createTestPost()
+	existing.Slug = ptrStr("old-slug")
+
+	selfItem, _ := attributevalue.MarshalMap(domain.BlogPost{ID: testPostID, Slug: ptrStr("same-slug")})
+
+	mockClient := &MockDynamoDBClient{
+		GetItemFunc: makeGetItemFunc(existing),
+		PutItemFunc: func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			return &dynamodb.PutItemOutput{}, nil
+		},
+		QueryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			// Edge case: index returns the post itself if this run was racing
+			// with a concurrent write that re-projected the same post.
+			return &dynamodb.QueryOutput{Count: 1, Items: []map[string]types.AttributeValue{selfItem}}, nil
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+
+	body, _ := json.Marshal(domain.UpdatePostRequest{Slug: ptrStr("same-slug")})
+	resp, _ := Handler(context.Background(), createAuthenticatedRequest(testPostID, string(body)))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d (body=%s)", resp.StatusCode, resp.Body)
+	}
+}
+
+// TestHandler_PersistsSlugExcerptCover verifies the three optional fields are
+// applied via applyUpdates and end up in the saved item.
+func TestHandler_PersistsSlugExcerptCover(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	existing := createTestPost() // Slug nil
+
+	var captured map[string]types.AttributeValue
+	mockClient := &MockDynamoDBClient{
+		GetItemFunc: makeGetItemFunc(existing),
+		PutItemFunc: func(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			captured = params.Item
+			return &dynamodb.PutItemOutput{}, nil
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+
+	body, _ := json.Marshal(domain.UpdatePostRequest{
+		Slug:          ptrStr("hello-world"),
+		Excerpt:       ptrStr("a short summary"),
+		CoverImageURL: ptrStr("https://cdn.example.com/c.jpg"),
+	})
+	resp, _ := Handler(context.Background(), createAuthenticatedRequest(testPostID, string(body)))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d (body=%s)", resp.StatusCode, resp.Body)
+	}
+	var saved domain.BlogPost
+	if err := attributevalue.UnmarshalMap(captured, &saved); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if saved.Slug == nil || *saved.Slug != "hello-world" {
+		t.Errorf("slug not persisted: %v", saved.Slug)
+	}
+	if saved.Excerpt == nil || *saved.Excerpt != "a short summary" {
+		t.Errorf("excerpt not persisted: %v", saved.Excerpt)
+	}
+	if saved.CoverImageURL == nil || *saved.CoverImageURL != "https://cdn.example.com/c.jpg" {
+		t.Errorf("coverImageUrl not persisted: %v", saved.CoverImageURL)
+	}
+}
+
+// TestHandler_InvalidSlugFormat_Returns400 verifies domain Validate is exercised.
+func TestHandler_InvalidSlugFormat_Returns400(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	existing := createTestPost()
+	mockClient := &MockDynamoDBClient{
+		GetItemFunc: makeGetItemFunc(existing),
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>x</p>", nil }
+
+	body, _ := json.Marshal(domain.UpdatePostRequest{Slug: ptrStr("Bad Slug!")})
+	resp, _ := Handler(context.Background(), createAuthenticatedRequest(testPostID, string(body)))
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
 	}
 }

--- a/tests/e2e/mocks/handlers.ts
+++ b/tests/e2e/mocks/handlers.ts
@@ -227,7 +227,18 @@ export const handlers = [
       contentMarkdown: string;
       category: string;
       publishStatus: 'draft' | 'published';
+      slug?: string;
+      excerpt?: string;
+      coverImageUrl?: string;
     };
+
+    // PR6: slug uniqueness — match server-side semantics (409 on collision).
+    if (body.slug && mockPosts.some((p) => p.slug === body.slug)) {
+      return HttpResponse.json(
+        { message: 'post with this slug already exists' },
+        { status: 409 }
+      );
+    }
 
     const newPost = createMockPost(body);
     mockPosts.unshift(newPost);
@@ -261,16 +272,31 @@ export const handlers = [
 
     const { id } = params;
     const body = (await request.json()) as {
-      title: string;
-      contentMarkdown: string;
-      category: string;
-      publishStatus: 'draft' | 'published';
+      title?: string;
+      contentMarkdown?: string;
+      category?: string;
+      publishStatus?: 'draft' | 'published';
+      slug?: string;
+      excerpt?: string;
+      coverImageUrl?: string;
     };
 
     const postIndex = mockPosts.findIndex((p) => p.id === id);
 
     if (postIndex === -1) {
       return HttpResponse.json({ message: 'Post not found' }, { status: 404 });
+    }
+
+    // PR6: slug uniqueness for update — only collide with *other* posts.
+    if (
+      body.slug !== undefined &&
+      body.slug !== mockPosts[postIndex].slug &&
+      mockPosts.some((p) => p.slug === body.slug && p.id !== id)
+    ) {
+      return HttpResponse.json(
+        { message: 'post with this slug already exists' },
+        { status: 409 }
+      );
     }
 
     const updatedPost = {

--- a/tests/e2e/mocks/mockData.ts
+++ b/tests/e2e/mocks/mockData.ts
@@ -22,6 +22,10 @@ export interface MockPost {
   updatedAt: string;
   publishedAt?: string;
   imageUrls?: string[];
+  // PR6: writer-experience metadata fields.
+  slug?: string;
+  excerpt?: string;
+  coverImageUrl?: string;
 }
 
 /**

--- a/tests/e2e/specs/admin-metadata-sidebar.spec.ts
+++ b/tests/e2e/specs/admin-metadata-sidebar.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '../fixtures';
+import { resetMockPosts } from '../mocks/mockData';
+import { getTiptapEditor, setEditorContent } from '../utils/tiptapHelpers';
+
+/**
+ * Admin Metadata Sidebar (PR6)
+ *
+ * - タイトルからslug が自動生成される (ロック OFF)
+ * - ロックすると手動編集可能、タイトル変更で上書きされない
+ * - excerpt 161字でカウンターが赤になる
+ * - 「本文先頭画像から」ボタンで cover image URL が埋まる
+ */
+
+test.describe('Admin Metadata Sidebar', () => {
+  const testCredentials = {
+    email: process.env.TEST_ADMIN_EMAIL || 'admin@example.com',
+    password: process.env.TEST_ADMIN_PASSWORD || 'testpassword',
+  };
+
+  test.beforeEach(async ({ adminLoginPage }) => {
+    resetMockPosts();
+    await adminLoginPage.navigate();
+    await adminLoginPage.clearCredentials();
+    await adminLoginPage.login(testCredentials.email, testCredentials.password);
+  });
+
+  test('タイトル入力で slug が自動生成される', async ({ page }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    await page.getByTestId('post-title-input').fill('Hello PR6 World');
+    const slugInput = page.getByTestId('metadata-slug-input');
+    await expect(slugInput).toHaveValue('hello-pr6-world');
+  });
+
+  test('ロック解除→ロック後の slug は手動編集できる', async ({ page }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    await page.getByTestId('post-title-input').fill('First Title');
+    const slug = page.getByTestId('metadata-slug-input');
+    await expect(slug).toHaveValue('first-title');
+
+    // ロックして手動編集
+    await page.getByTestId('metadata-slug-lock').click();
+    await expect(page.getByTestId('metadata-slug-lock')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await slug.fill('manual-slug-2026');
+
+    // タイトルを変更しても slug は変わらない
+    await page.getByTestId('post-title-input').fill('Different Title');
+    await expect(slug).toHaveValue('manual-slug-2026');
+  });
+
+  test('excerpt が161字でカウンターが赤くなる', async ({ page }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    const excerpt = page.getByTestId('metadata-excerpt-input');
+    await excerpt.fill('a'.repeat(161));
+    const counter = page.getByTestId('metadata-excerpt-counter');
+    await expect(counter).toHaveClass(/text-red-600/);
+    await expect(counter).toHaveText('161 / 160');
+  });
+
+  test('本文先頭画像から cover image を自動入力できる', async ({ page }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+
+    await page.getByTestId('post-title-input').fill('Cover Test');
+    await setEditorContent(
+      page,
+      '![hero](https://cdn.example.com/cover.jpg)\n\n本文。'
+    );
+
+    await page.getByTestId('metadata-cover-autofill').click();
+    await expect(page.getByTestId('metadata-cover-input')).toHaveValue(
+      'https://cdn.example.com/cover.jpg'
+    );
+    await expect(page.getByTestId('metadata-cover-preview')).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/admin-slug-conflict.spec.ts
+++ b/tests/e2e/specs/admin-slug-conflict.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '../fixtures';
+import { resetMockPosts } from '../mocks/mockData';
+import { getTiptapEditor, setEditorContent } from '../utils/tiptapHelpers';
+
+/**
+ * Admin Slug Conflict (PR6)
+ *
+ * 既に同じ slug を持つ記事があるとき、新規記事を保存しようとすると 409 が
+ * 返り、エラー banner に "slug already exists" が表示される。
+ */
+
+test.describe('Admin Slug Conflict', () => {
+  const testCredentials = {
+    email: process.env.TEST_ADMIN_EMAIL || 'admin@example.com',
+    password: process.env.TEST_ADMIN_PASSWORD || 'testpassword',
+  };
+
+  test.beforeEach(async ({ adminLoginPage }) => {
+    resetMockPosts();
+    await adminLoginPage.navigate();
+    await adminLoginPage.clearCredentials();
+    await adminLoginPage.login(testCredentials.email, testCredentials.password);
+  });
+
+  test('重複 slug で保存すると 409 エラーバナーが出る', async ({ page }) => {
+    await page.goto('/posts/new');
+    await expect(getTiptapEditor(page)).toBeVisible();
+    // Seed an existing post in browser-side MSW state with the slug we'll
+    // collide against. The bridge is exposed by main.tsx when MSW is on.
+    await page.evaluate(() => {
+      const seed = (
+        window as unknown as { __e2eMockPosts?: { slug?: string }[] }
+      ).__e2eMockPosts;
+      if (!seed || !seed[0]) throw new Error('mockPosts bridge not exposed');
+      seed[0].slug = 'taken-slug';
+    });
+
+    await page.getByTestId('post-title-input').fill('Conflict Test');
+    await setEditorContent(page, '本文');
+    // カテゴリを必須なので選択
+    await page.getByTestId('post-category-select').selectOption({ index: 1 });
+    // ロックを開けて重複 slug を入力
+    await page.getByTestId('metadata-slug-lock').click();
+    await page.getByTestId('metadata-slug-input').fill('taken-slug');
+
+    await page.getByTestId('save-draft-button').click();
+
+    await expect(page.getByTestId('error-message')).toContainText(
+      'slug already exists'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Pulls slug, excerpt, and cover-image out of the main editor into a new `MetadataSidebar` so writers can focus on title + body. PostEditor switches to a 2-pane grid; category/tags/publishStatus relocate to the sidebar.
- Closes the gap left by PR #193 (which added the type fields without persisting them): `cmd/posts/create` and `cmd/posts/update` now persist `Slug` / `Excerpt` / `CoverImageURL` into DynamoDB and enforce slug uniqueness via the `SlugIndex` GSI (409 on conflict, mirroring the categories pattern).
- New utilities (`utils/postDefaults.ts`, `utils/validation.ts` extensions), MSW handler parity for the 409 path, and 5 new Playwright specs.

## Changes

### Frontend
- `components/MetadataSidebar.tsx` (new) — auto-slug-from-title (lockable), excerpt counter, cover-image autofill from body, plus relocated category/tags/publish-status.
- `components/PostEditor.tsx` — `<PostData>` extended with `slug?/excerpt?/coverImageUrl?`; 2-pane grid; 591/356 ratio reflects the moved markup.
- `pages/PostCreatePage.tsx` + `pages/PostEditPage.tsx` — surface 409 conflicts; `PostEditPage` hydrates the new fields from `getPost`.
- `utils/postDefaults.ts` (new) — `slugify`, `excerptFromMarkdown`, `coverFromMarkdown`.
- `utils/validation.ts` — `validateSlug`, `validateExcerpt`.
- `main.tsx` — exposes `__e2eMockPosts` to Playwright when MSW is enabled.

### Backend (Go)
- `cmd/posts/create/main.go` — new `checkSlugExists` helper; returns 409 on collision; writes the three new fields to the BlogPost row.
- `cmd/posts/update/main.go` — `applyUpdates` writes-through Slug/Excerpt/CoverImageURL; `checkSlugExistsForOther` excludes the current post's id; `req.Validate()` runs domain-level slug regex.
- Both files extend `DynamoDBClientInterface` with `Query`. IAM (`Query` + `index/*`) was already granted, so no terraform delta.

### MSW + E2E
- `tests/e2e/mocks/mockData.ts` — `MockPost` gains slug/excerpt/coverImageUrl.
- `tests/e2e/mocks/handlers.ts` — POST + PUT enforce slug uniqueness (409).
- `tests/e2e/specs/admin-metadata-sidebar.spec.ts` (new) — auto-slug, lock/unlock, 161-char excerpt counter, cover autofill (4 cases).
- `tests/e2e/specs/admin-slug-conflict.spec.ts` (new) — 409 banner.

## Test plan
- [x] Go: `cd go-functions && go test ./...` (all packages green; new posts/create + posts/update tests cover slug Query/409/persistence).
- [x] Admin unit tests: `cd frontend/admin && bun run test --run` → 770 passed.
- [x] Admin lint: `bun run lint` clean.
- [x] Playwright admin specs: `bun x playwright test --config=playwright.admin.config.ts tests/e2e/specs/admin-metadata-sidebar.spec.ts tests/e2e/specs/admin-slug-conflict.spec.ts` → 5 passed.
- [x] Existing admin specs (`admin-crud`, `admin-autosave`, `admin-publish-flow`) still green.

## Follow-up
- PR7 (Astro slug routing + `GET /posts/by-slug/{slug}` + slug backfill) is unblocked now that uniqueness is enforced on writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)