### PR TITLE
feat(e2e): admin categories spec + login race fixes + PostDetailPage test fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1160,7 +1160,7 @@ jobs:
   # Job 7: E2E Tests - Admin Site (always runs if frontend tests passed)
   # =======================================
   e2e-admin-tests:
-    name: E2E Tests (Admin - Auth, CRUD & Security)
+    name: E2E Tests (Admin - Auth, CRUD, Categories & Security)
     runs-on: ubuntu-latest
     needs: [frontend-admin-tests]
     if: |
@@ -1213,8 +1213,13 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/azure-cli.list || true
           bunx playwright install-deps chromium
 
-      - name: Run E2E tests (Admin - Auth, CRUD & Security) - Chromium only
-        run: bun run test:e2e:admin -- tests/e2e/specs/admin-auth.spec.ts tests/e2e/specs/admin-crud.spec.ts tests/e2e/specs/admin-unauthorized-access.spec.ts --project=chromium --workers=1
+      - name: Run E2E tests (Admin - Auth, CRUD, Categories & Security) - Chromium only
+        # PR 時にゲートする admin spec を 4 件に拡張（旧: auth/crud/security の 3 件）。
+        # 残りの admin-*.spec.ts (tiptap / image / metadata / autosave / unsaved-guard /
+        # publish-flow / preview-parity / slug-conflict) は MSW 環境で flakiness があり、
+        # post-deploy AWS E2E ジョブ (deploy.yml) で全件実行する運用とする。
+        # 安定化したら順次 PR CI に追加する。
+        run: bun run test:e2e:admin -- tests/e2e/specs/admin-auth.spec.ts tests/e2e/specs/admin-crud.spec.ts tests/e2e/specs/admin-categories.spec.ts tests/e2e/specs/admin-unauthorized-access.spec.ts --project=chromium --workers=1
         env:
           CI: true
 

--- a/frontend/public/src/pages/PostDetailPage.test.tsx
+++ b/frontend/public/src/pages/PostDetailPage.test.tsx
@@ -537,9 +537,14 @@ describe('PostDetailPage', () => {
         expect(screen.getByText('Test Post Title')).toBeInTheDocument();
       });
 
-      // keywordsメタタグは空文字列のcontentで作成される
-      const keywordsMeta = document.querySelector('meta[name="keywords"]');
-      expect(keywordsMeta).toBeTruthy();
+      // keywordsメタタグは空文字列のcontentで作成される。
+      // PostDetailPage の本文描画と SEOHead の useEffect は別 effect サイクルなので、
+      // タイトル可視時点でメタタグが未挿入のことがある (CI の遅い環境で再現)。
+      const keywordsMeta = await waitFor(() => {
+        const el = document.querySelector('meta[name="keywords"]');
+        expect(el).toBeTruthy();
+        return el;
+      });
       expect(keywordsMeta?.getAttribute('content')).toBe('');
     });
   });

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -26,16 +26,38 @@ Layer 3: 実環境E2Eテスト（AWS Real Environment）
 
 ## テスト範囲
 
-### Layer 1: MSW E2Eテスト（6 spec files, 13 tests）
+### Layer 1: MSW E2Eテスト（18 spec files, 40 tests）
+
+R43「最小限 E2E（重要なユーザーフローのみ）」方針に従い、表示・バリデーション等の
+詳細はユニット/統合テストでカバーし、E2E はクロスレイヤの主要フローのみを検証する。
+
+#### 公開サイト（3 spec / 7 tests）
 
 | Specファイル | テスト数 | カバー範囲 |
 |------------|---------|----------|
-| seed.spec.ts | 4 | AI Agent用リファレンス（記事一覧、タイトル取得、ナビゲーション、記事詳細） |
-| home.spec.ts | 2 | 記事一覧表示、ナビゲーション |
-| article.spec.ts | 1 | 記事詳細表示 |
+| seed.spec.ts | 4 | **AI Agent (Generator/Healer) 用リファレンス**。home/article と意図的に重複しており、`fixtures` 経由インポート / Page Object パターン / 日本語コメント / AAA 構造などの規約を模範的に示す |
+| home.spec.ts | 2 | 記事一覧表示、記事詳細へのナビゲーション |
+| article.spec.ts | 1 | 記事詳細の表示（タイトル / 本文）。Astro slug routing も実遷移経由で暗黙にカバー |
+
+#### 管理画面（15 spec / 33 tests）
+
+| Specファイル | テスト数 | カバー範囲 |
+|------------|---------|----------|
 | admin-auth.spec.ts | 2 | ログイン成功/失敗 |
-| admin-crud.spec.ts | 3 | 記事CRUD統合フロー（作成・編集・削除） |
 | admin-unauthorized-access.spec.ts | 1 | 未認証アクセスリダイレクト |
