### PR TITLE
fix(theme): adapt logo white background to dark mode via CSS filter

### DIFF
--- a/frontend/admin/src/components/AdminHeader.tsx
+++ b/frontend/admin/src/components/AdminHeader.tsx
@@ -131,6 +131,10 @@ const AdminHeader: React.FC = () => {
           margin-right: 12px;
         }
 
+        :root[data-theme="dark"] .admin-logo-image {
+          filter: invert(1) hue-rotate(180deg);
+        }
+
         .admin-site-title {
           font-family: 'Caveat', cursive;
           font-size: 1.6rem;

--- a/frontend/admin/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/admin/src/pages/ForgotPasswordPage.tsx
@@ -389,6 +389,10 @@ const ForgotPasswordPage = () => {
           margin-right: 12px;
         }
 
+        :root[data-theme="dark"] .forgot-logo-image {
+          filter: invert(1) hue-rotate(180deg);
+        }
+
         .forgot-site-title {
           font-family: 'Caveat', cursive;
           font-size: 1.5rem;

--- a/frontend/admin/src/pages/LoginPage.tsx
+++ b/frontend/admin/src/pages/LoginPage.tsx
@@ -262,6 +262,10 @@ const LoginPage = () => {
             margin-right: 12px;
           }
 
+          :root[data-theme="dark"] .login-logo-image {
+            filter: invert(1) hue-rotate(180deg);
+          }
+
           .login-site-title {
             font-family: 'Caveat', cursive;
             font-size: 1.5rem;
@@ -486,6 +490,10 @@ const LoginPage = () => {
           height: 40px;
           width: auto;
           margin-right: 12px;
+        }
+
+        :root[data-theme="dark"] .login-logo-image {
+          filter: invert(1) hue-rotate(180deg);
         }
 
         .login-site-title {

--- a/frontend/public-astro/src/components/Header.astro
+++ b/frontend/public-astro/src/components/Header.astro
@@ -87,6 +87,10 @@ import ThemeToggle from './ThemeToggle.astro';
     margin-right: 12px;
   }
 
+  :root[data-theme="dark"] .logo-image {
+    filter: invert(1) hue-rotate(180deg);
+  }
+
   .site-title {
     font-family: 'Caveat', cursive;
     font-size: 1.6rem;


### PR DESCRIPTION
## Summary
- `fallacy.png` ロゴは白い正方形背景がピクセル焼き込みのため、ダークモード時に暗いサーフェス上で浮いて見えていた
- ダークモード時のみ `filter: invert(1) hue-rotate(180deg)` をロゴ `<img>` に適用し、白背景を黒寄りに反転しつつブランド色（金リング・紺楕円）の色味を近似的に維持
- 対象は admin（AdminHeader / LoginPage 通常 + 新パスワード設定 / ForgotPasswordPage）と public-astro Header の計4箇所

## Test plan
- [ ] `bun --cwd frontend/admin dev` でログイン画面 / パスワード忘れ画面 / 認証後のヘッダーを確認、ThemeToggle で light/dark 往復してロゴが視認できること
- [ ] `bun --cwd frontend/public-astro dev` でトップヘッダーのロゴを light/dark で確認
- [ ] DOM Inspector で `<html data-theme="dark">` 時に対象 `<img>` の computed style に filter が適用されていること
- [ ] Light モードで視覚的変化がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)