### PR TITLE
feat: Astro slug routing + GET /posts/by-slug + slug backfill (WX PR7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,8 @@ jobs:
             path: posts/delete
           - function: posts-build_status
             path: posts/build_status
+          - function: posts-get_by_slug
+            path: posts/get_by_slug
           - function: auth-login
             path: auth/login
           - function: auth-logout
@@ -548,7 +550,7 @@ jobs:
           echo "========================================="
           echo "Verifying Lambda Binaries"
           echo "========================================="
-          FUNCS="posts-create posts-get posts-get_public posts-list posts-update posts-delete posts-build_status auth-login auth-logout auth-refresh images-get_upload_url images-delete categories-list categories-create categories-update categories-bulk_sort categories-delete mindmaps-create mindmaps-get mindmaps-list mindmaps-update mindmaps-delete mindmaps-get_public mindmaps-list_public"
+          FUNCS="posts-create posts-get posts-get_public posts-get_by_slug posts-list posts-update posts-delete posts-build_status auth-login auth-logout auth-refresh images-get_upload_url images-delete categories-list categories-create categories-update categories-bulk_sort categories-delete mindmaps-create mindmaps-get mindmaps-list mindmaps-update mindmaps-delete mindmaps-get_public mindmaps-list_public"
           MISSING=0
           for f in $FUNCS; do
             if [ -f "go-functions/bin/$f/bootstrap" ]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,7 +177,7 @@ jobs:
             echo "cache-hit=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          FUNCS="posts-create posts-get posts-get_public posts-list posts-update posts-delete posts-build_status auth-login auth-logout auth-refresh images-get_upload_url images-delete categories-list categories-create categories-update categories-bulk_sort categories-delete mindmaps-create mindmaps-get mindmaps-get_public mindmaps-list mindmaps-list_public mindmaps-update mindmaps-delete"
+          FUNCS="posts-create posts-get posts-get_public posts-get_by_slug posts-list posts-update posts-delete posts-build_status auth-login auth-logout auth-refresh images-get_upload_url images-delete categories-list categories-create categories-update categories-bulk_sort categories-delete mindmaps-create mindmaps-get mindmaps-get_public mindmaps-list mindmaps-list_public mindmaps-update mindmaps-delete"
           TOTAL=0
           for f in $FUNCS; do TOTAL=$((TOTAL + 1)); done
           COUNT=0
@@ -233,6 +233,8 @@ jobs:
             path: posts/delete
           - function: posts-build_status
             path: posts/build_status
+          - function: posts-get_by_slug
+            path: posts/get_by_slug
           - function: auth-login
             path: auth/login
           - function: auth-logout

--- a/frontend/public-astro/src/components/PostCard.astro
+++ b/frontend/public-astro/src/components/PostCard.astro
@@ -18,10 +18,14 @@ interface Props {
 const { post } = Astro.props;
 const excerpt = generateExcerpt(post.contentHtml, 100);
 const formattedDate = formatDateJa(post.createdAt);
+
+// PR7: prefer slug-based URL when the post has one; fall back to id for
+// any post that hasn't been backfilled yet.
+const postHref = post.slug ? `/posts/${post.slug}/` : `/posts/${post.id}/`;
 ---
 
 <article class="post-card" data-testid="article-card" data-post-id={post.id}>
-  <a href={`/posts/${post.id}`} class="post-link">
+  <a href={postHref} class="post-link">
     <h2 class="post-title" data-testid="article-title">{post.title}</h2>
     <div class="post-meta">
       <span class="category" data-testid="article-category">{post.category}</span>

--- a/frontend/public-astro/src/lib/api.test.ts
+++ b/frontend/public-astro/src/lib/api.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   fetchAllPosts,
   fetchPost,
+  fetchPostBySlug,
   fetchAllPublicMindmaps,
   fetchPublicMindmap,
   type Post,
@@ -334,6 +335,62 @@ describe('API Module', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(result).toEqual(mockPost);
+    });
+  });
+
+  describe('fetchPostBySlug', () => {
+    it('should fetch a single post by slug', async () => {
+      const mockPost: Post = {
+        id: '123',
+        slug: 'hello-world',
+        title: 'Hello World',
+        contentHtml: '<p>Hi</p>',
+        category: 'tech',
+        tags: [],
+        publishStatus: 'published',
+        authorId: 'author1',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockPost,
+      });
+
+      const result = await fetchPostBySlug('hello-world');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/posts/by-slug/hello-world',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(result).toEqual(mockPost);
+    });
+
+    it('should URL-encode the slug', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      await fetchPostBySlug('weird/slug');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.example.com/posts/by-slug/weird%2Fslug',
+        expect.anything()
+      );
+    });
+
+    it('should throw on 404', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      await expect(fetchPostBySlug('missing')).rejects.toThrow(
+        'API request failed: 404 Not Found'
+      );
     });
   });
 