+| admin-crud.spec.ts | 3 | 記事 CRUD 統合フロー（作成・編集・削除） |
+| admin-categories.spec.ts | 4 | カテゴリ CRUD（一覧・作成・編集・削除）。並べ替え D&D は単体テスト側でカバー |
+| admin-tiptap-basic.spec.ts | 4 | エディタ初期化、Markdown 入力、整形、タブキー |
+| admin-image-paste.spec.ts | 1 | クリップボード貼り付けでの画像挿入 |
+| admin-image-drag.spec.ts | 1 | ドラッグ&ドロップでの画像挿入 |
+| admin-image-toolbar.spec.ts | 1 | 画像ツールバー操作 |
+| admin-image-fail.spec.ts | 2 | 画像アップロード失敗時のエラー / バリデーション |
+| admin-metadata-sidebar.spec.ts | 4 | slug 自動生成、excerpt カウンタ、cover image (PR6) |
+| admin-preview-parity.spec.ts | 1 | エディタプレビューと公開ページの Markdown 描画一致 |
+| admin-autosave.spec.ts | 3 | オートセーブの発火とインジケータ |
+| admin-unsaved-guard.spec.ts | 3 | 未保存変更ガード（beforeunload / キャンセル） |
+| admin-publish-flow.spec.ts | 2 | 公開時のビルドステータスバッジ表示遷移 (PR5b) |
+| admin-slug-conflict.spec.ts | 1 | slug 重複時の 409 エラー表示 |
 
 ### Layer 2: APIコントラクトテスト
 
@@ -61,21 +83,30 @@ MSW E2Eテストと同じspecファイルを使用し、`playwright.aws.config.t
 ```
 E2E Test Environment
 ├── tests/e2e/
-│   ├── specs/              # テストスペック（6ファイル、13テスト）
-│   │   ├── seed.spec.ts    # AI Agent用リファレンステスト
-│   │   ├── home.spec.ts    # 公開サイト: 記事一覧、ナビゲーション
-│   │   ├── article.spec.ts # 公開サイト: 記事詳細表示
-│   │   ├── admin-auth.spec.ts # 管理画面: ログイン/ログアウト
-│   │   ├── admin-crud.spec.ts # 管理画面: CRUD統合フロー
-│   │   └── admin-unauthorized-access.spec.ts # セキュリティ: 未認証リダイレクト
+│   ├── specs/              # テストスペック（18 ファイル / 40 テスト）
+│   │   ├── seed.spec.ts    # AI Agent (Generator/Healer) 用リファレンス
+│   │   ├── home.spec.ts    # 公開: 記事一覧、ナビゲーション
+│   │   ├── article.spec.ts # 公開: 記事詳細
+│   │   ├── admin-auth.spec.ts                # 管理: ログイン
+│   │   ├── admin-unauthorized-access.spec.ts # 管理: セキュリティリダイレクト
+│   │   ├── admin-crud.spec.ts                # 管理: 記事 CRUD
+│   │   ├── admin-categories.spec.ts          # 管理: カテゴリ CRUD
+│   │   ├── admin-tiptap-basic.spec.ts        # 管理: エディタ基本
+│   │   ├── admin-image-*.spec.ts             # 管理: 画像 paste/drag/toolbar/fail
+│   │   ├── admin-metadata-sidebar.spec.ts    # 管理: メタデータサイドバー (PR6)
+│   │   ├── admin-preview-parity.spec.ts      # 管理: プレビュー一致
+│   │   ├── admin-autosave.spec.ts            # 管理: オートセーブ (PR5a)
+│   │   ├── admin-unsaved-guard.spec.ts       # 管理: 未保存ガード (PR5a)
+│   │   ├── admin-publish-flow.spec.ts        # 管理: ビルドステータス (PR5b)
+│   │   └── admin-slug-conflict.spec.ts       # 管理: slug 409
 │   ├── pages/              # ページオブジェクト
 │   ├── fixtures/           # カスタムフィクスチャ
 │   ├── mocks/              # MSWモックハンドラー（ハッピーパスのみ）
 │   │   ├── handlers.ts     # APIモックハンドラー
-│   │   └── mockData.ts     # テストデータ
+│   │   └── mockData.ts     # テストデータ（記事 / カテゴリ）
 │   ├── utils/              # テストヘルパー
 │   ├── global-setup.ts     # グローバルセットアップ（MSW/AWS環境対応）
-│   └── global-teardown.ts  # グローバルティアダウン（テストデータクリーンアップ）
+│   └── global-teardown.ts  # グローバルティアダウン（記事 / カテゴリの [E2E-TEST] データを清掃）
 ├── playwright.config.ts       # 公開サイトMSWテスト設定
 ├── playwright.admin.config.ts # 管理画面MSWテスト設定
 └── playwright.aws.config.ts   # 実環境テスト設定（Basic認証対応）
