### PR TITLE
feat(theme): add dark mode with CSS variable tokens, FOUC bootstrap, …

### DIFF
--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -12,6 +12,23 @@
          block on fonts.googleapis.com. -->
     <link rel="preload" href="/fonts/caveat-variable.woff2" as="font" type="font/woff2" crossorigin />
 
+    <!-- Theme bootstrap (FOUC prevention). Mirrors public-astro Layout. -->
+    <script>
+      (function () {
+        try {
+          var saved = localStorage.getItem('theme');
+          if (saved !== 'light' && saved !== 'dark' && saved !== 'system') {
+            saved = 'system';
+          }
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var resolved = saved === 'system' ? (prefersDark ? 'dark' : 'light') : saved;
+          document.documentElement.setAttribute('data-theme', resolved);
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'light');
+        }
+      })();
+    </script>
+
     <title>Bone of my fallacy - Admin</title>
   </head>
   <body>

--- a/frontend/admin/src/components/AdminHeader.test.tsx
+++ b/frontend/admin/src/components/AdminHeader.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AdminHeader from './AdminHeader';
+import { ThemeProvider } from '../contexts/ThemeContext';
 
 // Amplifyのモック
 vi.mock('aws-amplify/auth', () => ({
@@ -27,9 +28,11 @@ vi.mock('../hooks/useAuth', () => ({
 
 const renderAdminHeader = (initialPath = '/dashboard') => {
   return render(
-    <MemoryRouter initialEntries={[initialPath]}>
-      <AdminHeader />
-    </MemoryRouter>
+    <ThemeProvider>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <AdminHeader />
+      </MemoryRouter>
+    </ThemeProvider>
   );
 };
 

--- a/frontend/admin/src/components/AdminHeader.tsx
+++ b/frontend/admin/src/components/AdminHeader.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import ThemeToggle from './ThemeToggle';
 
 const AdminHeader: React.FC = () => {
   const location = useLocation();
@@ -84,6 +85,7 @@ const AdminHeader: React.FC = () => {
             <Link to="/posts/new" className="admin-nav-link admin-nav-new">
               + New
             </Link>
+            <ThemeToggle />
             <button onClick={handleLogout} className="admin-logout-btn">
               Logout
             </button>
@@ -93,14 +95,13 @@ const AdminHeader: React.FC = () => {
 
       <style>{`
         .admin-header {
-          background: #ffffff;
-          border-bottom: 1px solid #e5e7eb;
+          background: var(--color-surface);
+          border-bottom: 1px solid var(--color-border);
           box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
           position: sticky;
           top: 0;
           z-index: 1000;
           backdrop-filter: blur(8px);
-          background: rgba(255, 255, 255, 0.95);
         }
 
         .admin-header-container {
@@ -134,19 +135,19 @@ const AdminHeader: React.FC = () => {
           font-family: 'Caveat', cursive;
           font-size: 1.6rem;
           font-weight: 600;
-          color: #1f2937;
+          color: var(--color-text-heading);
           letter-spacing: 0.02em;
           margin-right: 12px;
         }
 
         .admin-nav {
           display: flex;
-          gap: 24px;
+          gap: 20px;
           align-items: center;
         }
 
         .admin-nav-link {
-          color: #374151;
+          color: var(--color-text);
           text-decoration: none;
           font-size: 0.95rem;
           font-weight: 500;
@@ -162,12 +163,12 @@ const AdminHeader: React.FC = () => {
           left: 0;
           width: 0;
           height: 2px;
-          background: #2D2A5A;
+          background: var(--color-primary);
           transition: width 0.2s ease;
         }
 
         .admin-nav-link:hover {
-          color: #1f2937;
+          color: var(--color-text-heading);
         }
 
         .admin-nav-link:hover::after {
@@ -175,7 +176,7 @@ const AdminHeader: React.FC = () => {
         }
 
         .admin-nav-link.active {
-          color: #1f2937;
+          color: var(--color-text-heading);
         }
 
         .admin-nav-link.active::after {
@@ -186,11 +187,11 @@ const AdminHeader: React.FC = () => {
           display: flex;
           align-items: center;
           gap: 6px;
-          color: #6b7280 !important;
+          color: var(--color-text-muted) !important;
         }
 
         .admin-nav-external:hover {
-          color: #2D2A5A !important;
+          color: var(--color-primary) !important;
         }
 
         .admin-nav-external::after {
@@ -202,8 +203,8 @@ const AdminHeader: React.FC = () => {
         }
 
         .admin-nav-new {
-          background: #2D2A5A;
-          color: white !important;
+          background: var(--color-primary);
+          color: var(--color-text-on-primary) !important;
           padding: 8px 16px;
           border-radius: 8px;
           transition: all 0.2s ease;
@@ -214,14 +215,14 @@ const AdminHeader: React.FC = () => {
         }
 
         .admin-nav-new:hover {
-          background: #3d3a6a;
-          color: white !important;
+          background: var(--color-primary-hover);
+          color: var(--color-text-on-primary) !important;
         }
 
         .admin-logout-btn {
           background: transparent;
-          border: 1px solid #e5e7eb;
-          color: #6b7280;
+          border: 1px solid var(--color-border);
+          color: var(--color-text-muted);
           padding: 8px 16px;
           border-radius: 8px;
           font-size: 0.95rem;
@@ -231,9 +232,9 @@ const AdminHeader: React.FC = () => {
         }
 
         .admin-logout-btn:hover {
-          border-color: #2D2A5A;
-          color: #2D2A5A;
-          background: #f9fafb;
+          border-color: var(--color-primary);
+          color: var(--color-primary);
+          background: var(--color-surface-elevated);
         }
 
         @media (max-width: 768px) {

--- a/frontend/admin/src/components/AdminLayout.test.tsx
+++ b/frontend/admin/src/components/AdminLayout.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AdminLayout from './AdminLayout';
+import { ThemeProvider } from '../contexts/ThemeContext';
 
 // Amplifyのモック
 vi.mock('aws-amplify/auth', () => ({
@@ -31,11 +32,13 @@ const renderAdminLayout = (props: {
   children?: React.ReactNode;
 }) => {
   return render(
-    <MemoryRouter>
-      <AdminLayout {...props}>
-        {props.children || <div>Content</div>}
-      </AdminLayout>
-    </MemoryRouter>
+    <ThemeProvider>
+      <MemoryRouter>
+        <AdminLayout {...props}>
+          {props.children || <div>Content</div>}
+        </AdminLayout>
+      </MemoryRouter>
+    </ThemeProvider>
   );
 };
 

--- a/frontend/admin/src/components/ThemeToggle.tsx
+++ b/frontend/admin/src/components/ThemeToggle.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useTheme } from '../contexts/ThemeContext';
+
+const ThemeToggle: React.FC = () => {
+  const { resolvedTheme, toggleTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  return (
+    <>
+      <button
+        type="button"
+        className="theme-toggle"
+        aria-label={
+          isDark ? 'ライトモードに切り替える' : 'ダークモードに切り替える'
+        }
+        onClick={toggleTheme}
+      >
+        {isDark ? (
+          <svg
+            className="theme-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2" />
+            <path d="M12 20v2" />
+            <path d="m4.93 4.93 1.41 1.41" />
+            <path d="m17.66 17.66 1.41 1.41" />
+            <path d="M2 12h2" />
+            <path d="M20 12h2" />
+            <path d="m6.34 17.66-1.41 1.41" />
+            <path d="m19.07 4.93-1.41 1.41" />
+          </svg>
+        ) : (
+          <svg
+            className="theme-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+          </svg>
+        )}
+      </button>
+
+      <style>{`
+        .theme-toggle {
+          background: transparent;
+          border: 1px solid var(--color-border);
+          border-radius: 8px;
+          padding: 6px;
+          width: 36px;
+          height: 36px;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          cursor: pointer;
+          color: var(--color-text-muted);
+          transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+        }
+
+        .theme-toggle:hover {
+          color: var(--color-text);
+          border-color: var(--color-border-strong);
+          background: var(--color-surface-elevated);
+        }
+
+        .theme-icon {
+          width: 18px;
+          height: 18px;
+        }
+      `}</style>
+    </>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/admin/src/contexts/ThemeContext.tsx
+++ b/frontend/admin/src/contexts/ThemeContext.tsx
@@ -1,0 +1,120 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+const STORAGE_KEY = 'theme';
+
+interface ThemeContextValue {
+  theme: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (next: ThemePreference) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function readStoredTheme(): ThemePreference {
+  if (typeof window === 'undefined') return 'system';
+  const saved = window.localStorage.getItem(STORAGE_KEY);
+  if (saved === 'light' || saved === 'dark' || saved === 'system') return saved;
+  return 'system';
+}
+
+function resolveTheme(pref: ThemePreference): ResolvedTheme {
+  if (pref !== 'system') return pref;
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return 'light';
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
+function applyTheme(resolved: ResolvedTheme): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('data-theme', resolved);
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ThemePreference>(() =>
+    readStoredTheme()
+  );
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    resolveTheme(readStoredTheme())
+  );
+
+  useEffect(() => {
+    const next = resolveTheme(theme);
+    setResolvedTheme(next);
+    applyTheme(next);
+  }, [theme]);
+
+  useEffect(() => {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.matchMedia !== 'function'
+    ) {
+      return;
+    }
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const handle = (e: MediaQueryListEvent) => {
+      if (theme !== 'system') return;
+      const next: ResolvedTheme = e.matches ? 'dark' : 'light';
+      setResolvedTheme(next);
+      applyTheme(next);
+    };
+    if (mql.addEventListener) {
+      mql.addEventListener('change', handle);
+      return () => mql.removeEventListener('change', handle);
+    }
+    mql.addListener(handle);
+    return () => mql.removeListener(handle);
+  }, [theme]);
+
+  const setTheme = useCallback((next: ThemePreference) => {
+    setThemeState(next);
+    try {
+      if (next === 'system') {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(STORAGE_KEY, next);
+      }
+    } catch {
+      // localStorage may be unavailable; ignore.
+    }
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+  }, [resolvedTheme, setTheme]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, resolvedTheme, setTheme, toggleTheme }),
+    [theme, resolvedTheme, setTheme, toggleTheme]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
+}

--- a/frontend/admin/src/index.css
+++ b/frontend/admin/src/index.css
@@ -13,6 +13,130 @@
   src: url('/fonts/caveat-variable.woff2') format('woff2');
 }
 
+/* ============================================
+   Design Tokens (Light theme — default)
+   public-astro/src/styles/global.css と同型に揃える。
+   Dark theme は <html data-theme="dark"> で切替。
+   ============================================ */
+:root {
+  --color-bg: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-surface-elevated: #f9fafb;
+  --color-surface-muted: #f3f4f6;
+
+  --color-text: #374151;
+  --color-text-muted: #6b7280;
+  --color-text-heading: #111827;
+  --color-text-on-primary: #ffffff;
+
+  --color-border: #e5e7eb;
+  --color-border-strong: #d1d5db;
+
+  --color-primary: #2d2a5a;
+  --color-primary-hover: #3d3a6a;
+  --color-primary-soft: rgba(45, 42, 90, 0.1);
+  --color-accent: #c9a857;
+  --color-accent-hover: #b89346;
+
+  --color-success: #059669;
+  --color-success-hover: #047857;
+  --color-success-bg: #d1fae5;
+  --color-success-text: #065f46;
+  --color-success-border: #bbf7d0;
+  --color-success-alert-bg: #f0fdf4;
+
+  --color-danger: #dc2626;
+  --color-danger-hover: #b91c1c;
+  --color-danger-bg: #fef2f2;
+  --color-danger-text: #991b1b;
+  --color-danger-border: #fecaca;
+  --color-danger-soft: rgba(220, 38, 38, 0.1);
+
+  --color-warning: #d97706;
+  --color-warning-hover: #b45309;
+  --color-warning-bg: #fef3c7;
+  --color-warning-text: #92400e;
+  --color-warning-alert-bg: #fffbeb;
+  --color-warning-border: #fde68a;
+
+  --color-link: #c9a857;
+  --color-link-hover: #2d2a5a;
+
+  --color-code-bg: #f3f4f6;
+  --color-code-pre-bg: #1f2937;
+  --color-code-pre-text: #e5e7eb;
+
+  --color-focus-ring: rgba(156, 163, 175, 0.1);
+
+  --shadow-card: 0 4px 12px rgba(0, 0, 0, 0.05);
+  --shadow-card-strong: 0 10px 25px rgba(0, 0, 0, 0.08);
+
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  --color-bg: #0f1117;
+  --color-surface: #1a1d29;
+  --color-surface-elevated: #252937;
+  --color-surface-muted: #161922;
+
+  --color-text: #d1d5db;
+  --color-text-muted: #9ca3af;
+  --color-text-heading: #f3f4f6;
+  --color-text-on-primary: #ffffff;
+
+  --color-border: #2d3142;
+  --color-border-strong: #3d4252;
+
+  --color-primary: #7a76b8;
+  --color-primary-hover: #9590ce;
+  --color-primary-soft: rgba(122, 118, 184, 0.18);
+  --color-accent: #d4b56a;
+  --color-accent-hover: #e0c47e;
+
+  --color-success: #10b981;
+  --color-success-hover: #34d399;
+  --color-success-bg: rgba(16, 185, 129, 0.15);
+  --color-success-text: #6ee7b7;
+  --color-success-border: rgba(16, 185, 129, 0.3);
+  --color-success-alert-bg: rgba(16, 185, 129, 0.08);
+
+  --color-danger: #ef4444;
+  --color-danger-hover: #f87171;
+  --color-danger-bg: rgba(239, 68, 68, 0.15);
+  --color-danger-text: #fca5a5;
+  --color-danger-border: rgba(239, 68, 68, 0.3);
+  --color-danger-soft: rgba(239, 68, 68, 0.18);
+
+  --color-warning: #f59e0b;
+  --color-warning-hover: #fbbf24;
+  --color-warning-bg: rgba(245, 158, 11, 0.15);
+  --color-warning-text: #fcd34d;
+  --color-warning-alert-bg: rgba(245, 158, 11, 0.08);
+  --color-warning-border: rgba(245, 158, 11, 0.3);
+
+  --color-link: #d4b56a;
+  --color-link-hover: #a59ee0;
+
+  --color-code-bg: rgba(255, 255, 255, 0.06);
+  --color-code-pre-bg: #0a0c12;
+  --color-code-pre-text: #e5e7eb;
+
+  --color-focus-ring: rgba(122, 118, 184, 0.25);
+
+  --shadow-card: 0 4px 12px rgba(0, 0, 0, 0.45);
+  --shadow-card-strong: 0 10px 25px rgba(0, 0, 0, 0.6);
+
+  color-scheme: dark;
+}
+
+@layer base {
+  html, body {
+    background-color: var(--color-bg);
+    color: var(--color-text);
+  }
+}
+
 @layer components {
   /* ============================================
      Badge Styles
@@ -27,30 +151,30 @@
   }
 
   .admin-badge-dark {
-    background: #2D2A5A;
-    color: white;
+    background: var(--color-primary);
+    color: var(--color-text-on-primary);
   }
 
   .admin-badge-light {
-    background: #f3f4f6;
-    color: #374151;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface-muted);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
   }
 
   .admin-badge-success {
-    background: #d1fae5;
-    color: #065f46;
+    background: var(--color-success-bg);
+    color: var(--color-success-text);
   }
 
   .admin-badge-warning {
-    background: #fef3c7;
-    color: #92400e;
+    background: var(--color-warning-bg);
+    color: var(--color-warning-text);
   }
 
   /* Header-specific badge variant */
   .admin-badge-header {
-    background: #2D2A5A;
-    color: white;
+    background: var(--color-primary);
+    color: var(--color-text-on-primary);
     padding: 4px 10px;
     font-size: 0.7rem;
     text-transform: uppercase;
@@ -76,50 +200,50 @@
   }
 
   .admin-btn-primary {
-    background: #2D2A5A;
-    color: white;
+    background: var(--color-primary);
+    color: var(--color-text-on-primary);
   }
 
   .admin-btn-primary:hover {
-    background: #3d3a6a;
+    background: var(--color-primary-hover);
   }
 
   .admin-btn-secondary {
-    background: white;
-    color: #374151;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
   }
 
   .admin-btn-secondary:hover {
-    border-color: #d1d5db;
-    background: #f9fafb;
+    border-color: var(--color-border-strong);
+    background: var(--color-surface-elevated);
   }
 
   .admin-btn-success {
-    background: #059669;
-    color: white;
+    background: var(--color-success);
+    color: var(--color-text-on-primary);
   }
 
   .admin-btn-success:hover {
-    background: #047857;
+    background: var(--color-success-hover);
   }
 
   .admin-btn-danger {
-    background: #dc2626;
-    color: white;
+    background: var(--color-danger);
+    color: var(--color-text-on-primary);
   }
 
   .admin-btn-danger:hover {
-    background: #b91c1c;
+    background: var(--color-danger-hover);
   }
 
   .admin-btn-warning {
-    background: #d97706;
-    color: white;
+    background: var(--color-warning);
+    color: var(--color-text-on-primary);
   }
 
   .admin-btn-warning:hover {
-    background: #b45309;
+    background: var(--color-warning-hover);
   }
 
   .admin-btn-sm {
@@ -136,8 +260,8 @@
      Card Styles
      ============================================ */
   .admin-card {
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: 24px;
     margin-bottom: 24px;
@@ -145,13 +269,13 @@
   }
 
   .admin-card:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    box-shadow: var(--shadow-card);
   }
 
   .admin-card-title {
     font-size: 1.125rem;
     font-weight: 600;
-    color: #2D2A5A;
+    color: var(--color-primary);
     margin: 0 0 16px 0;
   }
 
@@ -166,8 +290,8 @@
   }
 
   .admin-stat-card {
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: 24px;
     transition: all 0.2s ease;
@@ -175,12 +299,12 @@
 
   .admin-stat-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-card-strong);
   }
 
   .admin-stat-label {
     font-size: 0.875rem;
-    color: #6b7280;
+    color: var(--color-text-muted);
     margin: 0 0 8px 0;
     font-weight: 500;
   }
@@ -188,27 +312,27 @@
   .admin-stat-value {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #2D2A5A;
+    color: var(--color-primary);
     margin: 0;
   }
 
   .admin-stat-value.accent {
-    color: #C9A857;
+    color: var(--color-accent);
   }
 
   /* ============================================
      List Styles
      ============================================ */
   .admin-list {
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     overflow: hidden;
   }
 
   .admin-list-item {
     padding: 20px 24px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--color-border);
     transition: background 0.2s ease;
   }
 
@@ -217,7 +341,7 @@
   }
 
   .admin-list-item:hover {
-    background: #f9fafb;
+    background: var(--color-surface-elevated);
   }
 
   /* ============================================
@@ -226,21 +350,22 @@
   .admin-input {
     width: 100%;
     padding: 12px 20px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     font-size: 0.95rem;
-    background: white;
+    background: var(--color-surface);
+    color: var(--color-text);
     transition: all 0.2s ease;
   }
 
   .admin-input:focus {
     outline: none;
-    border-color: #9ca3af;
-    box-shadow: 0 0 0 3px rgba(156, 163, 175, 0.1);
+    border-color: var(--color-border-strong);
+    box-shadow: 0 0 0 3px var(--color-focus-ring);
   }
 
   .admin-input::placeholder {
-    color: #9ca3af;
+    color: var(--color-text-muted);
   }
 
   /* ============================================
@@ -254,10 +379,10 @@
 
   .admin-tab {
     padding: 10px 20px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--color-border);
     border-radius: 24px;
-    background: white;
-    color: #6b7280;
+    background: var(--color-surface);
+    color: var(--color-text-muted);
     font-size: 0.95rem;
     font-weight: 500;
     cursor: pointer;
@@ -265,14 +390,14 @@
   }
 
   .admin-tab:hover {
-    border-color: #d1d5db;
-    color: #374151;
+    border-color: var(--color-border-strong);
+    color: var(--color-text);
   }
 
   .admin-tab.active {
-    background: #2D2A5A;
-    color: white;
-    border-color: #2D2A5A;
+    background: var(--color-primary);
+    color: var(--color-text-on-primary);
+    border-color: var(--color-primary);
   }
 
   /* ============================================
@@ -286,21 +411,21 @@
   }
 
   .admin-alert-error {
-    background: #fef2f2;
-    border: 1px solid #fecaca;
-    color: #991b1b;
+    background: var(--color-danger-bg);
+    border: 1px solid var(--color-danger-border);
+    color: var(--color-danger-text);
   }
 
   .admin-alert-success {
-    background: #f0fdf4;
-    border: 1px solid #bbf7d0;
-    color: #166534;
+    background: var(--color-success-alert-bg);
+    border: 1px solid var(--color-success-border);
+    color: var(--color-success-text);
   }
 
   .admin-alert-warning {
-    background: #fffbeb;
-    border: 1px solid #fde68a;
-    color: #92400e;
+    background: var(--color-warning-alert-bg);
+    border: 1px solid var(--color-warning-border);
+    color: var(--color-warning-text);
   }
 
   /* ============================================
@@ -309,13 +434,13 @@
   .admin-empty {
     text-align: center;
     padding: 48px 24px;
-    color: #6b7280;
+    color: var(--color-text-muted);
   }
 
   .admin-empty-title {
     font-size: 1.125rem;
     font-weight: 500;
-    color: #374151;
+    color: var(--color-text);
     margin: 0 0 8px 0;
   }
 
@@ -331,7 +456,7 @@
     justify-content: center;
     align-items: center;
     padding: 48px;
-    color: #6b7280;
+    color: var(--color-text-muted);
   }
 
   /* ============================================
@@ -345,62 +470,63 @@
     display: block;
     font-size: 0.875rem;
     font-weight: 500;
-    color: #374151;
+    color: var(--color-text);
     margin-bottom: 6px;
   }
 
   .admin-form-required {
-    color: #dc2626;
+    color: var(--color-danger);
   }
 
   .admin-form-input,
   .admin-form-textarea {
     width: 100%;
     padding: 12px 16px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     font-size: 0.95rem;
-    background: white;
+    background: var(--color-surface);
+    color: var(--color-text);
     transition: all 0.2s ease;
   }
 
   .admin-form-input:focus,
   .admin-form-textarea:focus {
     outline: none;
-    border-color: #2D2A5A;
-    box-shadow: 0 0 0 3px rgba(45, 42, 90, 0.1);
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px var(--color-primary-soft);
   }
 
   .admin-form-input::placeholder,
   .admin-form-textarea::placeholder {
-    color: #9ca3af;
+    color: var(--color-text-muted);
   }
 
   .admin-form-input-error {
-    border-color: #dc2626;
+    border-color: var(--color-danger);
   }
 
   .admin-form-input-error:focus {
-    border-color: #dc2626;
-    box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
+    border-color: var(--color-danger);
+    box-shadow: 0 0 0 3px var(--color-danger-soft);
   }
 
   .admin-form-input-disabled,
   .admin-form-input:disabled {
-    background-color: #f3f4f6;
-    color: #6b7280;
+    background-color: var(--color-surface-muted);
+    color: var(--color-text-muted);
     cursor: not-allowed;
-    border-color: #e5e7eb;
+    border-color: var(--color-border);
   }
 
   .admin-form-error {
-    color: #dc2626;
+    color: var(--color-danger);
     font-size: 0.875rem;
     margin-top: 6px;
   }
 
   .admin-form-hint {
-    color: #6b7280;
+    color: var(--color-text-muted);
     font-size: 0.875rem;
     margin-top: 6px;
   }

--- a/frontend/admin/src/main.tsx
+++ b/frontend/admin/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 import { configureAmplify } from './config/amplify';
+import { ThemeProvider } from './contexts/ThemeContext';
 
 /**
  * E2Eテスト時にMSWワーカーを起動
@@ -58,7 +59,9 @@ enableMocking()
     console.log('[main.tsx] Rendering React app...');
     createRoot(document.getElementById('root')!).render(
       <StrictMode>
-        <App />
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
       </StrictMode>
     );
     console.log('[main.tsx] React app rendered successfully');

--- a/frontend/public-astro/src/components/Header.astro
+++ b/frontend/public-astro/src/components/Header.astro
@@ -6,9 +6,11 @@
  * Features:
  * - Sticky header with blur effect
  * - Logo + site title (Caveat font)
- * - Navigation: Articles, About, Admin
+ * - Navigation: Articles, About, Admin, Theme toggle
  * - Responsive design
  */
+
+import ThemeToggle from './ThemeToggle.astro';
 ---
 
 <header class="site-header">
@@ -21,6 +23,7 @@
       <a href="/" class="nav-link">Articles</a>
       <a href="/mindmaps" class="nav-link">Mindmaps</a>
       <a href="/about" class="nav-link">About</a>
+      <ThemeToggle />
       <a href="/admin/" class="admin-icon-link" title="Admin">
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -48,14 +51,13 @@
 
 <style>
   .site-header {
-    background: #ffffff;
-    border-bottom: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     position: sticky;
     top: 0;
     z-index: 1000;
     backdrop-filter: blur(8px);
-    background: rgba(255, 255, 255, 0.95);
   }
 
   .header-container {
@@ -89,18 +91,18 @@
     font-family: 'Caveat', cursive;
     font-size: 1.6rem;
     font-weight: 600;
-    color: #1f2937;
+    color: var(--color-text-heading);
     letter-spacing: 0.02em;
   }
 
   .site-nav {
     display: flex;
-    gap: 32px;
+    gap: 24px;
     align-items: center;
   }
 
   .nav-link {
-    color: #374151;
+    color: var(--color-text);
     text-decoration: none;
     font-size: 0.95rem;
     font-weight: 500;
@@ -116,12 +118,12 @@
     left: 0;
     width: 0;
     height: 2px;
-    background: #374151;
+    background: var(--color-text);
     transition: width 0.2s ease;
   }
 
   .nav-link:hover {
-    color: #111827;
+    color: var(--color-text-heading);
   }
 
   .nav-link:hover::after {
@@ -129,17 +131,16 @@
   }
 
   .admin-icon-link {
-    color: #6b7280;
+    color: var(--color-text-muted);
     text-decoration: none;
     transition: color 0.2s ease;
     display: flex;
     align-items: center;
     padding: 8px;
-    margin-left: 8px;
   }
 
   .admin-icon-link:hover {
-    color: #374151;
+    color: var(--color-text);
   }
 
   .admin-icon-svg {
@@ -163,7 +164,7 @@
     }
 
     .site-nav {
-      gap: 20px;
+      gap: 16px;
     }
 
     .nav-link {

--- a/frontend/public-astro/src/components/MindmapCard.astro
+++ b/frontend/public-astro/src/components/MindmapCard.astro
@@ -33,8 +33,8 @@ const formattedDate = formatDateJa(mindmap.createdAt);
 
 <style>
   .mindmap-card {
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: 24px;
     transition: all 0.2s ease;
@@ -43,8 +43,8 @@ const formattedDate = formatDateJa(mindmap.createdAt);
 
   .mindmap-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 10px 25px rgba(45, 42, 90, 0.15);
-    border-color: #C9A857;
+    box-shadow: var(--shadow-card-strong);
+    border-color: var(--color-accent);
   }
 
   .mindmap-link {
@@ -56,7 +56,7 @@ const formattedDate = formatDateJa(mindmap.createdAt);
   }
 
   .mindmap-icon {
-    color: #C9A857;
+    color: var(--color-accent);
     margin-bottom: 12px;
   }
 
@@ -64,13 +64,13 @@ const formattedDate = formatDateJa(mindmap.createdAt);
     margin: 0 0 12px 0;
     font-size: 1.25rem;
     font-weight: 600;
-    color: #2D2A5A;
+    color: var(--color-primary);
     line-height: 1.4;
     flex-grow: 1;
   }
 
   .mindmap-link:hover .mindmap-title {
-    color: #C9A857;
+    color: var(--color-accent);
   }
 
   .mindmap-meta {
@@ -81,6 +81,6 @@ const formattedDate = formatDateJa(mindmap.createdAt);
   }
 
   .date {
-    color: #9ca3af;
+    color: var(--color-text-muted);
   }
 </style>

--- a/frontend/public-astro/src/components/PostCard.astro
+++ b/frontend/public-astro/src/components/PostCard.astro
@@ -19,11 +19,9 @@ const { post } = Astro.props;
 const excerpt = generateExcerpt(post.contentHtml, 100);
 const formattedDate = formatDateJa(post.createdAt);
 
-// PR8: slug is the canonical post URL; legacy /posts/<id> is gone. Posts
-// without a slug shouldn't reach this component (Astro getStaticPaths in
-// [slug].astro filters them and the listing API only returns slug-bearing
-// rows post-backfill).
-const postHref = post.slug ? `/posts/${post.slug}/` : `#missing-slug`;
+// PR7: prefer slug-based URL when the post has one; fall back to id for
+// any post that hasn't been backfilled yet.
+const postHref = post.slug ? `/posts/${post.slug}/` : `/posts/${post.id}/`;
 ---
 
 <article class="post-card" data-testid="article-card" data-post-id={post.id}>
@@ -46,8 +44,8 @@ const postHref = post.slug ? `/posts/${post.slug}/` : `#missing-slug`;
 
 <style>
   .post-card {
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: 24px;
     transition: all 0.2s ease;
@@ -56,8 +54,8 @@ const postHref = post.slug ? `/posts/${post.slug}/` : `#missing-slug`;
 
   .post-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 10px 25px rgba(45, 42, 90, 0.15);
-    border-color: #C9A857;
+    box-shadow: var(--shadow-card-strong);
+    border-color: var(--color-accent);
   }
 
   .post-link {
@@ -73,12 +71,12 @@ const postHref = post.slug ? `/posts/${post.slug}/` : `#missing-slug`;
     margin: 0 0 12px 0;
     font-size: 1.25rem;
     font-weight: 600;
-    color: #2D2A5A;
+    color: var(--color-primary);
     line-height: 1.4;
   }
 
   .post-link:hover .post-title {
-    color: #C9A857;
+    color: var(--color-accent);
   }
 
   .post-meta {
@@ -90,16 +88,16 @@ const postHref = post.slug ? `/posts/${post.slug}/` : `#missing-slug`;
   }
 
   .category {
-    background: #2D2A5A;
+    background: var(--color-primary);
     padding: 6px 16px;
     border-radius: 6px;
-    color: white;
+    color: var(--color-text-on-primary);
     font-weight: 500;
     font-size: 0.875rem;
   }
 
   .date {
-    color: #9ca3af;
+    color: var(--color-text-muted);
   }
 
   .tags {
@@ -110,18 +108,18 @@ const postHref = post.slug ? `/posts/${post.slug}/` : `#missing-slug`;
   }
 
   .tag {
-    background: #ffffff;
+    background: var(--color-surface);
     padding: 4px 10px;
     border-radius: 4px;
     font-size: 0.75rem;
-    color: #374151;
+    color: var(--color-text);
     font-weight: 500;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--color-border);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   }
 
   .excerpt {
-    color: #6b7280;
+    color: var(--color-text-muted);
     font-size: 0.95rem;
     line-height: 1.6;
     flex-grow: 1;

--- a/frontend/public-astro/src/components/SearchBar.astro
+++ b/frontend/public-astro/src/components/SearchBar.astro
@@ -205,7 +205,7 @@ const { posts } = Astro.props;
     left: 16px;
     width: 20px;
     height: 20px;
-    color: #9ca3af;
+    color: var(--color-text-muted);
     pointer-events: none;
   }
 
@@ -213,22 +213,22 @@ const { posts } = Astro.props;
     width: 100%;
     padding: 14px 48px 14px 48px;
     font-size: 1rem;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--color-border);
     border-radius: 12px;
-    background: white;
-    color: #111827;
+    background: var(--color-surface);
+    color: var(--color-text-heading);
     transition: all 0.2s ease;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   }
 
   .search-input:focus {
     outline: none;
-    border-color: #C9A857;
+    border-color: var(--color-accent);
     box-shadow: 0 0 0 3px rgba(201, 168, 87, 0.15), 0 1px 3px rgba(0, 0, 0, 0.05);
   }
 
   .search-input::placeholder {
-    color: #9ca3af;
+    color: var(--color-text-muted);
   }
 
   .search-clear {
@@ -242,15 +242,15 @@ const { posts } = Astro.props;
     padding: 0;
     border: none;
     background: transparent;
-    color: #9ca3af;
+    color: var(--color-text-muted);
     cursor: pointer;
     border-radius: 6px;
     transition: all 0.15s ease;
   }
 
   .search-clear:hover {
-    background: #f3f4f6;
-    color: #6b7280;
+    background: var(--color-surface-muted);
+    color: var(--color-text);
   }
 
   .search-clear svg {
@@ -260,10 +260,10 @@ const { posts } = Astro.props;
 
   .no-results-message {
     text-align: center;
-    color: #6b7280;
+    color: var(--color-text-muted);
     font-size: 1rem;
     padding: 40px 20px;
-    background: #f9fafb;
+    background: var(--color-surface-elevated);
     border-radius: 12px;
     margin-bottom: 24px;
   }

--- a/frontend/public-astro/src/components/ThemeToggle.astro
+++ b/frontend/public-astro/src/components/ThemeToggle.astro
@@ -1,0 +1,114 @@
+---
+/**
+ * ThemeToggle.astro - Light/Dark theme toggle button.
+ *
+ * - Reads the resolved theme from document.documentElement.dataset.theme
+ *   (set by the FOUC bootstrap script in Layout.astro).
+ * - Click toggles between "light" and "dark", persists to localStorage.
+ * - Setting localStorage to one of light/dark exits "system" mode; clearing
+ *   the key returns to system preference.
+ */
+---
+
+<button
+  type="button"
+  class="theme-toggle"
+  aria-label="テーマを切り替える"
+  data-theme-toggle
+>
+  <svg
+    class="theme-icon theme-icon-sun"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="4"></circle>
+    <path d="M12 2v2"></path>
+    <path d="M12 20v2"></path>
+    <path d="m4.93 4.93 1.41 1.41"></path>
+    <path d="m17.66 17.66 1.41 1.41"></path>
+    <path d="M2 12h2"></path>
+    <path d="M20 12h2"></path>
+    <path d="m6.34 17.66-1.41 1.41"></path>
+    <path d="m19.07 4.93-1.41 1.41"></path>
+  </svg>
+  <svg
+    class="theme-icon theme-icon-moon"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
+<script is:inline>
+  (function () {
+    var btn = document.querySelector('[data-theme-toggle]');
+    if (!btn) return;
+    btn.addEventListener('click', function () {
+      var current = document.documentElement.getAttribute('data-theme') === 'dark'
+        ? 'dark'
+        : 'light';
+      var next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', next);
+      try {
+        localStorage.setItem('theme', next);
+      } catch (e) {}
+    });
+  })();
+</script>
+
+<style>
+  .theme-toggle {
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    padding: 6px;
+    width: 36px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  }
+
+  .theme-toggle:hover {
+    color: var(--color-text);
+    border-color: var(--color-border-strong);
+    background: var(--color-surface-elevated);
+  }
+
+  .theme-icon {
+    width: 18px;
+    height: 18px;
+  }
+
+  /* Show the icon for the *opposite* mode (action affordance):
+     - light theme → moon icon (click → switch to dark)
+     - dark theme  → sun icon  (click → switch to light) */
+  :global(:root) .theme-icon-sun {
+    display: none;
+  }
+  :global(:root) .theme-icon-moon {
+    display: block;
+  }
+  :global(:root[data-theme='dark']) .theme-icon-sun {
+    display: block;
+  }
+  :global(:root[data-theme='dark']) .theme-icon-moon {
+    display: none;
+  }
+</style>

--- a/frontend/public-astro/src/layouts/Layout.astro
+++ b/frontend/public-astro/src/layouts/Layout.astro
@@ -63,6 +63,25 @@ const {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <!-- Theme bootstrap (FOUC prevention).
+         Reads localStorage.theme ("light" | "dark" | "system"), falls back to system preference,
+         and applies data-theme to <html> before any styles render. Must be inline & blocking. -->
+    <script is:inline>
+      (function () {
+        try {
+          var saved = localStorage.getItem('theme');
+          if (saved !== 'light' && saved !== 'dark' && saved !== 'system') {
+            saved = 'system';
+          }
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var resolved = saved === 'system' ? (prefersDark ? 'dark' : 'light') : saved;
+          document.documentElement.setAttribute('data-theme', resolved);
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'light');
+        }
+      })();
+    </script>
+
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/favicon.png" />
 
@@ -101,8 +120,22 @@ const {
       @import '../../../shared-ui/src/article.css';
     </style>
   </head>
-  <body class="min-h-screen bg-gray-50">
+  <body class="min-h-screen">
     <Header />
     <slot />
+
+    <!-- Live OS theme follow when user has not explicitly chosen light/dark. -->
+    <script is:inline>
+      (function () {
+        var mql = window.matchMedia('(prefers-color-scheme: dark)');
+        var handler = function (e) {
+          var saved = localStorage.getItem('theme') || 'system';
+          if (saved !== 'system') return;
+          document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+        };
+        if (mql.addEventListener) mql.addEventListener('change', handler);
+        else if (mql.addListener) mql.addListener(handler);
+      })();
+    </script>
   </body>
 </html>

--- a/frontend/public-astro/src/pages/404.astro
+++ b/frontend/public-astro/src/pages/404.astro
@@ -36,12 +36,29 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
       siteName={siteMetadata.siteName}
     />
 
+    <!-- Theme bootstrap (FOUC prevention). Mirrors Layout.astro. -->
+    <script is:inline>
+      (function () {
+        try {
+          var saved = localStorage.getItem('theme');
+          if (saved !== 'light' && saved !== 'dark' && saved !== 'system') {
+            saved = 'system';
+          }
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var resolved = saved === 'system' ? (prefersDark ? 'dark' : 'light') : saved;
+          document.documentElement.setAttribute('data-theme', resolved);
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'light');
+        }
+      })();
+    </script>
+
     <!-- Global Styles -->
     <style>
       @import '../styles/global.css';
     </style>
   </head>
-  <body class="min-h-screen bg-gray-50">
+  <body class="min-h-screen">
     <!-- Requirement 15.5: Site header and navigation maintained -->
     <header class="site-header">
       <a href="/" class="site-logo">{siteMetadata.siteName}</a>
@@ -101,8 +118,8 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
 <style>
   /* Header Styles - Consistent with site */
   .site-header {
-    background: white;
-    border-bottom: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
     padding: 16px 32px;
     display: flex;
     justify-content: space-between;
@@ -112,13 +129,13 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
   .site-logo {
     font-size: 1.25rem;
     font-weight: 600;
-    color: #2D2A5A;
+    color: var(--color-primary);
     text-decoration: none;
     font-family: 'Caveat', cursive;
   }
 
   .site-logo:hover {
-    color: #C9A857;
+    color: var(--color-accent);
   }
 
   .header-nav {
@@ -127,7 +144,7 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
   }
 
   .nav-link {
-    color: #6b7280;
+    color: var(--color-text-muted);
     text-decoration: none;
     font-size: 0.95rem;
     font-weight: 500;
@@ -135,7 +152,7 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
   }
 
   .nav-link:hover {
-    color: #C9A857;
+    color: var(--color-accent);
   }
 
   /* Error Container */
@@ -154,14 +171,14 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
   }
 
   .error-icon {
-    color: #9ca3af;
+    color: var(--color-text-muted);
     margin-bottom: 24px;
   }
 
   .error-code {
     font-size: 6rem;
     font-weight: 700;
-    color: #2D2A5A;
+    color: var(--color-primary);
     margin: 0;
     line-height: 1;
   }
@@ -169,13 +186,13 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
   .error-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #374151;
+    color: var(--color-text);
     margin: 16px 0;
   }
 
   .error-message {
     font-size: 1rem;
-    color: #6b7280;
+    color: var(--color-text-muted);
     margin: 0 0 32px 0;
     line-height: 1.6;
   }
@@ -184,8 +201,8 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    background: #2D2A5A;
-    color: white;
+    background: var(--color-primary);
+    color: var(--color-text-on-primary);
     padding: 12px 24px;
     border-radius: 8px;
     text-decoration: none;
@@ -195,19 +212,19 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
   }
 
   .home-button:hover {
-    background: #C9A857;
+    background: var(--color-accent);
     transform: translateY(-2px);
   }
 
   .suggestions {
     margin-top: 48px;
     padding-top: 32px;
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid var(--color-border);
   }
 
   .suggestions-title {
     font-size: 0.875rem;
-    color: #9ca3af;
+    color: var(--color-text-muted);
     margin: 0 0 16px 0;
   }
 
@@ -221,14 +238,14 @@ const SITE_URL = import.meta.env.SITE_URL || import.meta.env.SITE || 'https://ex
   }
 
   .suggestion-link {
-    color: #6b7280;
+    color: var(--color-text-muted);
     text-decoration: none;
     font-size: 0.95rem;
     transition: color 0.2s ease;
   }
 
   .suggestion-link:hover {
-    color: #C9A857;
+    color: var(--color-accent);
     text-decoration: underline;
   }
 

--- a/frontend/public-astro/src/pages/about.astro
+++ b/frontend/public-astro/src/pages/about.astro
@@ -99,20 +99,20 @@ const siteMetadata = getSiteMetadata();
 <style>
   .about-page {
     min-height: 100vh;
-    background: #fafafa;
+    background: var(--color-bg);
   }
 
   .hero-section {
-    background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+    background: linear-gradient(135deg, var(--color-surface-elevated) 0%, var(--color-surface-muted) 100%);
     padding: 80px 32px 60px;
     text-align: center;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--color-border);
   }
 
   .hero-title {
     font-size: 3.5rem;
     font-weight: 500;
-    color: #111827;
+    color: var(--color-text-heading);
     margin: 0;
     letter-spacing: 0.02em;
     font-family: 'Caveat', cursive;
@@ -135,35 +135,35 @@ const siteMetadata = getSiteMetadata();
   .section-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #2D2A5A;
+    color: var(--color-primary);
     margin: 0 0 24px 0;
     padding-bottom: 12px;
-    border-bottom: 2px solid #C9A857;
+    border-bottom: 2px solid var(--color-accent);
     display: inline-block;
   }
 
   .section-content {
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: 32px;
   }
 
   .section-content p {
-    color: #4b5563;
+    color: var(--color-text);
     font-size: 1rem;
     line-height: 1.8;
     margin: 0;
   }
 
   .section-content :global(strong) {
-    color: #2D2A5A;
+    color: var(--color-primary);
   }
 
   /* Profile Card */
   .profile-card {
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: 32px;
     display: flex;
@@ -180,7 +180,7 @@ const siteMetadata = getSiteMetadata();
     height: 120px;
     border-radius: 50%;
     object-fit: cover;
-    border: 3px solid #e5e7eb;
+    border: 3px solid var(--color-border);
   }
 
   .profile-info {
@@ -190,19 +190,19 @@ const siteMetadata = getSiteMetadata();
   .profile-name {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #2D2A5A;
+    color: var(--color-primary);
     margin: 0 0 8px 0;
   }
 
   .profile-role {
     font-size: 1rem;
-    color: #C9A857;
+    color: var(--color-accent);
     font-weight: 500;
     margin: 0 0 16px 0;
   }
 
   .profile-bio {
-    color: #4b5563;
+    color: var(--color-text);
     font-size: 1rem;
     line-height: 1.8;
     margin: 0;
@@ -219,21 +219,21 @@ const siteMetadata = getSiteMetadata();
     display: flex;
     align-items: center;
     gap: 12px;
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: 16px 24px;
     text-decoration: none;
-    color: #374151;
+    color: var(--color-text);
     font-weight: 500;
     transition: all 0.2s ease;
   }
 
   .social-link:hover {
-    border-color: #2D2A5A;
-    color: #2D2A5A;
+    border-color: var(--color-primary);
+    color: var(--color-primary);
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(45, 42, 90, 0.15);
+    box-shadow: var(--shadow-card-strong);
   }
 
   .social-icon {
@@ -248,14 +248,14 @@ const siteMetadata = getSiteMetadata();
   .navigation {
     margin-top: 48px;
     padding-top: 24px;
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid var(--color-border);
   }
 
   .back-link {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    color: #6b7280;
+    color: var(--color-text-muted);
     text-decoration: none;
     font-size: 0.95rem;
     font-weight: 500;
@@ -263,7 +263,7 @@ const siteMetadata = getSiteMetadata();
   }
 
   .back-link:hover {
-    color: #C9A857;
+    color: var(--color-accent);
   }
 
   @media (max-width: 768px) {

--- a/frontend/public-astro/src/pages/index.astro
+++ b/frontend/public-astro/src/pages/index.astro
@@ -84,16 +84,16 @@ const searchablePosts: SearchablePost[] = posts.map((post) => ({
 
 <style>
   .hero-section {
-    background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+    background: linear-gradient(135deg, var(--color-surface-elevated) 0%, var(--color-surface-muted) 100%);
     padding: 80px 32px 60px;
     text-align: center;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--color-border);
   }
 
   .hero-title {
     font-size: 3.5rem;
     font-weight: 500;
-    color: #111827;
+    color: var(--color-text-heading);
     margin: 0 0 24px 0;
     letter-spacing: 0.02em;
     font-family: 'Caveat', cursive;
@@ -112,18 +112,18 @@ const searchablePosts: SearchablePost[] = posts.map((post) => ({
   }
 
   .error-message {
-    background: #fef2f2;
-    border: 1px solid #fecaca;
+    background: var(--color-danger-bg);
+    border: 1px solid var(--color-danger-border);
     border-radius: 8px;
     padding: 16px;
     margin-bottom: 24px;
-    color: #991b1b;
+    color: var(--color-danger-text);
     font-size: 0.95rem;
   }
 
   .no-articles {
     text-align: center;
-    color: #6b7280;
+    color: var(--color-text-muted);
     font-size: 1.125rem;
     padding: 40px;
   }

--- a/frontend/public-astro/src/pages/mindmaps/[id].astro
+++ b/frontend/public-astro/src/pages/mindmaps/[id].astro
@@ -123,31 +123,31 @@ const jsonLdMindmap: JsonLdMindmap = {
   }
 
   .type-badge {
-    background: #2D2A5A;
+    background: var(--color-primary);
     padding: 6px 16px;
     border-radius: 6px;
-    color: white;
+    color: var(--color-text-on-primary);
     font-weight: 500;
     font-size: 0.875rem;
   }
 
   .date {
-    color: #6b7280;
+    color: var(--color-text-muted);
     font-size: 0.875rem;
   }
 
   .mindmap-title {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #111827;
+    color: var(--color-text-heading);
     line-height: 1.3;
     margin: 0;
     font-family: 'Caveat', cursive;
   }
 
   .mindmap-viewer-container {
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     overflow: hidden;
     margin-bottom: 32px;
@@ -159,21 +159,21 @@ const jsonLdMindmap: JsonLdMindmap = {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #9ca3af;
+    color: var(--color-text-muted);
     font-size: 1rem;
   }
 
   .mindmap-navigation {
     margin-top: 48px;
     padding-top: 24px;
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid var(--color-border);
   }
 
   .back-link {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    color: #6b7280;
+    color: var(--color-text-muted);
     text-decoration: none;
     font-size: 0.95rem;
     font-weight: 500;
@@ -181,7 +181,7 @@ const jsonLdMindmap: JsonLdMindmap = {
   }
 
   .back-link:hover {
-    color: #C9A857;
+    color: var(--color-accent);
   }
 
   /* D3.js Mindmap Viewer styles (Task 11.1) */

--- a/frontend/public-astro/src/pages/mindmaps/index.astro
+++ b/frontend/public-astro/src/pages/mindmaps/index.astro
@@ -58,16 +58,16 @@ try {
 
 <style>
   .page-header {
-    background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+    background: linear-gradient(135deg, var(--color-surface-elevated) 0%, var(--color-surface-muted) 100%);
     padding: 60px 32px 40px;
     text-align: center;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--color-border);
   }
 
   .page-title {
     font-size: 2.5rem;
     font-weight: 500;
-    color: #111827;
+    color: var(--color-text-heading);
     margin: 0;
     letter-spacing: 0.02em;
     font-family: 'Caveat', cursive;
@@ -81,7 +81,7 @@ try {
 
   .no-mindmaps {
     text-align: center;
-    color: #6b7280;
+    color: var(--color-text-muted);
     font-size: 1.125rem;
     padding: 40px;
   }

--- a/frontend/public-astro/src/pages/posts/[slug].astro
+++ b/frontend/public-astro/src/pages/posts/[slug].astro
@@ -192,23 +192,23 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   }
 
   .category {
-    background: #2D2A5A;
+    background: var(--color-primary);
     padding: 6px 16px;
     border-radius: 6px;
-    color: white;
+    color: var(--color-text-on-primary);
     font-weight: 500;
     font-size: 0.875rem;
   }
 
   .date {
-    color: #6b7280;
+    color: var(--color-text-muted);
     font-size: 0.875rem;
   }
 
   .post-title {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #111827;
+    color: var(--color-text-heading);
     line-height: 1.3;
     margin: 0 0 16px 0;
     font-family: 'Caveat', cursive;
@@ -221,13 +221,13 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   }
 
   .tag {
-    background: #f3f4f6;
+    background: var(--color-surface-muted);
     padding: 4px 12px;
     border-radius: 4px;
     font-size: 0.8rem;
-    color: #4b5563;
+    color: var(--color-text);
     font-weight: 500;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--color-border);
   }
 
   .hero-image {
@@ -245,7 +245,7 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   .post-content {
     font-size: 1.125rem;
     line-height: 1.8;
-    color: #374151;
+    color: var(--color-text);
   }
 
   /* Content HTML Styles */
@@ -255,7 +255,7 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   .post-content :global(h4),
   .post-content :global(h5),
   .post-content :global(h6) {
-    color: #111827;
+    color: var(--color-text-heading);
     margin-top: 2rem;
     margin-bottom: 1rem;
     font-weight: 600;
@@ -275,13 +275,13 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   }
 
   .post-content :global(a) {
-    color: #C9A857;
+    color: var(--color-link);
     text-decoration: underline;
     transition: color 0.2s ease;
   }
 
   .post-content :global(a:hover) {
-    color: #2D2A5A;
+    color: var(--color-link-hover);
   }
 
   .post-content :global(ul),
@@ -295,15 +295,15 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   }
 
   .post-content :global(blockquote) {
-    border-left: 4px solid #C9A857;
+    border-left: 4px solid var(--color-accent);
     padding-left: 1.5rem;
     margin: 1.5rem 0;
-    color: #6b7280;
+    color: var(--color-text-muted);
     font-style: italic;
   }
 
   .post-content :global(code) {
-    background: #f3f4f6;
+    background: var(--color-code-bg);
     padding: 0.2rem 0.4rem;
     border-radius: 4px;
     font-size: 0.9em;
@@ -311,8 +311,8 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   }
 
   .post-content :global(pre) {
-    background: #1f2937;
-    color: #e5e7eb;
+    background: var(--color-code-pre-bg);
+    color: var(--color-code-pre-text);
     padding: 1rem 1.5rem;
     border-radius: 8px;
     overflow-x: auto;
@@ -334,7 +334,7 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
 
   .post-content :global(strong) {
     font-weight: 600;
-    color: #111827;
+    color: var(--color-text-heading);
   }
 
   .post-content :global(em) {
@@ -358,14 +358,14 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   .post-navigation {
     margin-top: 48px;
     padding-top: 24px;
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid var(--color-border);
   }
 
   .back-link {
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    color: #6b7280;
+    color: var(--color-text-muted);
     text-decoration: none;
     font-size: 0.95rem;
     font-weight: 500;
@@ -373,13 +373,13 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   }
 
   .back-link:hover {
-    color: #C9A857;
+    color: var(--color-accent);
   }
 
   /* Task 11.2: Embedded mindmap styles (compact, fixed height) */
   .post-content :global(.mindmap-embed) {
-    background: white;
-    border: 1px solid #e5e7eb;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     overflow: hidden;
     margin: 1.5rem 0;
@@ -400,7 +400,7 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   }
 
   .post-content :global(.mindmap-embed-fallback) {
-    color: #9ca3af;
+    color: var(--color-text-muted);
     font-size: 0.9rem;
     font-style: italic;
     text-align: center;
@@ -417,7 +417,7 @@ const hasEmbeddedMindmaps = embeddedMindmapIds.length > 0;
   }
 
   .post-content :global(.mindmap-embed .mindmap-node.highlighted rect) {
-    stroke: #C9A857;
+    stroke: var(--color-accent);
     stroke-width: 2.5;
   }
 

--- a/frontend/public-astro/src/styles/global.css
+++ b/frontend/public-astro/src/styles/global.css
@@ -9,9 +9,6 @@
   src: url('/fonts/caveat-variable.woff2') format('woff2');
 }
 
-/* Self-hosted Shippori Mincho (Google Fonts v17 woff2) — body font.
-   font-display: swap so content renders immediately in fallback before
-   the ~3MB Japanese font finishes loading. */
 @font-face {
   font-family: 'Shippori Mincho';
   font-style: normal;
@@ -28,29 +25,117 @@
   src: url('/fonts/shippori-mincho-600.woff2') format('woff2');
 }
 
-/* Design tokens (aligned with admin) */
+/* Design tokens — light theme defaults.
+   Dark theme overrides via [data-theme="dark"]. FOUC bootstrap in Layout.astro. */
 :root {
-  --color-primary: #2D2A5A;
-  --color-accent: #C9A857;
+  --color-bg: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-surface-elevated: #f9fafb;
+  --color-surface-muted: #f3f4f6;
+  --color-text: #374151;
+  --color-text-muted: #6b7280;
+  --color-text-heading: #111827;
+  --color-text-on-primary: #ffffff;
+  --color-border: #e5e7eb;
+  --color-border-strong: #d1d5db;
+  --color-primary: #2d2a5a;
+  --color-primary-hover: #3d3a6a;
+  --color-primary-soft: rgba(45, 42, 90, 0.1);
+  --color-accent: #c9a857;
+  --color-accent-hover: #b89346;
+  --color-success: #059669;
+  --color-success-hover: #047857;
+  --color-success-bg: #d1fae5;
+  --color-success-text: #065f46;
+  --color-success-border: #bbf7d0;
+  --color-success-alert-bg: #f0fdf4;
+  --color-danger: #dc2626;
+  --color-danger-hover: #b91c1c;
+  --color-danger-bg: #fef2f2;
+  --color-danger-text: #991b1b;
+  --color-danger-border: #fecaca;
+  --color-danger-soft: rgba(220, 38, 38, 0.1);
+  --color-warning: #d97706;
+  --color-warning-hover: #b45309;
+  --color-warning-bg: #fef3c7;
+  --color-warning-text: #92400e;
+  --color-warning-alert-bg: #fffbeb;
+  --color-warning-border: #fde68a;
+  --color-link: #c9a857;
+  --color-link-hover: #2d2a5a;
+  --color-code-bg: #f3f4f6;
+  --color-code-pre-bg: #1f2937;
+  --color-code-pre-text: #e5e7eb;
+  --color-focus-ring: rgba(156, 163, 175, 0.1);
+  --shadow-card: 0 4px 12px rgba(0, 0, 0, 0.05);
+  --shadow-card-strong: 0 10px 25px rgba(0, 0, 0, 0.08);
+  color-scheme: light;
 }
 
-/* Custom base styles */
+:root[data-theme="dark"] {
+  --color-bg: #0f1117;
+  --color-surface: #1a1d29;
+  --color-surface-elevated: #252937;
+  --color-surface-muted: #161922;
+  --color-text: #d1d5db;
+  --color-text-muted: #9ca3af;
+  --color-text-heading: #f3f4f6;
+  --color-text-on-primary: #ffffff;
+  --color-border: #2d3142;
+  --color-border-strong: #3d4252;
+  --color-primary: #7a76b8;
+  --color-primary-hover: #9590ce;
+  --color-primary-soft: rgba(122, 118, 184, 0.18);
+  --color-accent: #d4b56a;
+  --color-accent-hover: #e0c47e;
+  --color-success: #10b981;
+  --color-success-hover: #34d399;
+  --color-success-bg: rgba(16, 185, 129, 0.15);
+  --color-success-text: #6ee7b7;
+  --color-success-border: rgba(16, 185, 129, 0.3);
+  --color-success-alert-bg: rgba(16, 185, 129, 0.08);
+  --color-danger: #ef4444;
+  --color-danger-hover: #f87171;
+  --color-danger-bg: rgba(239, 68, 68, 0.15);
+  --color-danger-text: #fca5a5;
+  --color-danger-border: rgba(239, 68, 68, 0.3);
+  --color-danger-soft: rgba(239, 68, 68, 0.18);
+  --color-warning: #f59e0b;
+  --color-warning-hover: #fbbf24;
+  --color-warning-bg: rgba(245, 158, 11, 0.15);
+  --color-warning-text: #fcd34d;
+  --color-warning-alert-bg: rgba(245, 158, 11, 0.08);
+  --color-warning-border: rgba(245, 158, 11, 0.3);
+  --color-link: #d4b56a;
+  --color-link-hover: #a59ee0;
+  --color-code-bg: rgba(255, 255, 255, 0.06);
+  --color-code-pre-bg: #0a0c12;
+  --color-code-pre-text: #e5e7eb;
+  --color-focus-ring: rgba(122, 118, 184, 0.25);
+  --shadow-card: 0 4px 12px rgba(0, 0, 0, 0.45);
+  --shadow-card-strong: 0 10px 25px rgba(0, 0, 0, 0.6);
+  color-scheme: dark;
+}
+
 @layer base {
   html {
     font-family: 'Shippori Mincho', serif;
-    background-color: #f5f5f5;
+    background-color: var(--color-bg);
+    color: var(--color-text);
   }
 
   body {
-    @apply text-gray-900 leading-relaxed;
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    line-height: 1.625;
   }
 
   h1, h2, h3, h4, h5, h6 {
     font-family: 'Caveat', cursive;
+    color: var(--color-text-heading);
   }
 }
 
-/* Custom component styles */
 @layer components {
   .container-main {
     @apply max-w-4xl mx-auto px-4 py-8;
@@ -77,23 +162,41 @@
   }
 
   .post-content a {
-    @apply text-blue-600 hover:text-blue-800 underline;
+    color: var(--color-link);
+    text-decoration: underline;
+  }
+
+  .post-content a:hover {
+    color: var(--color-link-hover);
   }
 
   .post-content code {
-    @apply bg-gray-100 px-1 py-0.5 rounded text-sm;
+    background: var(--color-code-bg);
+    padding: 0.125rem 0.25rem;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
   }
 
   .post-content pre {
-    @apply bg-gray-800 text-gray-100 p-4 rounded-lg overflow-x-auto my-4;
+    background: var(--color-code-pre-bg);
+    color: var(--color-code-pre-text);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    margin: 1rem 0;
   }
 
   .post-content pre code {
-    @apply bg-transparent p-0;
+    background: transparent;
+    padding: 0;
   }
 
   .post-content blockquote {
-    @apply border-l-4 border-gray-300 pl-4 italic my-4 text-gray-600;
+    border-left: 4px solid var(--color-border-strong);
+    padding-left: 1rem;
+    font-style: italic;
+    margin: 1rem 0;
+    color: var(--color-text-muted);
   }
 
   .post-content ul,

--- a/frontend/shared-ui/src/article.css
+++ b/frontend/shared-ui/src/article.css
@@ -8,18 +8,14 @@
  * すべてのルールは `.post-content` 配下にスコープしている。
  * 各アプリでレンダー結果を class="post-content" でラップすると適用される。
  *
- * 純粋 CSS で記述している (Tailwind の `@apply` を使わない) ため、
- * admin / public-astro いずれの Tailwind バージョンでも追加設定なしで動作する。
- *
- * Markdown→HTML エンジンが Goldmark (Astro) と react-markdown (admin) で異なる以上
- * pixel-perfect な一致は保証しないが、見出しサイズ / コードブロック / 引用枠線 /
- * リンク色など基本タイポグラフィは同一に揃える。
+ * 配色は `var(--color-*)` を参照する。トークンは public-astro/src/styles/global.css
+ * および admin/src/index.css で定義し、`[data-theme="dark"]` 切替に追従する。
  */
 
 .post-content {
   font-size: 1.125rem;
   line-height: 1.8;
-  color: #374151;
+  color: var(--color-text);
 }
 
 .post-content h1,
@@ -28,7 +24,7 @@
 .post-content h4,
 .post-content h5,
 .post-content h6 {
-  color: #111827;
+  color: var(--color-text-heading);
   margin-top: 2rem;
   margin-bottom: 1rem;
   font-weight: 600;
@@ -48,13 +44,13 @@
 }
 
 .post-content a {
-  color: #c9a857;
+  color: var(--color-link);
   text-decoration: underline;
   transition: color 0.2s ease;
 }
 
 .post-content a:hover {
-  color: #2d2a5a;
+  color: var(--color-link-hover);
 }
 
 .post-content ul,
@@ -63,9 +59,6 @@
   padding-left: 2rem;
 }
 
-/* `list-style-type` を明示する。Tailwind v4 の preflight が
-   `ul, ol { list-style: none }` でデフォルト bullet を消すため、
-   各アプリで Tailwind reset が入った場合でも bullet を復元する。 */
 .post-content ul {
   list-style-type: disc;
 }
@@ -79,15 +72,15 @@
 }
 
 .post-content blockquote {
-  border-left: 4px solid #c9a857;
+  border-left: 4px solid var(--color-accent);
   padding-left: 1.5rem;
   margin: 1.5rem 0;
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-style: italic;
 }
 
 .post-content code {
-  background: #f3f4f6;
+  background: var(--color-code-bg);
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
   font-size: 0.9em;
@@ -95,8 +88,8 @@
 }
 
 .post-content pre {
-  background: #1f2937;
-  color: #e5e7eb;
+  background: var(--color-code-pre-bg);
+  color: var(--color-code-pre-text);
   padding: 1rem 1.5rem;
   border-radius: 8px;
   overflow-x: auto;
@@ -119,7 +112,7 @@
 
 .post-content strong {
   font-weight: 600;
-  color: #111827;
+  color: var(--color-text-heading);
 }
 
 .post-content em {


### PR DESCRIPTION
…and toggle UI

- Define semantic color tokens in :root (light) and :root[data-theme="dark"] across public-astro/src/styles/global.css, shared-ui/src/article.css, admin/src/index.css
- Inline <head> bootstrap script in Layout.astro / 404.astro / admin/index.html resolves localStorage.theme ("light"|"dark"|"system") with prefers-color-scheme fallback, sets data-theme on <html> before render to prevent FOUC
- ThemeContext.tsx: React provider with useTheme hook, syncs to localStorage, follows OS theme changes when in "system" mode (matchMedia-guarded for jsdom)
- ThemeToggle.astro / ThemeToggle.tsx: header sun/moon toggle, persists choice
- Replace hardcoded hex/named colors with var(--color-*) in Header, AdminHeader, PostCard, MindmapCard, SearchBar, and pages (index/about/404/mindmaps/posts/[slug])
- Wrap AdminHeader/AdminLayout tests in <ThemeProvider>