--- a/frontend/public-astro/src/lib/api.ts
+++ b/frontend/public-astro/src/lib/api.ts
@@ -192,6 +192,23 @@ export async function fetchPost(id: string): Promise<Post> {
 }
 
 /**
+ * Friendly slug で公開記事を取得する (PR7)
+ * - 公開エンドポイント (no auth)
+ * - 該当記事が draft の場合は API 側で 404 を返す
+ */
+export async function fetchPostBySlug(slug: string): Promise<Post> {
+  const apiUrl = getApiUrl();
+  const url = `${apiUrl}/posts/by-slug/${encodeURIComponent(slug)}`;
+
+  return fetchWithRetry<Post>(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+/**
  * 全ての公開マインドマップを取得する
  *
  * カーソルベースのページネーションを使用して全マインドマップを再帰的に取得する

--- a/frontend/public-astro/src/pages/posts/[slug].astro
+++ b/frontend/public-astro/src/pages/posts/[slug].astro
@@ -1,28 +1,10 @@
 ---
 /**
- * [id].astro - 記事詳細ページ
+ * [slug].astro - 記事詳細ページ (PR7: friendly slug ルーティング)
  *
- * Task 2.3: 記事詳細ページ実装
- * Task 3.1: SEOメタタグ実装
- * Task 3.2: JSON-LD構造化データ実装
- * Task 11.2: 記事埋め込みマインドマップの描画実装
- *
- * Requirements:
- * - 2.3: 記事詳細ページ実装
- *   - 動的ルート (`posts/[id].astro`) で各記事の詳細ページを生成
- *   - `getStaticPaths` で全公開記事のパスを生成
- *   - 記事タイトル、本文HTML、カテゴリ、タグ、画像を表示
- *   - サニタイズ済みHTMLコンテンツを `set:html` で安全にレンダリング
- *   - ビルド時に `/posts/[id]/index.html` として静的生成
- * - 2.7: CSS/アセットをインライン化またはバンドル
- * - 3.4: Article pages set og:type to "article"
- * - 3.5: Post's first image as og:image if available
- * - 4.1: JSON-LD structured data with @type: "BlogPosting" schema
- * - 4.2: Include headline, datePublished, dateModified, and author properties
- * - 4.3: If the post has images, include image property
- * - 5.3: 埋め込みマーカーをインタラクティブなマインドマップビューに置換
- * - 5.4: Astro SSGビルド時に埋め込み対象のマインドマップデータをJSON形式で埋め込む
- * - 5.5: 埋め込み対象が削除/非公開の場合フォールバックメッセージを表示
+ * `/posts/<slug>/index.html` として静的生成する。slug を持つ投稿のみ対象。
+ * 動作・スタイル・JSON-LD・mindmap embed ロジックは [id].astro と同一。
+ * SEO の canonical はこの slug ベースの URL を採用する。
  */
 import Layout from '../../layouts/Layout.astro';
 import { fetchAllPosts, fetchPublicMindmap, type Post, type PublicMindmap } from '../../lib/api';
@@ -55,15 +37,18 @@ function extractMindmapIds(html: string): string[] {
 }
 
 /**
- * getStaticPaths: 全公開記事のパスを生成
+ * getStaticPaths: slug を持つ全公開記事のパスを生成。slug が無い投稿は
+ * [id].astro 側で従来通り id ベースで配信される。
  */
 export async function getStaticPaths() {
   const posts = await fetchAllPosts();
 
-  return posts.map((post) => ({
-    params: { id: post.id },
-    props: { post },
-  }));
+  return posts
+    .filter((post) => Boolean(post.slug))
+    .map((post) => ({
+      params: { slug: post.slug! },
+      props: { post },
+    }));
 }
 
 interface Props {
@@ -71,13 +56,6 @@ interface Props {
 }
 
 const { post } = Astro.props;
-
-// PR7: friendly slug routing. When a slug exists, the canonical URL is
-// /posts/<slug>/. Astro is in static mode so Astro.redirect can't emit a
-// real 30x; we render a minimal HTML page with <meta http-equiv="refresh">
-// and a canonical link so search engines and clients land on the slug URL.
-const slugRedirectTarget = post.slug ? `/posts/${post.slug}/` : null;
-
 const description = generateDescription(post.contentHtml);
 const publishedDate = formatPublishedDate(post);
 const firstImage = getFirstImage(post.imageUrls);
@@ -117,21 +95,6 @@ await Promise.all(
 const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
 ---
 
-{slugRedirectTarget ? (
-  <html lang="ja">
-    <head>
-      <meta charset="utf-8" />
-      <meta http-equiv="refresh" content={`0; url=${slugRedirectTarget}`} />
-      <link rel="canonical" href={slugRedirectTarget} />
-      <title>{post.title}</title>
-    </head>
-    <body>
-      <p>
-        Redirecting to <a href={slugRedirectTarget}>{slugRedirectTarget}</a>…
-      </p>
-    </body>
-  </html>
-) : (
 <Layout
   title={post.title}
   description={description}
@@ -208,7 +171,6 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
     </nav>
   </article>
 </Layout>
-)}
 
 <style>
   .post-detail {

--- a/go-functions/Makefile
+++ b/go-functions/Makefile
@@ -89,6 +89,12 @@ fmt:
 	@echo "Formatting code..."
 	go fmt ./...
 
+# Backfill slugs for legacy BlogPosts (PR7).
+# Usage: AWS_PROFILE=dev TABLE_NAME=blog-posts-dev make backfill-slugs ARGS="--dry-run"
+backfill-slugs:
+	@echo "Running backfill-post-slugs..."
+	go run ./cmd/scripts/backfill_post_slugs $(ARGS)
+
 # Clean build artifacts
 clean:
 	@echo "Cleaning build artifacts..."
@@ -105,5 +111,6 @@ help:
 	@echo "  test       - Run tests with race detector"
 	@echo "  lint       - Run golangci-lint"
 	@echo "  fmt        - Format code"
-	@echo "  clean      - Remove build artifacts"
-	@echo "  help       - Show this help message"
+	@echo "  clean          - Remove build artifacts"
+	@echo "  backfill-slugs - Backfill slugs for legacy BlogPosts (use ARGS='--dry-run' for preview)"
+	@echo "  help           - Show this help message"

--- a/go-functions/cmd/posts/get_by_slug/main.go
+++ b/go-functions/cmd/posts/get_by_slug/main.go
@@ -1,0 +1,103 @@
+// Package main provides the GetPublicPostBySlug Lambda function for retrieving
+// published posts by their friendly slug.
+//
+// Route: GET /posts/by-slug/{slug} (public, no-auth)
+// Requirement (PR7 of writer-experience refactor): Astro-side static routing
+// at `/posts/[slug]` calls this endpoint to populate JSON-LD / hero / etc.
+//
+// Slug uniqueness is enforced on writes (cmd/posts/create + cmd/posts/update),
+// so a SlugIndex Query is expected to return at most one item. If the matched
+// post is in draft status, we return 404 to avoid leaking unpublished content
+// through the public endpoint.
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"serverless-blog/go-functions/internal/clients"
+	"serverless-blog/go-functions/internal/domain"
+	"serverless-blog/go-functions/internal/middleware"
+)
+
+// DynamoDBClientInterface defines the interface for DynamoDB operations (for testing).
+type DynamoDBClientInterface interface {
+	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+// dynamoClientGetter returns the DynamoDB client. Overridable in tests.
+var dynamoClientGetter = func() (DynamoDBClientInterface, error) {
+	return clients.GetDynamoDB()
+}
+
+// slugIndexName returns the SlugIndex GSI name. Overridable via env in tests
+// (e.g. SLUG_INDEX_NAME=TestSlugIndex) so the Query inputs can be asserted.
+func slugIndexName() string {
+	if v := os.Getenv("SLUG_INDEX_NAME"); v != "" {
+		return v
+	}
+	return "SlugIndex"
+}
+
+// Handler handles GET /posts/by-slug/{slug} (public).
+func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	slug := request.PathParameters["slug"]
+	if slug == "" {
+		return errorResponse(400, "slug is required")
+	}
+
+	tableName := os.Getenv("TABLE_NAME")
+	if tableName == "" {
+		return errorResponse(500, "server configuration error")
+	}
+
+	dynamoClient, err := dynamoClientGetter()
+	if err != nil {
+		return errorResponse(500, "server error")
+	}
+
+	out, err := dynamoClient.Query(ctx, &dynamodb.QueryInput{
+		TableName:              &tableName,
+		IndexName:              aws.String(slugIndexName()),
+		KeyConditionExpression: aws.String("slug = :slug"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":slug": &types.AttributeValueMemberS{Value: slug},
+		},
+		Limit: aws.Int32(1),
+	})
+	if err != nil {
+		return errorResponse(500, "failed to retrieve post")
+	}
+
+	if out.Count == 0 || len(out.Items) == 0 {
+		return errorResponse(404, "post not found")
+	}
+
+	var post domain.BlogPost
+	if err := attributevalue.UnmarshalMap(out.Items[0], &post); err != nil {
+		return errorResponse(500, "failed to parse post data")
+	}
+
+	// Hide drafts from the public endpoint.
+	if post.PublishStatus != domain.PublishStatusPublished {
+		return errorResponse(404, "post not found")
+	}
+
+	return middleware.JSONResponse(200, post)
+}
+
+// errorResponse creates an error response with CORS headers.
+func errorResponse(statusCode int, message string) (events.APIGatewayProxyResponse, error) {
+	return middleware.JSONResponse(statusCode, domain.ErrorResponse{Message: message})
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/go-functions/cmd/posts/get_by_slug/main_test.go
+++ b/go-functions/cmd/posts/get_by_slug/main_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"serverless-blog/go-functions/internal/domain"
+)
+
+const testTableName = "test-table"
+
+type mockClient struct {
+	queryFunc func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+func (m *mockClient) Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	return m.queryFunc(ctx, params, optFns...)
+}
+
+func setupTest(t *testing.T) func() {
+	t.Helper()
+	t.Setenv("TABLE_NAME", testTableName)
+	t.Setenv("AWS_REGION", "ap-northeast-1")
+	original := dynamoClientGetter
+	return func() {
+		dynamoClientGetter = original
+	}
+}
+
+func makeRequest(slug string) events.APIGatewayProxyRequest {
+	return events.APIGatewayProxyRequest{
+		PathParameters: map[string]string{"slug": slug},
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestHandler_PublishedPost_Returns200(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	post := domain.BlogPost{
+		ID:            "post-1",
+		Title:         "Hello",
+		PublishStatus: domain.PublishStatusPublished,
+		Slug:          ptr("hello"),
+	}
+	item, err := attributevalue.MarshalMap(post)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) {
+		return &mockClient{
+			queryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+				if params.IndexName == nil || *params.IndexName != "SlugIndex" {
+					t.Errorf("expected SlugIndex, got %v", params.IndexName)
+				}
+				return &dynamodb.QueryOutput{Count: 1, Items: []map[string]types.AttributeValue{item}}, nil
+			},
+		}, nil
+	}
+
+	resp, _ := Handler(context.Background(), makeRequest("hello"))
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d body=%s", resp.StatusCode, resp.Body)
+	}
+	var got domain.BlogPost
+	if err := json.Unmarshal([]byte(resp.Body), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got.ID != "post-1" {
+		t.Errorf("expected post id post-1, got %q", got.ID)
+	}
+}
+
+func TestHandler_NotFound_Returns404(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) {
+		return &mockClient{
+			queryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+				return &dynamodb.QueryOutput{Count: 0}, nil
+			},
+		}, nil
+	}
+
+	resp, _ := Handler(context.Background(), makeRequest("missing"))
+	if resp.StatusCode != 404 {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_DraftPost_Returns404(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	draft := domain.BlogPost{
+		ID:            "post-1",
+		Title:         "Draft",
+		PublishStatus: domain.PublishStatusDraft,
+		Slug:          ptr("draft-only"),
+	}
+	item, err := attributevalue.MarshalMap(draft)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) {
+		return &mockClient{
+			queryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+				return &dynamodb.QueryOutput{Count: 1, Items: []map[string]types.AttributeValue{item}}, nil
+			},
+		}, nil
+	}
+
+	resp, _ := Handler(context.Background(), makeRequest("draft-only"))
+	if resp.StatusCode != 404 {
+		t.Errorf("expected 404 for draft, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_QueryError_Returns500(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) {
+		return &mockClient{
+			queryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+				return nil, errors.New("ddb down")
+			},
+		}, nil
+	}
+
+	resp, _ := Handler(context.Background(), makeRequest("any"))
+	if resp.StatusCode != 500 {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_MissingSlug_Returns400(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+	resp, _ := Handler(context.Background(), events.APIGatewayProxyRequest{PathParameters: map[string]string{}})
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_MissingTable_Returns500(t *testing.T) {
+	t.Setenv("TABLE_NAME", "")
+	resp, _ := Handler(context.Background(), makeRequest("hello"))
+	if resp.StatusCode != 500 {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandler_ClientInitError_Returns500(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) {
+		return nil, errors.New("client init failed")
+	}
+	resp, _ := Handler(context.Background(), makeRequest("hello"))
+	if resp.StatusCode != 500 {
+		t.Errorf("expected 500, got %d", resp.StatusCode)
+	}
+}

--- a/go-functions/cmd/scripts/backfill_post_slugs/main.go
+++ b/go-functions/cmd/scripts/backfill_post_slugs/main.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -35,32 +36,66 @@ type ddbAPI interface {
 	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
 }
 
-func main() {
-	var (
-		tableName = flag.String("table-name", os.Getenv("TABLE_NAME"), "DynamoDB BlogPosts table name (or TABLE_NAME env)")
-		region    = flag.String("region", os.Getenv("AWS_REGION"), "AWS region (or AWS_REGION env)")
-		indexName = flag.String("slug-index", defaultSlugIndex, "Name of the SlugIndex GSI on BlogPosts")
-		dryRun    = flag.Bool("dry-run", false, "Print proposed updates without writing")
-	)
-	flag.Parse()
+// runArgs holds the parsed CLI flags. Extracted so main() stays a thin
+// wrapper around testable logic.
+type runArgs struct {
+	tableName string
+	region    string
+	indexName string
+	dryRun    bool
+}
 
-	if *tableName == "" {
-		log.Fatal("--table-name (or TABLE_NAME env) is required")
+// parseFlags reads CLI flags + env defaults into runArgs and validates them.
+func parseFlags(args []string) (runArgs, error) {
+	fs := flag.NewFlagSet("backfill_post_slugs", flag.ContinueOnError)
+	tableName := fs.String("table-name", os.Getenv("TABLE_NAME"), "DynamoDB BlogPosts table name (or TABLE_NAME env)")
+	region := fs.String("region", os.Getenv("AWS_REGION"), "AWS region (or AWS_REGION env)")
+	indexName := fs.String("slug-index", defaultSlugIndex, "Name of the SlugIndex GSI on BlogPosts")
+	dryRun := fs.Bool("dry-run", false, "Print proposed updates without writing")
+	if err := fs.Parse(args); err != nil {
+		return runArgs{}, err
 	}
+	if *tableName == "" {
+		return runArgs{}, errors.New("--table-name (or TABLE_NAME env) is required")
+	}
+	return runArgs{
+		tableName: *tableName,
+		region:    *region,
+		indexName: *indexName,
+		dryRun:    *dryRun,
+	}, nil
+}
 
-	ctx := context.Background()
+// newAWSClient builds a real DynamoDB client. Indirected through a var so
+// tests can swap in a fake.
+var newAWSClient = func(ctx context.Context, region string) (ddbAPI, error) {
 	cfgLoaders := []func(*config.LoadOptions) error{}
-	if *region != "" {
-		cfgLoaders = append(cfgLoaders, config.WithRegion(*region))
+	if region != "" {
+		cfgLoaders = append(cfgLoaders, config.WithRegion(region))
 	}
 	cfg, err := config.LoadDefaultConfig(ctx, cfgLoaders...)
 	if err != nil {
-		log.Fatalf("load aws config: %v", err)
+		return nil, err
 	}
-	client := dynamodb.NewFromConfig(cfg)
+	return dynamodb.NewFromConfig(cfg), nil
+}
 
-	if err := backfill(ctx, client, *tableName, *indexName, *dryRun); err != nil {
-		log.Fatalf("backfill failed: %v", err)
+// run is the testable entry point. main() delegates to it.
+func run(ctx context.Context, args []string) error {
+	a, err := parseFlags(args)
+	if err != nil {
+		return err
+	}
+	client, err := newAWSClient(ctx, a.region)
+	if err != nil {
+		return fmt.Errorf("load aws config: %w", err)
+	}
+	return backfill(ctx, client, a.tableName, a.indexName, a.dryRun)
+}
+
+func main() {
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		log.Fatal(err)
 	}
 }
 

--- a/go-functions/cmd/scripts/backfill_post_slugs/main.go
+++ b/go-functions/cmd/scripts/backfill_post_slugs/main.go
@@ -1,0 +1,209 @@
+// Backfill script for the writer-experience PR7. Scans BlogPosts in
+// DynamoDB, computes a friendly slug for any post that lacks one, and
+// writes it back. Designed to be run from a developer workstation against
+// dev/prd via the usual AWS_PROFILE / TABLE_NAME env vars.
+//
+//	make backfill-slugs ARGS="--dry-run"
+//	make backfill-slugs            # writes for real
+//
+// Slug source of truth: domain.GenerateSlug (kana→romaji + kebab-case).
+// Collisions are resolved by appending -2, -3, ... until SlugIndex Query
+// returns 0 hits.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"serverless-blog/go-functions/internal/domain"
+)
+
+const defaultSlugIndex = "SlugIndex"
+
+type ddbAPI interface {
+	Scan(ctx context.Context, params *dynamodb.ScanInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)
+	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+}
+
+func main() {
+	var (
+		tableName = flag.String("table-name", os.Getenv("TABLE_NAME"), "DynamoDB BlogPosts table name (or TABLE_NAME env)")
+		region    = flag.String("region", os.Getenv("AWS_REGION"), "AWS region (or AWS_REGION env)")
+		indexName = flag.String("slug-index", defaultSlugIndex, "Name of the SlugIndex GSI on BlogPosts")
+		dryRun    = flag.Bool("dry-run", false, "Print proposed updates without writing")
+	)
+	flag.Parse()
+
+	if *tableName == "" {
+		log.Fatal("--table-name (or TABLE_NAME env) is required")
+	}
+
+	ctx := context.Background()
+	cfgLoaders := []func(*config.LoadOptions) error{}
+	if *region != "" {
+		cfgLoaders = append(cfgLoaders, config.WithRegion(*region))
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, cfgLoaders...)
+	if err != nil {
+		log.Fatalf("load aws config: %v", err)
+	}
+	client := dynamodb.NewFromConfig(cfg)
+
+	if err := backfill(ctx, client, *tableName, *indexName, *dryRun); err != nil {
+		log.Fatalf("backfill failed: %v", err)
+	}
+}
+
+type summary struct {
+	scanned       int
+	skipped       int
+	updated       int
+	collisions    int
+	emptyTitle    int
+	dryRunPlanned int
+}
+
+func backfill(ctx context.Context, client ddbAPI, tableName, indexName string, dryRun bool) error {
+	var s summary
+	var lastEvaluatedKey map[string]types.AttributeValue
+	for {
+		out, err := client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:         aws.String(tableName),
+			ExclusiveStartKey: lastEvaluatedKey,
+		})
+		if err != nil {
+			return fmt.Errorf("scan: %w", err)
+		}
+		for _, item := range out.Items {
+			s.scanned++
+			var post domain.BlogPost
+			if err := attributevalue.UnmarshalMap(item, &post); err != nil {
+				log.Printf("warn: unmarshal failed for item, skipping: %v", err)
+				s.skipped++
+				continue
+			}
+			if post.Slug != nil && *post.Slug != "" {
+				s.skipped++
+				continue
+			}
+			if post.Title == "" {
+				s.emptyTitle++
+				s.skipped++
+				log.Printf("warn: post id=%s has empty title; skipping (manual fix needed)", post.ID)
+				continue
+			}
+
+			base := domain.GenerateSlug(post.Title)
+			if base == "" {
+				s.skipped++
+				s.emptyTitle++
+				log.Printf("warn: post id=%s slug generation produced empty; skipping", post.ID)
+				continue
+			}
+
+			finalSlug, collisions, err := pickAvailableSlug(ctx, client, tableName, indexName, base, post.ID)
+			if err != nil {
+				return fmt.Errorf("pickAvailableSlug for id=%s: %w", post.ID, err)
+			}
+			s.collisions += collisions
+
+			if dryRun {
+				fmt.Printf("DRY-RUN id=%s\ttitle=%q\tslug=%s\n", post.ID, post.Title, finalSlug)
+				s.dryRunPlanned++
+				continue
+			}
+
+			if err := writeSlug(ctx, client, tableName, post.ID, finalSlug); err != nil {
+				return fmt.Errorf("writeSlug id=%s: %w", post.ID, err)
+			}
+			s.updated++
+			fmt.Printf("UPDATED id=%s\tslug=%s\n", post.ID, finalSlug)
+		}
+		if len(out.LastEvaluatedKey) == 0 {
+			break
+		}
+		lastEvaluatedKey = out.LastEvaluatedKey
+	}
+
+	fmt.Println("---- summary ----")
+	fmt.Printf("scanned: %d\n", s.scanned)
+	fmt.Printf("skipped: %d (already had slug or unprocessable)\n", s.skipped)
+	fmt.Printf("collisions resolved: %d\n", s.collisions)
+	fmt.Printf("empty-title skipped: %d\n", s.emptyTitle)
+	if dryRun {
+		fmt.Printf("dry-run planned updates: %d\n", s.dryRunPlanned)
+	} else {
+		fmt.Printf("updated: %d\n", s.updated)
+	}
+	return nil
+}
+
+// pickAvailableSlug returns a slug that doesn't collide with another BlogPost.
+// Excludes currentID from the collision set so re-running the script (which is
+// idempotent) doesn't pile up suffixes.
+func pickAvailableSlug(ctx context.Context, client ddbAPI, tableName, indexName, base, currentID string) (slug string, collisions int, err error) {
+	candidate := base
+	for n := 2; ; n++ {
+		hit, qErr := slugInUseBy(ctx, client, tableName, indexName, candidate, currentID)
+		if qErr != nil {
+			return "", collisions, qErr
+		}
+		if !hit {
+			return candidate, collisions, nil
+		}
+		collisions++
+		candidate = fmt.Sprintf("%s-%d", base, n)
+		if n > 1000 {
+			return "", collisions, fmt.Errorf("too many slug collisions for base=%q", base)
+		}
+	}
+}
+
+func slugInUseBy(ctx context.Context, client ddbAPI, tableName, indexName, slug, excludeID string) (bool, error) {
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(tableName),
+		IndexName:              aws.String(indexName),
+		KeyConditionExpression: aws.String("slug = :slug"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":slug": &types.AttributeValueMemberS{Value: slug},
+		},
+		Limit: aws.Int32(2),
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, it := range out.Items {
+		idAttr, ok := it["id"].(*types.AttributeValueMemberS)
+		if !ok {
+			continue
+		}
+		if idAttr.Value != excludeID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func writeSlug(ctx context.Context, client ddbAPI, tableName, postID, slug string) error {
+	_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"id": &types.AttributeValueMemberS{Value: postID},
+		},
+		UpdateExpression: aws.String("SET slug = :s"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":s": &types.AttributeValueMemberS{Value: slug},
+		},
+	})
+	return err
+}

--- a/go-functions/cmd/scripts/backfill_post_slugs/main_test.go
+++ b/go-functions/cmd/scripts/backfill_post_slugs/main_test.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"serverless-blog/go-functions/internal/domain"
+)
+
+const tn = "BlogPosts-test"
+const idx = "SlugIndex"
+
+type mockDDB struct {
+	scanFn   func(context.Context, *dynamodb.ScanInput, ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)
+	queryFn  func(context.Context, *dynamodb.QueryInput, ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+	updateFn func(context.Context, *dynamodb.UpdateItemInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+}
+
+func (m *mockDDB) Scan(ctx context.Context, in *dynamodb.ScanInput, opts ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+	return m.scanFn(ctx, in, opts...)
+}
+func (m *mockDDB) Query(ctx context.Context, in *dynamodb.QueryInput, opts ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	return m.queryFn(ctx, in, opts...)
+}
+func (m *mockDDB) UpdateItem(ctx context.Context, in *dynamodb.UpdateItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	return m.updateFn(ctx, in, opts...)
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func mustMarshal(t *testing.T, p domain.BlogPost) map[string]types.AttributeValue {
+	t.Helper()
+	av, err := attributevalue.MarshalMap(p)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return av
+}
+
+func TestSlugInUseBy_NoMatch(t *testing.T) {
+	c := &mockDDB{
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return &dynamodb.QueryOutput{}, nil
+		},
+	}
+	hit, err := slugInUseBy(context.Background(), c, tn, idx, "x", "self")
+	if err != nil || hit {
+		t.Fatalf("expected no hit, got hit=%v err=%v", hit, err)
+	}
+}
+
+func TestSlugInUseBy_HitDifferentID(t *testing.T) {
+	other := mustMarshal(t, domain.BlogPost{ID: "other"})
+	c := &mockDDB{
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return &dynamodb.QueryOutput{Count: 1, Items: []map[string]types.AttributeValue{other}}, nil
+		},
+	}
+	hit, err := slugInUseBy(context.Background(), c, tn, idx, "x", "self")
+	if err != nil || !hit {
+		t.Fatalf("expected hit, got hit=%v err=%v", hit, err)
+	}
+}
+
+func TestSlugInUseBy_HitSelf_NotConflict(t *testing.T) {
+	self := mustMarshal(t, domain.BlogPost{ID: "self"})
+	c := &mockDDB{
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return &dynamodb.QueryOutput{Count: 1, Items: []map[string]types.AttributeValue{self}}, nil
+		},
+	}
+	hit, err := slugInUseBy(context.Background(), c, tn, idx, "x", "self")
+	if err != nil || hit {
+		t.Fatalf("expected self-hit not conflict, got hit=%v err=%v", hit, err)
+	}
+}
+
+func TestSlugInUseBy_QueryError(t *testing.T) {
+	c := &mockDDB{
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return nil, errors.New("ddb")
+		},
+	}
+	_, err := slugInUseBy(context.Background(), c, tn, idx, "x", "self")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestPickAvailableSlug_NoCollision(t *testing.T) {
+	c := &mockDDB{
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return &dynamodb.QueryOutput{}, nil
+		},
+	}
+	slug, collisions, err := pickAvailableSlug(context.Background(), c, tn, idx, "hello", "self")
+	if err != nil || slug != "hello" || collisions != 0 {
+		t.Fatalf("expected hello/0/nil, got %s/%d/%v", slug, collisions, err)
+	}
+}
+
+func TestPickAvailableSlug_TwoCollisions(t *testing.T) {
+	calls := 0
+	other := mustMarshal(t, domain.BlogPost{ID: "x"})
+	c := &mockDDB{
+		queryFn: func(_ context.Context, in *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			calls++
+			val := in.ExpressionAttributeValues[":slug"].(*types.AttributeValueMemberS).Value
+			if val == "hello" || val == "hello-2" {
+				return &dynamodb.QueryOutput{Count: 1, Items: []map[string]types.AttributeValue{other}}, nil
+			}
+			return &dynamodb.QueryOutput{}, nil
+		},
+	}
+	slug, collisions, err := pickAvailableSlug(context.Background(), c, tn, idx, "hello", "self")
+	if err != nil || slug != "hello-3" || collisions != 2 {
+		t.Fatalf("expected hello-3/2/nil, got %s/%d/%v", slug, collisions, err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 query calls, got %d", calls)
+	}
+}
+
+func TestPickAvailableSlug_QueryError(t *testing.T) {
+	c := &mockDDB{
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return nil, errors.New("ddb")
+		},
+	}
+	_, _, err := pickAvailableSlug(context.Background(), c, tn, idx, "hello", "self")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestWriteSlug_OK(t *testing.T) {
+	var captured *dynamodb.UpdateItemInput
+	c := &mockDDB{
+		updateFn: func(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+			captured = in
+			return &dynamodb.UpdateItemOutput{}, nil
+		},
+	}
+	if err := writeSlug(context.Background(), c, tn, "id-1", "my-slug"); err != nil {
+		t.Fatal(err)
+	}
+	if captured == nil {
+		t.Fatal("UpdateItem not called")
+	}
+	if *captured.UpdateExpression != "SET slug = :s" {
+		t.Errorf("unexpected expression: %s", *captured.UpdateExpression)
+	}
+	got := captured.ExpressionAttributeValues[":s"].(*types.AttributeValueMemberS).Value
+	if got != "my-slug" {
+		t.Errorf("expected my-slug, got %s", got)
+	}
+}
+
+func TestBackfill_DryRunDoesNotUpdate(t *testing.T) {
+	post := mustMarshal(t, domain.BlogPost{ID: "id-1", Title: "Hello World"})
+	c := &mockDDB{
+		scanFn: func(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+			return &dynamodb.ScanOutput{Items: []map[string]types.AttributeValue{post}}, nil
+		},
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return &dynamodb.QueryOutput{}, nil
+		},
+		updateFn: func(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+			t.Error("UpdateItem should not be called on dry-run")
+			return &dynamodb.UpdateItemOutput{}, nil
+		},
+	}
+	if err := backfill(context.Background(), c, tn, idx, true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBackfill_SkipsPostsWithExistingSlug(t *testing.T) {
+	withSlug := mustMarshal(t, domain.BlogPost{ID: "id-1", Title: "Hello", Slug: ptr("already-set")})
+	scanned := false
+	updated := false
+	c := &mockDDB{
+		scanFn: func(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+			scanned = true
+			return &dynamodb.ScanOutput{Items: []map[string]types.AttributeValue{withSlug}}, nil
+		},
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			t.Error("Query should not run for posts with slug")
+			return &dynamodb.QueryOutput{}, nil
+		},
+		updateFn: func(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+			updated = true
+			return &dynamodb.UpdateItemOutput{}, nil
+		},
+	}
+	if err := backfill(context.Background(), c, tn, idx, false); err != nil {
+		t.Fatal(err)
+	}
+	if !scanned {
+		t.Error("expected Scan to run")
+	}
+	if updated {
+		t.Error("expected UpdateItem NOT to run")
+	}
+}
+
+func TestBackfill_UpdatesPostsMissingSlug(t *testing.T) {
+	missing := mustMarshal(t, domain.BlogPost{ID: "id-1", Title: "Hello World"})
+	queries := 0
+	var updatedSlug string
+	c := &mockDDB{
+		scanFn: func(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+			return &dynamodb.ScanOutput{Items: []map[string]types.AttributeValue{missing}}, nil
+		},
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			queries++
+			return &dynamodb.QueryOutput{}, nil
+		},
+		updateFn: func(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+			updatedSlug = in.ExpressionAttributeValues[":s"].(*types.AttributeValueMemberS).Value
+			return &dynamodb.UpdateItemOutput{}, nil
+		},
+	}
+	if err := backfill(context.Background(), c, tn, idx, false); err != nil {
+		t.Fatal(err)
+	}
+	if queries != 1 {
+		t.Errorf("expected 1 query, got %d", queries)
+	}
+	if updatedSlug != "hello-world" {
+		t.Errorf("expected slug hello-world, got %q", updatedSlug)
+	}
+}
+
+func TestBackfill_HandlesPagination(t *testing.T) {
+	page1 := mustMarshal(t, domain.BlogPost{ID: "id-1", Title: "First"})
+	page2 := mustMarshal(t, domain.BlogPost{ID: "id-2", Title: "Second"})
+	scanCalls := 0
+	c := &mockDDB{
+		scanFn: func(_ context.Context, in *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+			scanCalls++
+			if scanCalls == 1 {
+				return &dynamodb.ScanOutput{
+					Items:            []map[string]types.AttributeValue{page1},
+					LastEvaluatedKey: map[string]types.AttributeValue{"id": &types.AttributeValueMemberS{Value: "id-1"}},
+				}, nil
+			}
+			if in.ExclusiveStartKey == nil {
+				t.Error("expected ExclusiveStartKey on second scan")
+			}
+			return &dynamodb.ScanOutput{Items: []map[string]types.AttributeValue{page2}}, nil
+		},
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			return &dynamodb.QueryOutput{}, nil
+		},
+		updateFn: func(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+			return &dynamodb.UpdateItemOutput{}, nil
+		},
+	}
+	if err := backfill(context.Background(), c, tn, idx, false); err != nil {
+		t.Fatal(err)
+	}
+	if scanCalls != 2 {
+		t.Errorf("expected 2 scan calls, got %d", scanCalls)
+	}
+}
+
+func TestBackfill_SkipsEmptyTitle(t *testing.T) {
+	empty := mustMarshal(t, domain.BlogPost{ID: "id-1", Title: ""})
+	c := &mockDDB{
+		scanFn: func(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+			return &dynamodb.ScanOutput{Items: []map[string]types.AttributeValue{empty}}, nil
+		},
+		queryFn: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+			t.Error("Query should not be called for empty title")
+			return &dynamodb.QueryOutput{}, nil
+		},
+		updateFn: func(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+			t.Error("UpdateItem should not be called for empty title")
+			return &dynamodb.UpdateItemOutput{}, nil
+		},
+	}
+	if err := backfill(context.Background(), c, tn, idx, false); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBackfill_PropagatesScanError(t *testing.T) {
+	c := &mockDDB{
+		scanFn: func(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+			return nil, errors.New("scan failed")
+		},
+	}
+	err := backfill(context.Background(), c, tn, idx, false)
+	if err == nil || !strings.Contains(err.Error(), "scan") {
+		t.Errorf("expected scan error, got %v", err)
+	}
+}
+
+func TestParseFlags_OK(t *testing.T) {
+	t.Setenv("TABLE_NAME", "")
+	t.Setenv("AWS_REGION", "")
+	a, err := parseFlags([]string{"--table-name", "T", "--region", "ap-northeast-1", "--dry-run"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.tableName != "T" || a.region != "ap-northeast-1" || !a.dryRun || a.indexName != defaultSlugIndex {
+		t.Errorf("got %+v", a)
+	}
+}
+
+func TestParseFlags_MissingTableName(t *testing.T) {
+	t.Setenv("TABLE_NAME", "")
+	if _, err := parseFlags([]string{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRun_FlagError(t *testing.T) {
+	t.Setenv("TABLE_NAME", "")
+	if err := run(context.Background(), []string{}); err == nil {
+		t.Fatal("expected error from missing table-name")
+	}
+}
+
+func TestRun_AWSClientError(t *testing.T) {
+	original := newAWSClient
+	t.Cleanup(func() { newAWSClient = original })
+	newAWSClient = func(_ context.Context, _ string) (ddbAPI, error) {
+		return nil, errors.New("aws failed")
+	}
+	err := run(context.Background(), []string{"--table-name", "T"})
+	if err == nil || !strings.Contains(err.Error(), "aws") {
+		t.Errorf("expected aws error, got %v", err)
+	}
+}
+
+func TestRun_BackfillSucceeds(t *testing.T) {
+	original := newAWSClient
+	t.Cleanup(func() { newAWSClient = original })
+	newAWSClient = func(_ context.Context, _ string) (ddbAPI, error) {
+		return &mockDDB{
+			scanFn: func(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+				return &dynamodb.ScanOutput{}, nil
+			},
+		}, nil
+	}
+	if err := run(context.Background(), []string{"--table-name", "T", "--dry-run"}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -139,6 +139,8 @@ module "api" {
   lambda_delete_post_invoke_arn       = module.lambda.function_invoke_arns["delete_post"]
   lambda_build_status_post_arn        = module.lambda.function_arns["build_status_post"]
   lambda_build_status_post_invoke_arn = module.lambda.function_invoke_arns["build_status_post"]
+  lambda_get_post_by_slug_arn         = module.lambda.function_arns["get_post_by_slug"]
+  lambda_get_post_by_slug_invoke_arn  = module.lambda.function_invoke_arns["get_post_by_slug"]
   lambda_login_arn                    = module.lambda.function_arns["login"]
   lambda_login_invoke_arn             = module.lambda.function_invoke_arns["login"]
   lambda_logout_arn                   = module.lambda.function_arns["logout"]

--- a/terraform/environments/prd/main.tf
+++ b/terraform/environments/prd/main.tf
@@ -134,6 +134,8 @@ module "api" {
   lambda_delete_post_invoke_arn       = module.lambda.function_invoke_arns["delete_post"]
   lambda_build_status_post_arn        = module.lambda.function_arns["build_status_post"]
   lambda_build_status_post_invoke_arn = module.lambda.function_invoke_arns["build_status_post"]
+  lambda_get_post_by_slug_arn         = module.lambda.function_arns["get_post_by_slug"]
+  lambda_get_post_by_slug_invoke_arn  = module.lambda.function_invoke_arns["get_post_by_slug"]
   lambda_login_arn                    = module.lambda.function_arns["login"]
   lambda_login_invoke_arn             = module.lambda.function_invoke_arns["login"]
   lambda_logout_arn                   = module.lambda.function_arns["logout"]

--- a/terraform/modules/api/main.tf
+++ b/terraform/modules/api/main.tf
@@ -85,6 +85,21 @@ resource "aws_api_gateway_resource" "posts_id" {
   path_part   = "{id}"
 }
 
+# /posts/by-slug resource (PR7) — namespace for the friendly-slug lookup so
+# it can't collide with /posts/{id} (slugs and UUIDs share the same path slot).
+resource "aws_api_gateway_resource" "posts_by_slug" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  parent_id   = aws_api_gateway_resource.posts.id
+  path_part   = "by-slug"
+}
+
+# /posts/by-slug/{slug} resource (PR7)
+resource "aws_api_gateway_resource" "posts_by_slug_value" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  parent_id   = aws_api_gateway_resource.posts_by_slug.id
+  path_part   = "{slug}"
+}
+
 # /admin/posts resource
 # Requirement 5.1: Create /admin/posts resource
 resource "aws_api_gateway_resource" "admin_posts" {
@@ -907,6 +922,76 @@ resource "aws_api_gateway_integration_response" "posts_id_options" {
   resource_id = aws_api_gateway_resource.posts_id.id
   http_method = aws_api_gateway_method.posts_id_options.http_method
   status_code = aws_api_gateway_method_response.posts_id_options.status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
+    "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.cors_allow_origins[0]}'"
+  }
+}
+
+# --- GET /posts/by-slug/{slug} (No auth - public) --- (PR7)
+resource "aws_api_gateway_method" "posts_by_slug_value_get" {
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  resource_id   = aws_api_gateway_resource.posts_by_slug_value.id
+  http_method   = "GET"
+  authorization = "NONE"
+
+  request_parameters = {
+    "method.request.path.slug" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "posts_by_slug_value_get" {
+  rest_api_id             = aws_api_gateway_rest_api.main.id
+  resource_id             = aws_api_gateway_resource.posts_by_slug_value.id
+  http_method             = aws_api_gateway_method.posts_by_slug_value_get.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = var.lambda_get_post_by_slug_invoke_arn
+}
+
+# --- OPTIONS /posts/by-slug/{slug} (CORS) ---
+resource "aws_api_gateway_method" "posts_by_slug_value_options" {
+  rest_api_id   = aws_api_gateway_rest_api.main.id
+  resource_id   = aws_api_gateway_resource.posts_by_slug_value.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "posts_by_slug_value_options" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  resource_id = aws_api_gateway_resource.posts_by_slug_value.id
+  http_method = aws_api_gateway_method.posts_by_slug_value_options.http_method
+  type        = "MOCK"
+
+  request_templates = {
+    "application/json" = "{\"statusCode\": 200}"
+  }
+}
+
+resource "aws_api_gateway_method_response" "posts_by_slug_value_options" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  resource_id = aws_api_gateway_resource.posts_by_slug_value.id
+  http_method = aws_api_gateway_method.posts_by_slug_value_options.http_method
+  status_code = "200"
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+
+  response_models = {
+    "application/json" = "Empty"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "posts_by_slug_value_options" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  resource_id = aws_api_gateway_resource.posts_by_slug_value.id
+  http_method = aws_api_gateway_method.posts_by_slug_value_options.http_method
+  status_code = aws_api_gateway_method_response.posts_by_slug_value_options.status_code
 
   response_parameters = {
     "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
@@ -1741,6 +1826,8 @@ resource "aws_api_gateway_deployment" "main" {
       aws_api_gateway_resource.public.id,
       aws_api_gateway_resource.public_mindmaps.id,
       aws_api_gateway_resource.public_mindmaps_id.id,
+      aws_api_gateway_resource.posts_by_slug.id,
+      aws_api_gateway_resource.posts_by_slug_value.id,
       # Authorizer
       aws_api_gateway_authorizer.cognito.id,
       # Gateway Responses
@@ -1761,6 +1848,8 @@ resource "aws_api_gateway_deployment" "main" {
       aws_api_gateway_method.admin_auth_refresh_post.id,
       aws_api_gateway_method.posts_get.id,
       aws_api_gateway_method.posts_id_get.id,
+      aws_api_gateway_method.posts_by_slug_value_get.id,
+      aws_api_gateway_method.posts_by_slug_value_options.id,
       aws_api_gateway_method.categories_get.id,
       aws_api_gateway_method.admin_categories_post.id,
       aws_api_gateway_method.admin_categories_id_put.id,
@@ -1793,6 +1882,8 @@ resource "aws_api_gateway_deployment" "main" {
       aws_api_gateway_integration.admin_auth_refresh_post.id,
       aws_api_gateway_integration.posts_get.id,
       aws_api_gateway_integration.posts_id_get.id,
+      aws_api_gateway_integration.posts_by_slug_value_get.id,
+      aws_api_gateway_integration.posts_by_slug_value_options.id,
       aws_api_gateway_integration.categories_get.id,
       aws_api_gateway_integration.admin_categories_post.id,
       aws_api_gateway_integration.admin_categories_id_put.id,
@@ -1832,6 +1923,8 @@ resource "aws_api_gateway_deployment" "main" {
     aws_api_gateway_integration.admin_auth_refresh_post,
     aws_api_gateway_integration.posts_get,
     aws_api_gateway_integration.posts_id_get,
+    aws_api_gateway_integration.posts_by_slug_value_get,
+    aws_api_gateway_integration.posts_by_slug_value_options,
     aws_api_gateway_integration.categories_get,
     aws_api_gateway_integration.admin_categories_post,
     aws_api_gateway_integration.admin_categories_id_put,
@@ -2009,6 +2102,14 @@ resource "aws_lambda_permission" "build_status_post" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = var.lambda_build_status_post_arn
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.main.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "get_post_by_slug" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_get_post_by_slug_arn
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_api_gateway_rest_api.main.execution_arn}/*/*"
 }

--- a/terraform/modules/api/main.tf
+++ b/terraform/modules/api/main.tf
@@ -932,10 +932,11 @@ resource "aws_api_gateway_integration_response" "posts_id_options" {
 
 # --- GET /posts/by-slug/{slug} (No auth - public) --- (PR7)
 resource "aws_api_gateway_method" "posts_by_slug_value_get" {
-  rest_api_id   = aws_api_gateway_rest_api.main.id
-  resource_id   = aws_api_gateway_resource.posts_by_slug_value.id
-  http_method   = "GET"
-  authorization = "NONE"
+  rest_api_id          = aws_api_gateway_rest_api.main.id
+  resource_id          = aws_api_gateway_resource.posts_by_slug_value.id
+  http_method          = "GET"
+  authorization        = "NONE"
+  request_validator_id = aws_api_gateway_request_validator.main.id
 
   request_parameters = {
     "method.request.path.slug" = true
@@ -953,10 +954,11 @@ resource "aws_api_gateway_integration" "posts_by_slug_value_get" {
 
 # --- OPTIONS /posts/by-slug/{slug} (CORS) ---
 resource "aws_api_gateway_method" "posts_by_slug_value_options" {
-  rest_api_id   = aws_api_gateway_rest_api.main.id
-  resource_id   = aws_api_gateway_resource.posts_by_slug_value.id
-  http_method   = "OPTIONS"
-  authorization = "NONE"
+  rest_api_id          = aws_api_gateway_rest_api.main.id
+  resource_id          = aws_api_gateway_resource.posts_by_slug_value.id
+  http_method          = "OPTIONS"
+  authorization        = "NONE"
+  request_validator_id = aws_api_gateway_request_validator.main.id
 }
 
 resource "aws_api_gateway_integration" "posts_by_slug_value_options" {

--- a/terraform/modules/api/variables.tf
+++ b/terraform/modules/api/variables.tf
@@ -111,6 +111,16 @@ variable "lambda_build_status_post_invoke_arn" {
   description = "Build Status Post Lambda function invoke ARN"
 }
 
+variable "lambda_get_post_by_slug_arn" {
+  type        = string
+  description = "Get Post By Slug Lambda function ARN"
+}
+
+variable "lambda_get_post_by_slug_invoke_arn" {
+  type        = string
+  description = "Get Post By Slug Lambda function invoke ARN"
+}
+
 variable "lambda_login_arn" {
   type        = string
   description = "Login Lambda function ARN"

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -72,6 +72,11 @@ locals {
       description = "Get latest CodeBuild status for the Astro SSG site rebuild (Go)"
       binary_name = "posts-build_status"
     }
+    get_post_by_slug = {
+      name        = "blog-get-post-by-slug-go"
+      description = "Get published blog post by friendly slug (public, no-auth) (Go)"
+      binary_name = "posts-get_by_slug"
+    }
     login = {
       name        = "blog-login-go"
       description = "User authentication (Go)"
@@ -227,6 +232,12 @@ resource "aws_cloudwatch_log_group" "build_status_post" {
   tags              = local.common_tags
 }
 
+resource "aws_cloudwatch_log_group" "get_post_by_slug" {
+  name              = "/aws/lambda/${local.lambda_functions.get_post_by_slug.name}"
+  retention_in_days = local.log_retention_days
+  tags              = local.common_tags
+}
+
 resource "aws_cloudwatch_log_group" "login" {
   name              = "/aws/lambda/${local.lambda_functions.login.name}"
   retention_in_days = local.log_retention_days
@@ -310,6 +321,13 @@ data "archive_file" "build_status_post" {
   type             = "zip"
   source_file      = "${var.go_binary_path}/${local.lambda_functions.build_status_post.binary_name}/bootstrap"
   output_path      = "${path.module}/.terraform/tmp/${local.lambda_functions.build_status_post.binary_name}.zip"
+  output_file_mode = "0644"
+}
+
+data "archive_file" "get_post_by_slug" {
+  type             = "zip"
+  source_file      = "${var.go_binary_path}/${local.lambda_functions.get_post_by_slug.binary_name}/bootstrap"
+  output_path      = "${path.module}/.terraform/tmp/${local.lambda_functions.get_post_by_slug.binary_name}.zip"
   output_file_mode = "0644"
 }
 
@@ -556,6 +574,37 @@ resource "aws_lambda_function" "build_status_post" {
   }
 
   depends_on = [aws_cloudwatch_log_group.build_status_post]
+
+  tags = local.common_tags
+}
+
+# GET /posts/by-slug/{slug} - Public post fetch by friendly slug (PR7).
+# No-auth public endpoint that powers Astro's slug-based static routing.
+# Reuses the lambda_posts role: dynamodb:Query on SlugIndex is already
+# permitted via the existing index/* grant.
+resource "aws_lambda_function" "get_post_by_slug" {
+  function_name = local.lambda_functions.get_post_by_slug.name
+  description   = local.lambda_functions.get_post_by_slug.description
+  role          = aws_iam_role.lambda_posts.arn
+
+  filename         = data.archive_file.get_post_by_slug.output_path
+  source_code_hash = data.archive_file.get_post_by_slug.output_base64sha256
+
+  runtime       = "provided.al2023"
+  architectures = ["arm64"]
+  handler       = "bootstrap"
+  memory_size   = 128
+  timeout       = 30
+
+  environment {
+    variables = local.common_environment
+  }
+
+  tracing_config {
+    mode = local.tracing_mode
+  }
+
+  depends_on = [aws_cloudwatch_log_group.get_post_by_slug]
 
   tags = local.common_tags
 }

--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -14,6 +14,7 @@ output "function_arns" {
     update_post                  = aws_lambda_function.update_post.arn
     delete_post                  = aws_lambda_function.delete_post.arn
     build_status_post            = aws_lambda_function.build_status_post.arn
+    get_post_by_slug             = aws_lambda_function.get_post_by_slug.arn
     login                        = aws_lambda_function.login.arn
     logout                       = aws_lambda_function.logout.arn
     refresh                      = aws_lambda_function.refresh.arn
@@ -48,6 +49,7 @@ output "function_invoke_arns" {
     update_post                  = aws_lambda_function.update_post.invoke_arn
     delete_post                  = aws_lambda_function.delete_post.invoke_arn
     build_status_post            = aws_lambda_function.build_status_post.invoke_arn
+    get_post_by_slug             = aws_lambda_function.get_post_by_slug.invoke_arn
     login                        = aws_lambda_function.login.invoke_arn
     logout                       = aws_lambda_function.logout.invoke_arn
     refresh                      = aws_lambda_function.refresh.invoke_arn
@@ -82,6 +84,7 @@ output "function_names" {
     aws_lambda_function.update_post.function_name,
     aws_lambda_function.delete_post.function_name,
     aws_lambda_function.build_status_post.function_name,
+    aws_lambda_function.get_post_by_slug.function_name,
     aws_lambda_function.login.function_name,
     aws_lambda_function.logout.function_name,
     aws_lambda_function.refresh.function_name,
@@ -229,6 +232,21 @@ output "build_status_post_function_name" {
 output "build_status_post_invoke_arn" {
   value       = aws_lambda_function.build_status_post.invoke_arn
   description = "Build Status Post Lambda function invoke ARN for API Gateway integration"
+}
+
+output "get_post_by_slug_function_arn" {
+  value       = aws_lambda_function.get_post_by_slug.arn
+  description = "Get Post By Slug Lambda function ARN"
+}
+
+output "get_post_by_slug_function_name" {
+  value       = aws_lambda_function.get_post_by_slug.function_name
+  description = "Get Post By Slug Lambda function name"
+}
+
+output "get_post_by_slug_invoke_arn" {
+  value       = aws_lambda_function.get_post_by_slug.invoke_arn
+  description = "Get Post By Slug Lambda function invoke ARN for API Gateway integration"
 }
 
 # Auth domain

--- a/terraform/tests/module_interdependency.tftest.hcl
+++ b/terraform/tests/module_interdependency.tftest.hcl
@@ -150,6 +150,8 @@ run "api_outputs_for_cdn_and_lambda" {
     lambda_delete_post_invoke_arn                  = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-delete-post-go/invocations"
     lambda_build_status_post_arn                   = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-build-status-post-go"
     lambda_build_status_post_invoke_arn            = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-build-status-post-go/invocations"
+    lambda_get_post_by_slug_arn                    = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-post-by-slug-go"
+    lambda_get_post_by_slug_invoke_arn             = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-get-post-by-slug-go/invocations"
     lambda_login_arn                               = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-login-go"
     lambda_login_invoke_arn                        = "arn:aws:apigateway:ap-northeast-1:lambda:path/2015-03-31/functions/arn:aws:lambda:ap-northeast-1:123456789012:function:blog-login-go/invocations"
     lambda_logout_arn                              = "arn:aws:lambda:ap-northeast-1:123456789012:function:blog-logout-go"
@@ -223,8 +225,8 @@ run "lambda_outputs_for_monitoring" {
 
   # Verify function_names has expected count (known during plan)
   assert {
-    condition     = length(output.function_names) == 24
-    error_message = "Lambda module must export all 24 function names"
+    condition     = length(output.function_names) == 25
+    error_message = "Lambda module must export all 25 function names"
   }
 
   # Verify role name outputs match expected values

--- a/tests/e2e/mocks/handlers.ts
+++ b/tests/e2e/mocks/handlers.ts
@@ -122,6 +122,20 @@ export const handlers = [
     });
   }),
 
+  // 記事詳細取得（公開サイト・slug指定 / PR7）
+  // /posts/by-slug/:slug must be matched BEFORE /posts/:id so MSW doesn't
+  // treat "by-slug" as a post id.
+  http.get(`${API_BASE_URL}/posts/by-slug/:slug`, ({ params }) => {
+    const { slug } = params;
+    const post = mockPosts.find(
+      (p) => p.slug === slug && p.publishStatus === 'published'
+    );
+    if (!post) {
+      return HttpResponse.json({ message: 'Post not found' }, { status: 404 });
+    }
+    return HttpResponse.json(post);
+  }),
+
   // 記事詳細取得（公開サイト）
   http.get(`${API_BASE_URL}/posts/:id`, ({ params }) => {
     const { id } = params;

--- a/tests/e2e/mocks/mockData.ts
+++ b/tests/e2e/mocks/mockData.ts
@@ -62,6 +62,7 @@ export const createMockPost = (overrides: Partial<MockPost> = {}): MockPost => {
 export let mockPosts: MockPost[] = [
   createMockPost({
     id: 'post-1',
+    slug: 'getting-started-with-serverless',
     title: 'Getting Started with Serverless',
     contentMarkdown:
       '# Getting Started with Serverless\n\nServerless architecture is revolutionizing cloud computing...',
@@ -76,6 +77,7 @@ export let mockPosts: MockPost[] = [
   }),
   createMockPost({
     id: 'post-2',
+    slug: 'intro-to-typescript',
     title: 'Introduction to TypeScript',
     contentMarkdown:
       '# Introduction to TypeScript\n\nTypeScript adds static typing to JavaScript...',
@@ -153,6 +155,7 @@ export const resetMockPosts = () => {
   mockPosts = [
     createMockPost({
       id: 'post-1',
+      slug: 'getting-started-with-serverless',
       title: 'Getting Started with Serverless',
       contentMarkdown:
         '# Getting Started with Serverless\n\nServerless architecture is revolutionizing cloud computing...',
@@ -167,6 +170,7 @@ export const resetMockPosts = () => {
     }),
     createMockPost({
       id: 'post-2',
+      slug: 'intro-to-typescript',
       title: 'Introduction to TypeScript',
       contentMarkdown:
         '# Introduction to TypeScript\n\nTypeScript adds static typing to JavaScript...',


### PR DESCRIPTION
## Summary

- Public site moves to friendly `/posts/<slug>/` URLs while legacy `/posts/<id>/` keeps working via `<meta http-equiv="refresh">` + canonical link.
- New public Lambda `GET /posts/by-slug/{slug}` (no auth) backed by the `SlugIndex` GSI; Astro `[slug].astro` consumes it for static path generation.
- One-shot Go backfill script (`make backfill-slugs`) scans BlogPosts, computes slugs via `domain.GenerateSlug`, resolves collisions, supports `--dry-run`.

## Changes

### Backend (Go)
- `cmd/posts/get_by_slug/main.go` (+ tests, 7 cases): no-auth, Query SlugIndex `Limit:1`, 404 for missing/draft, hides drafts from public.
- `cmd/scripts/backfill_post_slugs/main.go`: Scan + UpdateItem, collision suffix `-2/-3/...`, summary log, dry-run mode.

### Terraform
- `modules/lambda`: register `get_post_by_slug` Lambda (reuses `lambda_posts` role; IAM `dynamodb:Query` + `index/*` already granted, no IAM delta).
- `modules/api`: new resources `posts_by_slug` + `posts_by_slug_value`, GET method, AWS_PROXY integration, OPTIONS CORS, lambda permission, deployment trigger updates.
- New variables/outputs (`lambda_get_post_by_slug_arn`/`_invoke_arn`); env wiring for both `dev` and `prd`.

### Astro
- `pages/posts/[slug].astro` (new): mirror of `[id].astro`; getStaticPaths filters posts by `Boolean(post.slug)`.
- `pages/posts/[id].astro`: when `post.slug` is set, render minimal HTML doc with meta-refresh + canonical → `/posts/<slug>/`. Legacy posts without a slug keep the original article render.
- `components/PostCard.astro`: link prefers `/posts/<slug>/`, falls back to `/posts/<id>/`.
- `lib/api.ts`: new `fetchPostBySlug()`. `lib/api.test.ts` adds 3 cases (happy, URL-encoding, 404).

### CI / E2E
- `ci.yml` + `deploy.yml` build matrices and verify-list include `posts-get_by_slug`.
- MSW handler mirrors `GET /posts/by-slug/:slug` (matched before `/posts/:id` to avoid collisions). `mockPosts` post-1/post-2 carry default slugs so existing admin specs continue to pass.

## Backfill workflow (manual after merge)

```bash
# preview
AWS_PROFILE=dev TABLE_NAME=blog-posts-dev make backfill-slugs ARGS="--dry-run"
# apply
AWS_PROFILE=dev TABLE_NAME=blog-posts-dev make backfill-slugs
# trigger SSG rebuild
aws codebuild start-build --project-name <project>
```

## Test plan
- [x] Go: `go test ./...` (all green; new `posts/get_by_slug` 84.6% coverage).
- [x] Go lint: clean for new packages (`get_by_slug`, `scripts/backfill_post_slugs`).
- [x] Public-astro: `bun run test --run` 447 passing (1 pre-existing failure unrelated, see `staticPageUtils.test.ts` on develop).
- [x] Public-astro Vite/Astro compile passes for `[slug].astro`.
- [x] Terraform: `terraform fmt -recursive` clean; `terraform validate` succeeds for `modules/lambda` and `modules/api`.
- [x] Admin E2E: `admin-metadata-sidebar`, `admin-slug-conflict`, `admin-crud`, `admin-autosave`, `admin-publish-flow` all green with the updated mockData.
- [ ] Manual after deploy: `curl https://<api>/posts/by-slug/<slug>` returns 200 for published, 404 for draft/missing.
- [ ] Manual after backfill: `aws dynamodb scan --filter-expression "attribute_not_exists(slug)"` returns 0 published items.

## Risks / follow-ups
- Meta-refresh is not equivalent to a 301 for SEO. CloudFront Functions can be added later to emit a real redirect — out of scope here.
- Astro emits the legacy `/posts/<id>/` HTML files alongside `/posts/<slug>/`. Once the slug rollout is verified, a follow-up PR can drop the `[id].astro` file (PR8 cleanup).
- The backfill script writes one item at a time. For ~hundreds of posts this is fine; for tens of thousands, batch via `BatchWriteItem` (not needed today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)