@@ -156,15 +187,31 @@ MSW環境では `resetMockPosts()` でインメモリデータをリセット。
 ### PR時（ci.yml）
 
 ```
-MSW E2Eテスト（Layer 1）→ UI変更の高速フィードバック
+Job 6: e2e-public-tests → 公開サイト全 spec (3 / 7 tests)
+Job 7: e2e-admin-tests  → 管理画面のうち認証 / CRUD / カテゴリ / セキュリティ系 4 spec
 APIコントラクトテスト（Layer 2）→ GoテストCIジョブに自動組み込み
 ```
+
+> Job 7 が PR で実行するのは下記 4 spec:
+> - `admin-auth.spec.ts`
+> - `admin-crud.spec.ts`
+> - `admin-categories.spec.ts`
+> - `admin-unauthorized-access.spec.ts`
+>
+> **PR では実行されない admin spec** (tiptap-basic / image-* / metadata-sidebar / autosave /
+> unsaved-guard / publish-flow / preview-parity / slug-conflict) は、現時点で MSW 環境
+> での flakiness（特に Tiptap エディタ起動）があり、安定化前に PR を一律 fail させる
+> リスクがあるため除外している。これらは下記の post-deploy AWS E2E ジョブで全件回す。
+> flakiness を解消したら順次 Job 7 に追加する。
 
 ### デプロイ後（deploy.yml）
 
 ```
-post-deploy-e2e-dev → 実環境E2Eテスト（Layer 3）
+post-deploy-e2e-dev → 実環境E2Eテスト（Layer 3, 全 18 spec）
 ```
+
+実環境では `[E2E-TEST]` プレフィックスの記事 / カテゴリを `global-teardown.ts` が
+自動削除する。手動掃除は `bun run cleanup:test-data`。
 
 ## トラブルシューティング
 

--- a/tests/e2e/fixtures/index.ts
+++ b/tests/e2e/fixtures/index.ts
@@ -6,6 +6,8 @@ import { AdminDashboardPage } from '../pages/AdminDashboardPage';
 import { AdminPostCreatePage } from '../pages/AdminPostCreatePage';
 import { AdminPostEditPage } from '../pages/AdminPostEditPage';
 import { ArticleEditorPage } from '../pages/ArticleEditorPage';
+import { AdminCategoryListPage } from '../pages/AdminCategoryListPage';
+import { AdminCategoryEditPage } from '../pages/AdminCategoryEditPage';
 import { clearAllStorage } from '../utils/testHelpers';
 import { resetMockPosts } from '../mocks/mockData';
 
@@ -21,6 +23,8 @@ type CustomFixtures = {
   adminPostCreatePage: AdminPostCreatePage;
   adminPostEditPage: AdminPostEditPage;
   articleEditorPage: ArticleEditorPage;
+  adminCategoryListPage: AdminCategoryListPage;
+  adminCategoryEditPage: AdminCategoryEditPage;
 };
 
 /**
@@ -87,6 +91,22 @@ export const test = base.extend<CustomFixtures>({
   articleEditorPage: async ({ page }, use) => {
     const articleEditorPage = new ArticleEditorPage(page);
     await use(articleEditorPage);
+  },
+
+  /**
+   * 管理画面カテゴリ一覧ページフィクスチャ
+   */
+  adminCategoryListPage: async ({ page }, use) => {
+    const adminCategoryListPage = new AdminCategoryListPage(page);
+    await use(adminCategoryListPage);
+  },
+
+  /**
+   * 管理画面カテゴリ作成・編集ページフィクスチャ
+   */
+  adminCategoryEditPage: async ({ page }, use) => {
+    const adminCategoryEditPage = new AdminCategoryEditPage(page);
+    await use(adminCategoryEditPage);
   },
 });
 

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -142,7 +142,51 @@ async function globalTeardown(config: FullConfig) {
           console.log(`  ✅ Deleted: ${post.title}`);
         }
       } else {
-        console.log('✅ No test data to clean up');
+        console.log('✅ No test post data to clean up');
+      }
+
+      // [E2E-TEST] prefix のカテゴリも削除（admin-categories.spec.ts 用）
+      const categories = await page.evaluate(
+        async ({ apiBase }: { apiBase: string }) => {
+          const resp = await fetch(`${apiBase}/categories`);
+          if (resp.ok) {
+            return resp.json();
+          }
+          return [];
+        },
+        { apiBase: apiBaseURL }
+      );
+
+      const testCategories = (
+        categories as Array<{ id: string; name: string }>
+      ).filter((c) => c.name && c.name.startsWith(E2E_TEST_PREFIX));
+
+      if (testCategories.length > 0) {
+        console.log(
+          `🗑️  Found ${testCategories.length} test category(s) to clean up`
+        );
+        for (const cat of testCategories) {
+          await page.evaluate(
+            async ({
+              apiBase,
+              token,
+              catId,
+            }: {
+              apiBase: string;
+              token: string;
+              catId: string;
+            }) => {
+              await fetch(`${apiBase}/admin/categories/${catId}`, {
+                method: 'DELETE',
+                headers: { Authorization: `Bearer ${token}` },
+              });
+            },
+            { apiBase: apiBaseURL, token: authToken, catId: cat.id }
+          );
+          console.log(`  ✅ Deleted category: ${cat.name}`);
+        }
+      } else {
+        console.log('✅ No test category data to clean up');
       }
 
       await context.close();

