### PR TITLE
feat(theme): ダークモード対応 (public-astro + admin)

### DIFF
--- a/frontend/admin/src/components/MindmapCustomNode.tsx
+++ b/frontend/admin/src/components/MindmapCustomNode.tsx
@@ -5,7 +5,7 @@ import type { MindmapNodeData } from '../utils/mindmapLayout';
 
 function MindmapCustomNodeComponent({ data, selected }: NodeProps) {
   const nodeData = data as MindmapNodeData;
-  const bgColor = nodeData.color ?? '#ffffff';
+  const bgColor = nodeData.color ?? 'var(--color-surface)';
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(nodeData.label);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -72,7 +72,7 @@ function MindmapCustomNodeComponent({ data, selected }: NodeProps) {
     ? '2px dashed #22c55e'
     : selected
       ? '2px solid #3b82f6'
-      : '1px solid #d1d5db';
+      : '1px solid var(--color-border-strong)';
   const boxShadowStyle = isDropTarget
     ? '0 0 8px rgba(34, 197, 94, 0.5)'
     : selected
@@ -166,7 +166,7 @@ function MindmapCustomNodeComponent({ data, selected }: NodeProps) {
           style={{
             fontSize: '10px',
             flexShrink: 0,
-            border: '1px solid #d1d5db',
+            border: '1px solid var(--color-border-strong)',
             borderRadius: '50%',
             width: '20px',
             height: '20px',
@@ -174,7 +174,7 @@ function MindmapCustomNodeComponent({ data, selected }: NodeProps) {
             alignItems: 'center',
             justifyContent: 'center',
             cursor: 'pointer',
-            backgroundColor: '#f9fafb',
+            backgroundColor: 'var(--color-surface-elevated)',
             padding: 0,
           }}
           title={

--- a/frontend/admin/src/components/MindmapEditor.tsx
+++ b/frontend/admin/src/components/MindmapEditor.tsx
@@ -523,7 +523,7 @@ function MindmapEditorInner({
           display: 'flex',
           gap: '8px',
           padding: '8px',
-          borderBottom: '1px solid #e5e7eb',
+          borderBottom: '1px solid var(--color-border)',
           flexWrap: 'wrap',
           alignItems: 'center',
         }}
@@ -535,8 +535,10 @@ function MindmapEditorInner({
           style={{
             padding: '4px 12px',
             borderRadius: '4px',
-            border: '1px solid #d1d5db',
-            backgroundColor: !selectedNodeId ? '#f3f4f6' : '#ffffff',
+            border: '1px solid var(--color-border-strong)',
+            backgroundColor: !selectedNodeId
+              ? 'var(--color-surface-muted)'
+              : 'var(--color-surface)',
             cursor: !selectedNodeId ? 'not-allowed' : 'pointer',
             fontSize: '13px',
           }}
@@ -549,11 +551,11 @@ function MindmapEditorInner({
           style={{
             padding: '4px 12px',
             borderRadius: '4px',
-            border: '1px solid #d1d5db',
+            border: '1px solid var(--color-border-strong)',
             backgroundColor:
               !selectedNodeId || selectedNodeId === rootNode.id
-                ? '#f3f4f6'
-                : '#ffffff',
+                ? 'var(--color-surface-muted)'
+                : 'var(--color-surface)',
             cursor:
               !selectedNodeId || selectedNodeId === rootNode.id
                 ? 'not-allowed'
@@ -569,11 +571,15 @@ function MindmapEditorInner({
           style={{
             padding: '4px 12px',
             borderRadius: '4px',
-            border: '1px solid #d1d5db',
-            backgroundColor: isDeleteDisabled ? '#f3f4f6' : '#ffffff',
+            border: '1px solid var(--color-border-strong)',
+            backgroundColor: isDeleteDisabled
+              ? 'var(--color-surface-muted)'
+              : 'var(--color-surface)',
             cursor: isDeleteDisabled ? 'not-allowed' : 'pointer',
             fontSize: '13px',
-            color: isDeleteDisabled ? '#9ca3af' : '#ef4444',
+            color: isDeleteDisabled
+              ? 'var(--color-text-muted)'
+              : 'var(--color-danger)',
           }}
         >
           Delete
@@ -589,8 +595,10 @@ function MindmapEditorInner({
             style={{
               padding: '4px 12px',
               borderRadius: '4px',
-              border: '1px solid #d1d5db',
-              backgroundColor: !canUndo ? '#f3f4f6' : '#ffffff',
+              border: '1px solid var(--color-border-strong)',
+              backgroundColor: !canUndo
+                ? 'var(--color-surface-muted)'
+                : 'var(--color-surface)',
               cursor: !canUndo ? 'not-allowed' : 'pointer',
               fontSize: '13px',
             }}
@@ -609,8 +617,10 @@ function MindmapEditorInner({
             style={{
               padding: '4px 12px',
               borderRadius: '4px',
-              border: '1px solid #d1d5db',
-              backgroundColor: !canRedo ? '#f3f4f6' : '#ffffff',
+              border: '1px solid var(--color-border-strong)',
+              backgroundColor: !canRedo
+                ? 'var(--color-surface-muted)'
+                : 'var(--color-surface)',
               cursor: !canRedo ? 'not-allowed' : 'pointer',
               fontSize: '13px',
             }}
@@ -625,8 +635,8 @@ function MindmapEditorInner({
           style={{
             padding: '4px 12px',
             borderRadius: '4px',
-            border: '1px solid #d1d5db',
-            backgroundColor: '#ffffff',
+            border: '1px solid var(--color-border-strong)',
+            backgroundColor: 'var(--color-surface)',
             cursor: 'pointer',
             fontSize: '13px',
           }}

--- a/frontend/admin/src/components/MindmapExport.tsx
+++ b/frontend/admin/src/components/MindmapExport.tsx
@@ -44,7 +44,7 @@ export function MindmapExport({ rootNode }: MindmapExportProps) {
           padding: '4px 12px',
           borderRadius: '4px',
           border: '1px solid #d1d5db',
-          backgroundColor: '#ffffff',
+          backgroundColor: 'var(--color-surface)',
           cursor: 'pointer',
           fontSize: '13px',
         }}
@@ -58,7 +58,7 @@ export function MindmapExport({ rootNode }: MindmapExportProps) {
             top: '100%',
             left: 0,
             marginTop: '4px',
-            backgroundColor: '#ffffff',
+            backgroundColor: 'var(--color-surface)',
             border: '1px solid #d1d5db',
             borderRadius: '4px',
             boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
@@ -71,7 +71,7 @@ export function MindmapExport({ rootNode }: MindmapExportProps) {
               data-testid="copy-error"
               style={{
                 padding: '8px 12px',
-                color: '#ef4444',
+                color: 'var(--color-danger)',
                 fontSize: '12px',
                 borderBottom: '1px solid #e5e7eb',
               }}

--- a/frontend/admin/src/components/MindmapShortcutHelp.tsx
+++ b/frontend/admin/src/components/MindmapShortcutHelp.tsx
@@ -50,7 +50,7 @@ function MindmapShortcutHelpComponent({ onClose }: MindmapShortcutHelpProps) {
       <div
         onClick={(e) => e.stopPropagation()}
         style={{
-          backgroundColor: '#ffffff',
+          backgroundColor: 'var(--color-surface)',
           borderRadius: '12px',
           padding: '24px',
           maxWidth: '560px',
@@ -80,7 +80,7 @@ function MindmapShortcutHelpComponent({ onClose }: MindmapShortcutHelpProps) {
               fontSize: '20px',
               cursor: 'pointer',
               padding: '4px',
-              color: '#6b7280',
+              color: 'var(--color-text-muted)',
             }}
           >
             ✕
@@ -91,7 +91,7 @@ function MindmapShortcutHelpComponent({ onClose }: MindmapShortcutHelpProps) {
           style={{
             fontSize: '14px',
             fontWeight: 600,
-            color: '#374151',
+            color: 'var(--color-text)',
             margin: '0 0 8px 0',
           }}
         >
@@ -109,7 +109,7 @@ function MindmapShortcutHelpComponent({ onClose }: MindmapShortcutHelpProps) {
             <div key={key} style={{ display: 'contents' }}>
               <kbd
                 style={{
-                  backgroundColor: '#f3f4f6',
+                  backgroundColor: 'var(--color-surface-muted)',
                   border: '1px solid #d1d5db',
                   borderRadius: '4px',
                   padding: '2px 6px',
@@ -120,7 +120,7 @@ function MindmapShortcutHelpComponent({ onClose }: MindmapShortcutHelpProps) {
               >
                 {key}
               </kbd>
-              <span style={{ fontSize: '13px', color: '#4b5563' }}>
+              <span style={{ fontSize: '13px', color: 'var(--color-text)' }}>
                 {action}
               </span>
             </div>
@@ -131,7 +131,7 @@ function MindmapShortcutHelpComponent({ onClose }: MindmapShortcutHelpProps) {
           style={{
             fontSize: '14px',
             fontWeight: 600,
-            color: '#374151',
+            color: 'var(--color-text)',
             margin: '0 0 8px 0',
           }}
         >
@@ -148,7 +148,7 @@ function MindmapShortcutHelpComponent({ onClose }: MindmapShortcutHelpProps) {
             <div key={key} style={{ display: 'contents' }}>
               <kbd
                 style={{
-                  backgroundColor: '#f3f4f6',
+                  backgroundColor: 'var(--color-surface-muted)',
                   border: '1px solid #d1d5db',
                   borderRadius: '4px',
                   padding: '2px 6px',
@@ -159,7 +159,7 @@ function MindmapShortcutHelpComponent({ onClose }: MindmapShortcutHelpProps) {
               >
                 {key}
               </kbd>
-              <span style={{ fontSize: '13px', color: '#4b5563' }}>
+              <span style={{ fontSize: '13px', color: 'var(--color-text)' }}>
                 {action}
               </span>
             </div>

--- a/frontend/admin/src/components/NodePropertyPanel.tsx
+++ b/frontend/admin/src/components/NodePropertyPanel.tsx
@@ -33,7 +33,7 @@ export function NodePropertyPanel({
       data-testid="node-property-panel"
       style={{
         width: '260px',
-        borderLeft: '1px solid #e5e7eb',
+        borderLeft: '1px solid var(--color-border)',
         padding: '16px',
         display: 'flex',
         flexDirection: 'column',
@@ -71,7 +71,7 @@ export function NodePropertyPanel({
           <input
             id="node-color"
             type="color"
-            value={selectedNode.color ?? '#ffffff'}
+            value={selectedNode.color ?? 'var(--color-surface)'}
             onChange={(e) =>
               onMetadataChange(selectedNode.id, { color: e.target.value })
             }
@@ -93,7 +93,7 @@ export function NodePropertyPanel({
             style={{
               flex: 1,
               padding: '4px 8px',
-              border: '1px solid #d1d5db',
+              border: '1px solid var(--color-border-strong)',
               borderRadius: '4px',
               fontSize: '13px',
             }}
@@ -125,7 +125,7 @@ export function NodePropertyPanel({
           style={{
             width: '100%',
             padding: '6px 8px',
-            border: '1px solid #d1d5db',
+            border: '1px solid var(--color-border-strong)',
             borderRadius: '4px',
             fontSize: '13px',
             boxSizing: 'border-box',
@@ -157,7 +157,7 @@ export function NodePropertyPanel({
           style={{
             width: '100%',
             padding: '6px 8px',
-            border: `1px solid ${isNoteOverLimit ? '#ef4444' : '#d1d5db'}`,
+            border: `1px solid ${isNoteOverLimit ? 'var(--color-danger)' : 'var(--color-border-strong)'}`,
             borderRadius: '4px',
             fontSize: '13px',
             resize: 'vertical',
@@ -173,13 +173,15 @@ export function NodePropertyPanel({
           }}
         >
           {isNoteOverLimit && (
-            <span style={{ color: '#ef4444' }}>
+            <span style={{ color: 'var(--color-danger)' }}>
               1000文字以内で入力してください
             </span>
           )}
           <span
             style={{
-              color: isNoteOverLimit ? '#ef4444' : '#9ca3af',
+              color: isNoteOverLimit
+                ? 'var(--color-danger)'
+                : 'var(--color-text-muted)',
               marginLeft: 'auto',
             }}
           >

--- a/frontend/admin/src/components/NodePropertyPanel.tsx
+++ b/frontend/admin/src/components/NodePropertyPanel.tsx
@@ -71,7 +71,7 @@ export function NodePropertyPanel({
           <input
             id="node-color"
             type="color"
-            value={selectedNode.color ?? 'var(--color-surface)'}
+            value={selectedNode.color ?? '#ffffff'}
             onChange={(e) =>
               onMetadataChange(selectedNode.id, { color: e.target.value })
             }

--- a/frontend/admin/src/components/SortableCategoryItem.tsx
+++ b/frontend/admin/src/components/SortableCategoryItem.tsx
@@ -52,7 +52,7 @@ const SortableCategoryItem = ({
             padding: '8px',
             border: 'none',
             background: 'transparent',
-            color: '#9ca3af',
+            color: 'var(--color-text-muted)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -82,7 +82,7 @@ const SortableCategoryItem = ({
             style={{
               fontSize: '1.125rem',
               fontWeight: 600,
-              color: '#111827',
+              color: 'var(--color-text-heading)',
               margin: '0 0 8px 0',
             }}
             data-testid="category-name"
@@ -96,7 +96,7 @@ const SortableCategoryItem = ({
               gap: '12px',
               flexWrap: 'wrap',
               fontSize: '0.875rem',
-              color: '#6b7280',
+              color: 'var(--color-text-muted)',
             }}
           >
             <span className="admin-badge admin-badge-dark">
@@ -109,7 +109,7 @@ const SortableCategoryItem = ({
               style={{
                 marginTop: '8px',
                 fontSize: '0.875rem',
-                color: '#6b7280',
+                color: 'var(--color-text-muted)',
               }}
             >
               {category.description}

--- a/frontend/admin/src/pages/DashboardPage.tsx
+++ b/frontend/admin/src/pages/DashboardPage.tsx
@@ -81,7 +81,10 @@ const DashboardPage = () => {
   const hasNoPosts = allPosts.length === 0;
 
   return (
-    <AdminLayout title="Dashboard" subtitle="Polylex管理画面へようこそ">
+    <AdminLayout
+      title="Dashboard"
+      subtitle="Bone of my fallacy 管理画面へようこそ"
+    >
       <div data-testid="dashboard">
         {/* 記事統計 */}
         <div className="admin-stat-grid">
@@ -125,7 +128,7 @@ const DashboardPage = () => {
               style={{
                 fontSize: '1.25rem',
                 fontWeight: 600,
-                color: '#111827',
+                color: 'var(--color-text-heading)',
                 marginBottom: '16px',
               }}
             >
@@ -146,7 +149,7 @@ const DashboardPage = () => {
                         style={{
                           fontSize: '1.125rem',
                           fontWeight: 600,
-                          color: '#111827',
+                          color: 'var(--color-text-heading)',
                           margin: '0 0 8px 0',
                         }}
                       >
@@ -157,7 +160,7 @@ const DashboardPage = () => {
                           display: 'flex',
                           gap: '16px',
                           fontSize: '0.875rem',
-                          color: '#6b7280',
+                          color: 'var(--color-text-muted)',
                         }}
                       >
                         <span className="admin-badge admin-badge-dark">
@@ -186,7 +189,7 @@ const DashboardPage = () => {
               style={{
                 fontSize: '1.25rem',
                 fontWeight: 600,
-                color: '#111827',
+                color: 'var(--color-text-heading)',
                 marginBottom: '16px',
               }}
             >
@@ -207,7 +210,7 @@ const DashboardPage = () => {
                         style={{
                           fontSize: '1.125rem',
                           fontWeight: 600,
-                          color: '#111827',
+                          color: 'var(--color-text-heading)',
                           margin: '0 0 8px 0',
                         }}
                       >
@@ -218,7 +221,7 @@ const DashboardPage = () => {
                           display: 'flex',
                           gap: '16px',
                           fontSize: '0.875rem',
-                          color: '#6b7280',
+                          color: 'var(--color-text-muted)',
                         }}
                       >
                         <span className="admin-badge admin-badge-warning">

--- a/frontend/admin/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/admin/src/pages/ForgotPasswordPage.tsx
@@ -350,7 +350,7 @@ const ForgotPasswordPage = () => {
       <style>{`
         .forgot-page {
           min-height: 100vh;
-          background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+          background: linear-gradient(135deg, var(--color-surface-elevated) 0%, var(--color-surface-muted) 100%);
           display: flex;
           align-items: center;
           justify-content: center;
@@ -363,11 +363,11 @@ const ForgotPasswordPage = () => {
         }
 
         .forgot-card {
-          background: white;
-          border: 1px solid #e5e7eb;
+          background: var(--color-surface);
+          border: 1px solid var(--color-border);
           border-radius: 16px;
           padding: 40px;
-          box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+          box-shadow: var(--shadow-card);
         }
 
         .forgot-header {
@@ -393,13 +393,13 @@ const ForgotPasswordPage = () => {
           font-family: 'Caveat', cursive;
           font-size: 1.5rem;
           font-weight: 600;
-          color: #1f2937;
+          color: var(--color-text-heading);
           letter-spacing: 0.02em;
         }
 
         .forgot-badge {
-          background: #2D2A5A;
-          color: white;
+          background: var(--color-primary);
+          color: var(--color-text-on-primary);
           padding: 4px 10px;
           border-radius: 6px;
           font-size: 0.75rem;
@@ -411,14 +411,14 @@ const ForgotPasswordPage = () => {
         .forgot-title {
           font-size: 1.5rem;
           font-weight: 700;
-          color: #2D2A5A;
+          color: var(--color-primary);
           text-align: center;
           margin: 0 0 16px 0;
         }
 
         .forgot-subtitle {
           font-size: 0.95rem;
-          color: #6b7280;
+          color: var(--color-text-muted);
           text-align: center;
           margin: 0 0 24px 0;
           line-height: 1.6;
@@ -432,40 +432,40 @@ const ForgotPasswordPage = () => {
           display: block;
           font-size: 0.875rem;
           font-weight: 500;
-          color: #374151;
+          color: var(--color-text);
           margin-bottom: 6px;
         }
 
         .forgot-input {
           width: 100%;
           padding: 12px 16px;
-          border: 1px solid #e5e7eb;
+          border: 1px solid var(--color-border);
           border-radius: 10px;
           font-size: 0.95rem;
-          background: white;
+          background: var(--color-surface);
           transition: all 0.2s ease;
           box-sizing: border-box;
         }
 
         .forgot-input:focus {
           outline: none;
-          border-color: #9ca3af;
-          box-shadow: 0 0 0 3px rgba(156, 163, 175, 0.1);
+          border-color: var(--color-text-muted);
+          box-shadow: 0 0 0 3px var(--color-focus-ring);
         }
 
         .forgot-input.error {
-          border-color: #dc2626;
+          border-color: var(--color-danger);
         }
 
         .forgot-input:disabled {
-          background: #f9fafb;
-          color: #6b7280;
+          background: var(--color-surface-elevated);
+          color: var(--color-text-muted);
         }
 
         .forgot-error {
-          background: #fef2f2;
-          border: 1px solid #fecaca;
-          color: #991b1b;
+          background: var(--color-danger-bg);
+          border: 1px solid var(--color-danger-border);
+          color: var(--color-danger-text);
           padding: 12px 16px;
           border-radius: 10px;
           margin-bottom: 20px;
@@ -473,15 +473,15 @@ const ForgotPasswordPage = () => {
         }
 
         .forgot-field-error {
-          color: #dc2626;
+          color: var(--color-danger);
           font-size: 0.8rem;
           margin-top: 6px;
         }
 
         .forgot-success {
-          background: #f0fdf4;
-          border: 1px solid #bbf7d0;
-          color: #166534;
+          background: var(--color-success-alert-bg);
+          border: 1px solid var(--color-success-border);
+          color: var(--color-success-text);
           padding: 16px;
           border-radius: 10px;
           margin-bottom: 20px;
@@ -493,8 +493,8 @@ const ForgotPasswordPage = () => {
         .forgot-btn-primary {
           width: 100%;
           padding: 12px 20px;
-          background: #2D2A5A;
-          color: white;
+          background: var(--color-primary);
+          color: var(--color-text-on-primary);
           border: none;
           border-radius: 10px;
           font-size: 0.95rem;
@@ -505,7 +505,7 @@ const ForgotPasswordPage = () => {
         }
 
         .forgot-btn-primary:hover {
-          background: #3d3a6a;
+          background: var(--color-primary-hover);
         }
 
         .forgot-btn-primary:disabled {
@@ -517,7 +517,7 @@ const ForgotPasswordPage = () => {
           width: 100%;
           padding: 8px 16px;
           background: transparent;
-          color: #6b7280;
+          color: var(--color-text-muted);
           border: none;
           font-size: 0.875rem;
           cursor: pointer;
@@ -525,7 +525,7 @@ const ForgotPasswordPage = () => {
         }
 
         .forgot-btn-link:hover {
-          color: #2D2A5A;
+          color: var(--color-primary);
         }
 
         @media (max-width: 480px) {

--- a/frontend/admin/src/pages/LoginPage.tsx
+++ b/frontend/admin/src/pages/LoginPage.tsx
@@ -223,7 +223,7 @@ const LoginPage = () => {
         <style>{`
           .login-page {
             min-height: 100vh;
-            background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+            background: linear-gradient(135deg, var(--color-surface-elevated) 0%, var(--color-surface-muted) 100%);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -236,11 +236,11 @@ const LoginPage = () => {
           }
 
           .login-card {
-            background: white;
-            border: 1px solid #e5e7eb;
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
             border-radius: 16px;
             padding: 40px;
-            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+            box-shadow: var(--shadow-card);
           }
 
           .login-header {
@@ -266,13 +266,13 @@ const LoginPage = () => {
             font-family: 'Caveat', cursive;
             font-size: 1.5rem;
             font-weight: 600;
-            color: #1f2937;
+            color: var(--color-text-heading);
             letter-spacing: 0.02em;
           }
 
           .login-badge {
-            background: #2D2A5A;
-            color: white;
+            background: var(--color-primary);
+            color: var(--color-text-on-primary);
             padding: 4px 10px;
             border-radius: 6px;
             font-size: 0.75rem;
@@ -284,21 +284,21 @@ const LoginPage = () => {
           .login-title {
             font-size: 1.5rem;
             font-weight: 700;
-            color: #2D2A5A;
+            color: var(--color-primary);
             text-align: center;
             margin: 0 0 8px 0;
           }
 
           .login-subtitle {
             font-size: 0.95rem;
-            color: #6b7280;
+            color: var(--color-text-muted);
             text-align: center;
             margin: 0 0 24px 0;
             line-height: 1.6;
           }
 
           .login-email {
-            color: #2D2A5A;
+            color: var(--color-primary);
             font-weight: 500;
           }
 
@@ -310,40 +310,41 @@ const LoginPage = () => {
             display: block;
             font-size: 0.875rem;
             font-weight: 500;
-            color: #374151;
+            color: var(--color-text);
             margin-bottom: 6px;
           }
 
           .login-input {
             width: 100%;
             padding: 12px 16px;
-            border: 1px solid #e5e7eb;
+            border: 1px solid var(--color-border);
             border-radius: 10px;
             font-size: 0.95rem;
-            background: white;
+            background: var(--color-surface);
+            color: var(--color-text);
             transition: all 0.2s ease;
             box-sizing: border-box;
           }
 
           .login-input:focus {
             outline: none;
-            border-color: #9ca3af;
-            box-shadow: 0 0 0 3px rgba(156, 163, 175, 0.1);
+            border-color: var(--color-border-strong);
+            box-shadow: 0 0 0 3px var(--color-focus-ring);
           }
 
           .login-input.error {
-            border-color: #dc2626;
+            border-color: var(--color-danger);
           }
 
           .login-input:disabled {
-            background: #f9fafb;
-            color: #6b7280;
+            background: var(--color-surface-elevated);
+            color: var(--color-text-muted);
           }
 
           .login-error {
-            background: #fef2f2;
-            border: 1px solid #fecaca;
-            color: #991b1b;
+            background: var(--color-danger-bg);
+            border: 1px solid var(--color-danger-border);
+            color: var(--color-danger-text);
             padding: 12px 16px;
             border-radius: 10px;
             margin-bottom: 20px;
@@ -351,22 +352,22 @@ const LoginPage = () => {
           }
 
           .login-field-error {
-            color: #dc2626;
+            color: var(--color-danger);
             font-size: 0.8rem;
             margin-top: 6px;
           }
 
           .login-password-hint {
             font-size: 0.8rem;
-            color: #6b7280;
+            color: var(--color-text-muted);
             margin: 0 0 20px 0;
           }
 
           .login-btn-primary {
             width: 100%;
             padding: 12px 20px;
-            background: #2D2A5A;
-            color: white;
+            background: var(--color-primary);
+            color: var(--color-text-on-primary);
             border: none;
             border-radius: 10px;
             font-size: 0.95rem;
@@ -377,7 +378,7 @@ const LoginPage = () => {
           }
 
           .login-btn-primary:hover {
-            background: #3d3a6a;
+            background: var(--color-primary-hover);
           }
 
           .login-btn-primary:disabled {
@@ -389,7 +390,7 @@ const LoginPage = () => {
             width: 100%;
             padding: 8px 16px;
             background: transparent;
-            color: #6b7280;
+            color: var(--color-text-muted);
             border: none;
             font-size: 0.875rem;
             cursor: pointer;
@@ -397,7 +398,7 @@ const LoginPage = () => {
           }
 
           .login-btn-link:hover {
-            color: #2D2A5A;
+            color: var(--color-primary);
           }
 
           @media (max-width: 480px) {
@@ -448,7 +449,7 @@ const LoginPage = () => {
       <style>{`
         .login-page {
           min-height: 100vh;
-          background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+          background: linear-gradient(135deg, var(--color-surface-elevated) 0%, var(--color-surface-muted) 100%);
           display: flex;
           align-items: center;
           justify-content: center;
@@ -461,11 +462,11 @@ const LoginPage = () => {
         }
 
         .login-card {
-          background: white;
-          border: 1px solid #e5e7eb;
+          background: var(--color-surface);
+          border: 1px solid var(--color-border);
           border-radius: 16px;
           padding: 40px;
-          box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+          box-shadow: var(--shadow-card);
         }
 
         .login-header {
@@ -491,13 +492,13 @@ const LoginPage = () => {
           font-family: 'Caveat', cursive;
           font-size: 1.5rem;
           font-weight: 600;
-          color: #1f2937;
+          color: var(--color-text-heading);
           letter-spacing: 0.02em;
         }
 
         .login-badge {
-          background: #2D2A5A;
-          color: white;
+          background: var(--color-primary);
+          color: var(--color-text-on-primary);
           padding: 4px 10px;
           border-radius: 6px;
           font-size: 0.75rem;
@@ -509,14 +510,14 @@ const LoginPage = () => {
         .login-title {
           font-size: 1.5rem;
           font-weight: 700;
-          color: #2D2A5A;
+          color: var(--color-primary);
           text-align: center;
           margin: 0 0 8px 0;
         }
 
         .login-subtitle {
           font-size: 0.95rem;
-          color: #6b7280;
+          color: var(--color-text-muted);
           text-align: center;
           margin: 0 0 32px 0;
         }
@@ -525,29 +526,30 @@ const LoginPage = () => {
         .login-card input {
           width: 100%;
           padding: 12px 16px;
-          border: 1px solid #e5e7eb;
+          border: 1px solid var(--color-border);
           border-radius: 10px;
           font-size: 0.95rem;
-          background: white;
+          background: var(--color-surface);
+          color: var(--color-text);
           transition: all 0.2s ease;
           box-sizing: border-box;
         }
 
         .login-card input:focus {
           outline: none;
-          border-color: #9ca3af;
-          box-shadow: 0 0 0 3px rgba(156, 163, 175, 0.1);
+          border-color: var(--color-border-strong);
+          box-shadow: 0 0 0 3px var(--color-focus-ring);
         }
 
         .login-card input::placeholder {
-          color: #9ca3af;
+          color: var(--color-text-muted);
         }
 
         .login-card button[type="submit"] {
           width: 100%;
           padding: 12px 20px;
-          background: #2D2A5A;
-          color: white;
+          background: var(--color-primary);
+          color: var(--color-text-on-primary);
           border: none;
           border-radius: 10px;
           font-size: 0.95rem;
@@ -557,7 +559,7 @@ const LoginPage = () => {
         }
 
         .login-card button[type="submit"]:hover {
-          background: #3d3a6a;
+          background: var(--color-primary-hover);
         }
 
         .login-card button[type="submit"]:disabled {
@@ -567,7 +569,7 @@ const LoginPage = () => {
 
         .login-card a,
         .login-card button:not([type="submit"]) {
-          color: #6b7280;
+          color: var(--color-text-muted);
           font-size: 0.875rem;
           text-decoration: none;
           transition: color 0.2s ease;
@@ -575,14 +577,14 @@ const LoginPage = () => {
 
         .login-card a:hover,
         .login-card button:not([type="submit"]):hover {
-          color: #2D2A5A;
+          color: var(--color-primary);
         }
 
         .login-card label {
           display: block;
           font-size: 0.875rem;
           font-weight: 500;
-          color: #374151;
+          color: var(--color-text);
           margin-bottom: 6px;
         }
 

--- a/frontend/admin/src/pages/MindmapCreatePage.tsx
+++ b/frontend/admin/src/pages/MindmapCreatePage.tsx
@@ -95,7 +95,7 @@ const MindmapCreatePage = () => {
             {validationError && (
               <p
                 style={{
-                  color: '#ef4444',
+                  color: 'var(--color-danger)',
                   fontSize: '0.875rem',
                   marginTop: '4px',
                 }}

--- a/frontend/admin/src/pages/MindmapEditPage.tsx
+++ b/frontend/admin/src/pages/MindmapEditPage.tsx
@@ -152,7 +152,7 @@ const MindmapEditPage = () => {
             {validationError && (
               <p
                 style={{
-                  color: '#ef4444',
+                  color: 'var(--color-danger)',
                   fontSize: '0.875rem',
                   marginTop: '4px',
                 }}

--- a/frontend/admin/src/pages/MindmapListPage.tsx
+++ b/frontend/admin/src/pages/MindmapListPage.tsx
@@ -217,7 +217,7 @@ const MindmapListPage = () => {
                     style={{
                       fontSize: '1.125rem',
                       fontWeight: 600,
-                      color: '#111827',
+                      color: 'var(--color-text-heading)',
                       margin: '0 0 8px 0',
                     }}
                     data-testid="admin-mindmap-title"
@@ -231,7 +231,7 @@ const MindmapListPage = () => {
                       gap: '12px',
                       flexWrap: 'wrap',
                       fontSize: '0.875rem',
-                      color: '#6b7280',
+                      color: 'var(--color-text-muted)',
                     }}
                   >
                     <span

--- a/frontend/admin/src/pages/PostListPage.tsx
+++ b/frontend/admin/src/pages/PostListPage.tsx
@@ -244,7 +244,7 @@ const PostListPage = () => {
                     style={{
                       fontSize: '1.125rem',
                       fontWeight: 600,
-                      color: '#111827',
+                      color: 'var(--color-text-heading)',
                       margin: '0 0 8px 0',
                     }}
                     data-testid="admin-article-title"
@@ -258,7 +258,7 @@ const PostListPage = () => {
                       gap: '12px',
                       flexWrap: 'wrap',
                       fontSize: '0.875rem',
-                      color: '#6b7280',
+                      color: 'var(--color-text-muted)',
                     }}
                   >
                     <span


### PR DESCRIPTION
## Summary

- `public-astro` と `admin` の両フロントエンドにダークモードを実装
- CSS変数トークン中心の実装 (`:root` ライト + `:root[data-theme=\"dark\"]` ダーク)
- ヘッダーに月/太陽トグル、初回は OS 設定追従、選択は `localStorage` で永続化
- FOUC 防止: `<head>` に inline 解決スクリプトを挿入し `data-theme` 属性を render 前に確定
- admin の各ページ・Mindmap 系コンポーネント・認証画面のハードコード色も token 化

## Approach

**1. 共有デザイントークン** — 同じ token セットを `public-astro/src/styles/global.css` と `admin/src/index.css` に定義し、共有の `shared-ui/src/article.css` も `var(--color-*)` に統一。

**2. 切替モデル (3 値)** — `localStorage.theme` に `light` / `dark` / `system` を保持。`system` の時のみ OS テーマ変更を `matchMedia('change')` で即時反映。トグル UI は 2 値 (light↔dark) で localStorage を上書き。

**3. FOUC 防止** — `Layout.astro` / `404.astro` / `admin/index.html` の `<head>` 先頭に inline script を配置。localStorage と `prefers-color-scheme` を読み取って `<html data-theme=\"...\">` を即時設定。

**4. React 側 Provider** — `admin/src/contexts/ThemeContext.tsx` で `useTheme()` フックを提供。`matchMedia` ガードで jsdom テスト環境にも対応。

## Files Changed (要約)

### 新規
- \`frontend/admin/src/contexts/ThemeContext.tsx\` — React Provider + \`useTheme\` フック
- \`frontend/admin/src/components/ThemeToggle.tsx\` — admin トグル
- \`frontend/public-astro/src/components/ThemeToggle.astro\` — public-astro トグル

### 主要修正
- **トークン**: \`global.css\`, \`admin/src/index.css\`, \`shared-ui/src/article.css\`
- **FOUC bootstrap**: \`Layout.astro\`, \`admin/index.html\`, \`404.astro\`
- **Provider 配線**: \`admin/src/main.tsx\`
- **ヘッダー + トグル**: \`Header.astro\`, \`AdminHeader.tsx\`
- **public-astro コンポーネント**: \`PostCard.astro\`, \`MindmapCard.astro\`, \`SearchBar.astro\`
- **public-astro ページ**: \`index.astro\`, \`about.astro\`, \`404.astro\`, \`mindmaps/{index,[id]}.astro\`, \`posts/[slug].astro\`
- **admin ページ**: \`LoginPage.tsx\`, \`ForgotPasswordPage.tsx\`, \`DashboardPage.tsx\`, \`PostListPage.tsx\`, \`MindmapList/Create/EditPage.tsx\`
- **admin コンポーネント (Mindmap系)**: \`MindmapEditor\`, \`MindmapCustomNode\`, \`NodePropertyPanel\`, \`MindmapShortcutHelp\`, \`MindmapExport\`, \`SortableCategoryItem\`
- **テスト**: \`AdminHeader.test.tsx\`, \`AdminLayout.test.tsx\` を \`<ThemeProvider>\` でラップ

## Bug fix included

- DashboardPage の subtitle が \"Polylex管理画面へようこそ\" となっていたのを \"Bone of my fallacy 管理画面へようこそ\" に修正

## Test plan

- [ ] admin: \`bun run build\` 通過 ✅ (確認済み)
- [ ] public-astro: Astro check + Vite トランスフォーム通過 ✅ (確認済み, 静的route生成は API_URL 環境設定次第)
- [ ] AdminHeader/AdminLayout テスト: 39件 全 pass ✅ (確認済み)
- [ ] localhost で目視確認:
    - [ ] public-astro でホーム/about/投稿詳細/mindmap一覧の両モード描画
    - [ ] admin で Login → Dashboard → 記事一覧 → MindmapEditor の両モード描画
    - [ ] ヘッダーのトグルクリックで切替 + リロード後も維持
    - [ ] OS テーマ変更が \"system\" 状態で即時反映
    - [ ] FOUC 無し (DevTools Slow 3G + Disable cache)
- [ ] アクセシビリティ: \`aria-label\` がトグルの状態に応じて切替

## Out of scope

- legacy \`frontend/public/\` (deprecated 想定でスコープ外)
- Tiptap エディタ内部の細かな色 (admin-* クラス経由で大部分は適用済)
- 印刷モード \`@media print\` の調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)