--- a/tests/e2e/mocks/handlers.ts
+++ b/tests/e2e/mocks/handlers.ts
@@ -16,7 +16,13 @@
  */
 
 import { http, HttpResponse } from 'msw';
-import { mockPosts, createMockPost } from './mockData';
+import {
+  mockPosts,
+  createMockPost,
+  mockCategories,
+  slugifyCategoryName,
+  type MockCategory,
+} from './mockData';
 
 // ブラウザ環境では import.meta.env を使用
 // nullish coalescing演算子(??)を使用して、undefinedとnullのみデフォルト値を使用
@@ -59,17 +65,119 @@ const checkAuth = (request: Request): boolean => {
   return token.split('.').length === 3;
 };
 
-// モックカテゴリデータ
-const mockCategories = [
-  { id: 'cat-1', name: 'technology', slug: 'technology', sortOrder: 1 },
-  { id: 'cat-2', name: 'life', slug: 'life', sortOrder: 2 },
-  { id: 'cat-3', name: 'business', slug: 'business', sortOrder: 3 },
-];
-
 export const handlers = [
-  // カテゴリ一覧取得（公開サイト）
+  // カテゴリ一覧取得（公開サイト・管理画面共用）
   http.get(`${API_BASE_URL}/categories`, () => {
     return HttpResponse.json(mockCategories);
+  }),
+
+  // 管理画面: カテゴリ作成
+  http.post(`${API_BASE_URL}/admin/categories`, async ({ request }) => {
+    if (!checkAuth(request)) {
+      return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await request.json()) as {
+      name: string;
+      slug?: string;
+      description?: string;
+      sortOrder?: number;
+    };
+
+    const slug = body.slug?.trim() || slugifyCategoryName(body.name);
+
+    if (mockCategories.some((c) => c.slug === slug)) {
+      return HttpResponse.json(
+        { message: 'category with this slug already exists' },
+        { status: 409 }
+      );
+    }
+
+    const now = new Date().toISOString();
+    const newCategory: MockCategory = {
+      id: `cat-${Date.now()}`,
+      name: body.name,
+      slug,
+      description: body.description,
+      sortOrder:
+        body.sortOrder ??
+        Math.max(0, ...mockCategories.map((c) => c.sortOrder)) + 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    mockCategories.push(newCategory);
+
+    return HttpResponse.json(newCategory, { status: 201 });
+  }),
+
+  // 管理画面: カテゴリ更新
+  http.put(
+    `${API_BASE_URL}/admin/categories/:id`,
+    async ({ request, params }) => {
+      if (!checkAuth(request)) {
+        return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+      }
+
+      const { id } = params;
+      const idx = mockCategories.findIndex((c) => c.id === id);
+      if (idx === -1) {
+        return HttpResponse.json(
+          { message: 'Category not found' },
+          { status: 404 }
+        );
+      }
+
+      const body = (await request.json()) as {
+        name?: string;
+        slug?: string;
+        description?: string;
+        sortOrder?: number;
+      };
+
+      mockCategories[idx] = {
+        ...mockCategories[idx],
+        ...body,
+        updatedAt: new Date().toISOString(),
+      };
+
+      return HttpResponse.json(mockCategories[idx]);
+    }
+  ),
+
+  // 管理画面: カテゴリ削除
+  http.delete(`${API_BASE_URL}/admin/categories/:id`, ({ request, params }) => {
+    if (!checkAuth(request)) {
+      return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = params;
+    const idx = mockCategories.findIndex((c) => c.id === id);
+    if (idx === -1) {
+      return HttpResponse.json(
+        { message: 'Category not found' },
+        { status: 404 }
+      );
+    }
+
+    mockCategories.splice(idx, 1);
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // 管理画面: カテゴリ並び順一括更新（D&D は E2E ではカバーしないが
+  // ハンドラを置かないと UI の楽観的更新が永続化に失敗してエラーバナーが
+  // 出るため、無害なスタブを提供する）
+  http.patch(`${API_BASE_URL}/admin/categories/sort`, async ({ request }) => {
+    if (!checkAuth(request)) {
+      return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+    const body = (await request.json()) as {
+      orders: Array<{ id: string; sortOrder: number }>;
+    };
+    for (const order of body.orders) {
+      const cat = mockCategories.find((c) => c.id === order.id);
+      if (cat) cat.sortOrder = order.sortOrder;
+    }
+    return HttpResponse.json([...mockCategories]);
   }),
 
   // 記事一覧取得（公開サイト）- Happy Path Only

--- a/tests/e2e/mocks/mockData.ts
+++ b/tests/e2e/mocks/mockData.ts
@@ -153,6 +153,67 @@ export let mockPosts: MockPost[] = [
 export const mockPost = mockPosts[0];
 
 /**
+ * カテゴリエンティティ
+ */
+export interface MockCategory {
+  id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const initialCategories: MockCategory[] = [
+  {
+    id: 'cat-1',
+    name: 'technology',
+    slug: 'technology',
+    sortOrder: 1,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'cat-2',
+    name: 'life',
+    slug: 'life',
+    sortOrder: 2,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 'cat-3',
+    name: 'business',
+    slug: 'business',
+    sortOrder: 3,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
+];
+
+export let mockCategories: MockCategory[] = [...initialCategories];
+
+/**
+ * カテゴリ用 slug 生成（実環境のサーバ生成と等価ではないが、E2E では十分）
+ */
+export const slugifyCategoryName = (name: string): string =>
+  name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+/**
+ * カテゴリのモックデータをリセット
+ */
+export const resetMockCategories = () => {
+  mockCategories = initialCategories.map((cat) => ({ ...cat }));
+};
+
+/**
  * モックデータをリセット
  */
 export const resetMockPosts = () => {

--- a/tests/e2e/pages/AdminCategoryEditPage.ts
+++ b/tests/e2e/pages/AdminCategoryEditPage.ts
@@ -1,0 +1,67 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * 管理画面カテゴリ作成・編集ページオブジェクト
+ *
+ * Requirements:
+ * - R43: UI E2Eテスト（最小限）（カテゴリ管理）
+ */
+export class AdminCategoryEditPage extends BasePage {
+  private readonly selectors = {
+    form: '[data-testid="category-form"]',
+    nameInput: '[data-testid="name-input"]',
+    descriptionInput: '[data-testid="description-input"]',
+    submitButton: '[data-testid="submit-button"]',
+    cancelButton: '[data-testid="cancel-button"]',
+    errorMessage: '[data-testid="error-message"]',
+    nameError: '[data-testid="name-error"]',
+  };
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async navigateNew(): Promise<void> {
+    await this.goto('/categories/new');
+    await this.waitForElement(this.selectors.nameInput);
+  }
+
+  async navigateEdit(id: string): Promise<void> {
+    await this.goto(`/categories/edit/${id}`);
+    await this.waitForElement(this.selectors.nameInput);
+  }
+
+  async fillName(name: string): Promise<void> {
+    await this.fill(this.selectors.nameInput, name);
+  }
+
+  async fillDescription(description: string): Promise<void> {
+    await this.fill(this.selectors.descriptionInput, description);
+  }
+
+  async submit(): Promise<void> {
+    await this.click(this.selectors.submitButton);
+  }
+
+  async submitAndWaitForList(): Promise<void> {
+    await this.submit();
+    await this.page.waitForURL(/\/categories(\?.*)?$/, { timeout: 10000 });
+    // 一覧画面側の useEffect (fetchCategories) が完了するのを待つ
+    await this.page.waitForLoadState('networkidle');
+    await Promise.race([
+      this.page
+        .locator('[data-testid="category-list"]')
+        .waitFor({ state: 'visible', timeout: 10000 }),
+      this.page
+        .getByText('カテゴリがありません', { exact: false })
+        .waitFor({ state: 'visible', timeout: 10000 }),
+    ]);
+  }
+
+  async getNameValue(): Promise<string> {
+    return (
+      (await this.page.locator(this.selectors.nameInput).inputValue()) || ''
+    );
+  }
+}

--- a/tests/e2e/pages/AdminCategoryListPage.ts
+++ b/tests/e2e/pages/AdminCategoryListPage.ts
@@ -1,0 +1,130 @@
+import { Page, Locator } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * 管理画面カテゴリ一覧ページオブジェクト
+ *
+ * Requirements:
+ * - R43: UI E2Eテスト（最小限）（カテゴリ管理）
+ */
+export class AdminCategoryListPage extends BasePage {
+  private readonly selectors = {
+    newCategoryButton: '[data-testid="new-category-button"]',
+    categoryList: '[data-testid="category-list"]',
+    categoryItem: '[data-testid="category-item"]',
+    categoryName: '[data-testid="category-name"]',
+    editButton: '[data-testid="edit-category-button"]',
+    deleteButton: '[data-testid="delete-category-button"]',
+    confirmYes: '[data-testid="confirm-yes"]',
+    successMessage: '[data-testid="success-message"]',
+    errorMessage: '[data-testid="error-message"]',
+  };
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async navigate(): Promise<void> {
+    await this.goto('/categories');
+    await this.page.waitForURL('**/categories', { timeout: 30000 });
+    await this.page.waitForTimeout(500);
+
+    if (this.page.url().includes('/login')) {
+      throw new Error(
+        'Authentication failed: Redirected to /login. Check VITE_ENABLE_MSW_MOCK.'
+      );
+    }
+
+    await this.waitForElement(this.selectors.newCategoryButton, {
+      timeout: 30000,
+    });
+    await this.waitForListLoaded();
+  }
+
+  /**
+   * カテゴリ取得 useEffect が完了し、リストまたは空状態が描画されるまで待つ
+   */
+  async waitForListLoaded(): Promise<void> {
+    await this.page.waitForLoadState('networkidle');
+    await Promise.race([
+      this.page.locator(this.selectors.categoryList).waitFor({
+        state: 'visible',
+        timeout: 10000,
+      }),
+      this.page
+        .getByText('カテゴリがありません', { exact: false })
+        .waitFor({ state: 'visible', timeout: 10000 }),
+    ]);
+  }
+
+  getCategoryItems(): Locator {
+    return this.page.locator(this.selectors.categoryItem);
+  }
+
+  async getCategoryCount(): Promise<number> {
+    return await this.getCategoryItems().count();
+  }
+
+  async getCategoryNames(): Promise<string[]> {
+    const items = this.getCategoryItems();
+    const count = await items.count();
+    const names: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const text = await items
+        .nth(i)
+        .locator(this.selectors.categoryName)
+        .textContent();
+      names.push((text ?? '').trim());
+    }
+    return names;
+  }
+
+  async hasCategoryWithName(name: string): Promise<boolean> {
+    const names = await this.getCategoryNames();
+    return names.includes(name.trim());
+  }
+
+  async clickNewCategoryButton(): Promise<void> {
+    await this.click(this.selectors.newCategoryButton);
+    await this.page.waitForURL('**/categories/new', { timeout: 10000 });
+  }
+
+  async clickEditByName(name: string): Promise<void> {
+    const items = this.getCategoryItems();
+    const count = await items.count();
+    for (let i = 0; i < count; i++) {
+      const text = (
+        await items.nth(i).locator(this.selectors.categoryName).textContent()
+      )?.trim();
+      if (text === name.trim()) {
+        await items.nth(i).locator(this.selectors.editButton).click();
+        await this.page.waitForURL('**/categories/edit/**', { timeout: 10000 });
+        return;
+      }
+    }
+    throw new Error(`Category with name "${name}" not found`);
+  }
+
+  async deleteByName(name: string): Promise<void> {
+    const items = this.getCategoryItems();
+    const count = await items.count();
+    for (let i = 0; i < count; i++) {
+      const text = (
+        await items.nth(i).locator(this.selectors.categoryName).textContent()
+      )?.trim();
+      if (text === name.trim()) {
+        await items.nth(i).locator(this.selectors.deleteButton).click();
+        await this.waitForElement(this.selectors.confirmYes);
+        await this.click(this.selectors.confirmYes);
+        return;
+      }
+    }
+    throw new Error(`Category with name "${name}" not found`);
+  }
+
+  async waitForSuccessMessage(): Promise<void> {
+    await this.waitForElement(this.selectors.successMessage, {
+      timeout: 10000,
+    });
+  }
+}

--- a/tests/e2e/pages/AdminLoginPage.ts
+++ b/tests/e2e/pages/AdminLoginPage.ts
@@ -49,10 +49,32 @@ export class AdminLoginPage extends BasePage {
 
   /**
    * ログインボタンをクリック
+   *
+   * 認証 API のレスポンスを明示的に待ち、成功時はダッシュボードへの遷移完了まで
+   * ブロックする。失敗時は /login に留まったまま return する。
+   *
+   * 背景: 旧実装は networkidle のみを待っていたため、`saveAuthToken` (sessionStorage 書込)
+   * と navigate('/dashboard') を含む onSuccess コールバックの完了前に return することがあり、
+   * 後続の `goto('/posts')` 等のフルページナビゲーションで AuthContext 再初期化時に
+   * トークンが見つからず /login にリダイレクトされる flaky を引き起こしていた
+   * (admin-crud.spec.ts のローカル失敗の真因)。
    */
   async clickLogin(): Promise<void> {
+    const responsePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/auth/login') &&
+        resp.request().method() === 'POST',
+      { timeout: 10000 }
+    );
     await this.click(this.selectors.loginButton);
-    await this.waitForPageLoad();
+    const response = await responsePromise;
+
+    if (response.ok()) {
+      // 成功: onSuccess で saveAuthToken → navigate('/dashboard') が走るので、
+      // URL 遷移確定まで待つ
+      await this.page.waitForURL('**/dashboard', { timeout: 10000 });
+    }
+    // 失敗時は /login に留まる。エラーメッセージ表示の確認は呼び出し側に任せる。
   }
 
   /**

--- a/tests/e2e/specs/admin-categories.spec.ts
+++ b/tests/e2e/specs/admin-categories.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '../fixtures';
+import { resetMockCategories } from '../mocks/mockData';
+
+/**
+ * 管理画面カテゴリ CRUD の最小限 E2E テスト
+ *
+ * R43 に従い「重要なユーザーフローのみ」をカバーする：
+ * - 一覧表示
+ * - 新規作成
+ * - 編集（名前変更）
+ * - 削除
+ *
+ * 並べ替え D&D は単体テスト (CategoryListPage.test.tsx) でカバー済み。
+ *
+ * Test data prefix: AWS 実環境でも実行されるため、`[E2E-TEST]` プレフィックスを
+ * 名前に含めて識別・後処理可能にする (global-teardown が拾う想定)。
+ *
+ * Requirements:
+ * - R43: UI E2E テスト（最小限）（カテゴリ管理）
+ */
+
+const E2E_TEST_PREFIX = '[E2E-TEST]';
+
+test.describe('Admin Categories - CRUD', () => {
+  const testCredentials = {
+    email: process.env.TEST_ADMIN_EMAIL || 'admin@example.com',
+    password: process.env.TEST_ADMIN_PASSWORD || 'testpassword',
+  };
+
+  test.beforeEach(async ({ adminLoginPage }) => {
+    // MSW: 各テスト間でカテゴリ状態を独立させる
+    resetMockCategories();
+
+    await adminLoginPage.navigate();
+    await adminLoginPage.clearCredentials();
+    // login() は内部で /dashboard 遷移完了まで待つ
+    await adminLoginPage.login(testCredentials.email, testCredentials.password);
+  });
+
+  test('一覧に既存カテゴリが表示される', async ({ adminCategoryListPage }) => {
+    // Act
+    await adminCategoryListPage.navigate();
+
+    // Assert: シードカテゴリ (technology / life / business) が見える
+    const count = await adminCategoryListPage.getCategoryCount();
+    expect(count).toBeGreaterThan(0);
+
+    const names = await adminCategoryListPage.getCategoryNames();
+    expect(names.length).toBe(count);
+  });
+
+  test('新規作成すると一覧に反映される', async ({
+    adminCategoryListPage,
+    adminCategoryEditPage,
+  }) => {
+    const newName = `${E2E_TEST_PREFIX} cat-create-${Date.now()}`;
+
+    // Arrange
+    await adminCategoryListPage.navigate();
+    const initialCount = await adminCategoryListPage.getCategoryCount();
+
+    // Act: 新規ボタン → フォーム入力 → 保存
+    await adminCategoryListPage.clickNewCategoryButton();
+    await adminCategoryEditPage.fillName(newName);
+    await adminCategoryEditPage.submitAndWaitForList();
+
+    // Assert: 件数 +1 かつ作成名が一覧に存在
+    const newCount = await adminCategoryListPage.getCategoryCount();
+    expect(newCount).toBe(initialCount + 1);
+    expect(await adminCategoryListPage.hasCategoryWithName(newName)).toBe(true);
+  });
+
+  test('編集で名前を更新すると一覧に反映される', async ({
+    adminCategoryListPage,
+    adminCategoryEditPage,
+  }) => {
+    const seedName = `${E2E_TEST_PREFIX} cat-edit-seed-${Date.now()}`;
+    const updatedName = `${E2E_TEST_PREFIX} cat-edit-updated-${Date.now()}`;
+
+    // Arrange: 編集対象の一意なカテゴリを 1 件作成
+    await adminCategoryListPage.navigate();
+    await adminCategoryListPage.clickNewCategoryButton();
+    await adminCategoryEditPage.fillName(seedName);
+    await adminCategoryEditPage.submitAndWaitForList();
+    expect(await adminCategoryListPage.hasCategoryWithName(seedName)).toBe(
+      true
+    );
+
+    // Act: その行の編集 → 名前変更 → 保存
+    await adminCategoryListPage.clickEditByName(seedName);
+    await adminCategoryEditPage.fillName(updatedName);
+    await adminCategoryEditPage.submitAndWaitForList();
+
+    // Assert: 旧名が消え、新名が見える
+    expect(await adminCategoryListPage.hasCategoryWithName(updatedName)).toBe(
+      true
+    );
+    expect(await adminCategoryListPage.hasCategoryWithName(seedName)).toBe(
+      false
+    );
+  });
+
+  test('削除するとカテゴリが一覧から消える', async ({
+    adminCategoryListPage,
+    adminCategoryEditPage,
+  }) => {
+    const targetName = `${E2E_TEST_PREFIX} cat-delete-${Date.now()}`;
+
+    // Arrange: 削除対象の一意なカテゴリを 1 件作成
+    await adminCategoryListPage.navigate();
+    await adminCategoryListPage.clickNewCategoryButton();
+    await adminCategoryEditPage.fillName(targetName);
+    await adminCategoryEditPage.submitAndWaitForList();
+    const beforeCount = await adminCategoryListPage.getCategoryCount();
+
+    // Act
+    await adminCategoryListPage.deleteByName(targetName);
+    await adminCategoryListPage.waitForSuccessMessage();
+
+    // Assert: 件数 -1 かつ対象が消えている
+    await expect(async () => {
+      const afterCount = await adminCategoryListPage.getCategoryCount();
+      expect(afterCount).toBe(beforeCount - 1);
+    }).toPass({ timeout: 5000 });
+    expect(await adminCategoryListPage.hasCategoryWithName(targetName)).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary

E2E テストの過不足整理と、その過程で見つかった既存テストの flakiness を修正します。3 コミットで論理的に分離。

- **fix(test)**: `PostDetailPage.test.tsx` の SEOHead meta タグ race を `waitFor` で吸収。CI failure (`expected null to be truthy` at line 542) の原因。
- **fix(e2e)**: `AdminLoginPage.clickLogin()` を `waitForResponse` + `waitForURL('**/dashboard')` に変更し、post-login の auth state 永続化と後続 navigate の競合を解消。
- **feat(e2e)**: 管理画面カテゴリ CRUD の最小限 E2E spec (`admin-categories.spec.ts`, 4 test) を追加し、PR CI Job 7 のゲート対象に昇格。MSW handler / Page Object / fixtures / global-teardown / README も同期。

## 背景

E2E テストの過不足調査で以下のギャップを発見:

| # | 内容 | 対応 |
|---|------|------|
| A1 | `.kiro/specs/category-management/` で要件化済みの管理カテゴリ CRUD に E2E が無い | spec 追加 (commit 3) |
| A2 | `tests/e2e/README.md` が「6 spec / 13 tests」と記載されているが実体は 17/41 | README 同期 (commit 3) |
| A3 | `admin-crud` がローカルでだけ flaky (CI は pass) | AdminLoginPage 修正 (commit 2) |

調査中に PR CI が `PostDetailPage.test.tsx` で落ちていることに気付き、SEOHead `useEffect` と本文描画の effect サイクル分離による race と特定 → commit 1 で解消。

## R43 方針との整合

「最小限 E2E (重要なユーザーフローのみ)」方針は維持。dark mode toggle / about / RSS / Astro slug routing 等は unit/integration カバーで十分なので E2E 追加対象外と README に明記。

## CI スコープ

PR ゲート (Job 7) は以下 4 spec のみに拡張:
- `admin-auth.spec.ts`
- `admin-crud.spec.ts`
- `admin-categories.spec.ts` (新規)
- `admin-unauthorized-access.spec.ts`

残りの admin spec (tiptap / image / metadata-sidebar / autosave / unsaved-guard / publish-flow / preview-parity / slug-conflict) は MSW 環境で Tiptap 起動 race による pre-existing flakiness が確認されたため、安定化前は post-deploy AWS E2E (deploy.yml) のみで実行する運用を継続。理由は README に記載。

## Test plan

- [x] `bun run test:coverage` (frontend/public): 92/92 pass、100% coverage 維持
- [x] `bun run test:e2e -- --project=chromium --workers=1`: 7/7 pass
- [x] `bun run test:e2e:admin -- <PR-gated 4 spec>`: 10/10 pass、3 回連続実行で deterministic
- [x] `bun run test:e2e:admin -- admin-crud.spec.ts`: 3/3 pass (修正前は 1/3)
- [ ] CI で全ジョブ pass 確認

## 影響範囲

- **追加**: `tests/e2e/specs/admin-categories.spec.ts`, `tests/e2e/pages/AdminCategoryEditPage.ts`, `tests/e2e/pages/AdminCategoryListPage.ts`
- **修正**: `tests/e2e/pages/AdminLoginPage.ts`, `tests/e2e/fixtures/index.ts`, `tests/e2e/mocks/handlers.ts`, `tests/e2e/mocks/mockData.ts`, `tests/e2e/global-teardown.ts`, `tests/e2e/README.md`, `frontend/public/src/pages/PostDetailPage.test.tsx`, `.github/workflows/ci.yml`
- **アプリ本体は無変更**

🤖 Generated with [Claude Code](https://claude.com/claude-code)