### PR TITLE
ci: terraform plan を -lock-timeout で直列化（concurrency キャンセルの偽失敗を解消）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -761,12 +761,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-labels, terraform-validate-dev, terraform-merge-artifacts]
     environment: dev
-    # Serialize Plan jobs across all PRs to avoid Terraform state lock contention.
-    # Without this, concurrent Dependabot PRs all race for the same DynamoDB lock
-    # and most fail with "Error acquiring the state lock".
-    concurrency:
-      group: terraform-plan-dev
-      cancel-in-progress: false
+    # NOTE: Plan jobs are NOT serialized via a shared `concurrency` group.
+    # A single fixed group only keeps one pending run and cancels the rest, so
+    # concurrent Dependabot PRs surfaced as false "cancelled" failures.
+    # Instead we let plans run in parallel and wait politely for the shared
+    # DynamoDB state lock via `terraform plan -lock-timeout` (see the Plan step).
     if: |
       always() &&
       needs.setup-labels.outputs.has-terraform == 'true' &&
@@ -839,7 +838,9 @@ jobs:
         id: plan
         working-directory: terraform/environments/dev
         run: |
-          terraform plan -out=tfplan.binary -detailed-exitcode -no-color 2>&1 | tee tfplan_output.txt || exitcode=$?
+          # -lock-timeout lets concurrent PR plans wait for the shared DynamoDB
+          # state lock instead of failing immediately with "Error acquiring the state lock".
+          terraform plan -out=tfplan.binary -lock-timeout=5m -detailed-exitcode -no-color 2>&1 | tee tfplan_output.txt || exitcode=$?
           terraform show -json tfplan.binary > tfplan.json
           terraform show -no-color tfplan.binary > tfplan.txt
           echo "exitcode=${exitcode:-0}" >> $GITHUB_OUTPUT
@@ -886,12 +887,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-labels, terraform-validate-prd, terraform-merge-artifacts]
     environment: prod
-    # Serialize Plan jobs across all PRs to avoid Terraform state lock contention.
-    # Without this, concurrent Dependabot PRs all race for the same DynamoDB lock
-    # and most fail with "Error acquiring the state lock".
-    concurrency:
-      group: terraform-plan-prd
-      cancel-in-progress: false
+    # NOTE: Plan jobs are NOT serialized via a shared `concurrency` group.
+    # A single fixed group only keeps one pending run and cancels the rest, so
+    # concurrent Dependabot PRs surfaced as false "cancelled" failures.
+    # Instead we let plans run in parallel and wait politely for the shared
+    # DynamoDB state lock via `terraform plan -lock-timeout` (see the Plan step).
     if: |
       always() &&
       needs.setup-labels.outputs.has-terraform == 'true' &&
@@ -957,7 +957,9 @@ jobs:
         id: plan
         working-directory: terraform/environments/prd
         run: |
-          terraform plan -out=tfplan.binary -detailed-exitcode -no-color 2>&1 | tee tfplan_output.txt || exitcode=$?
+          # -lock-timeout lets concurrent PR plans wait for the shared DynamoDB
+          # state lock instead of failing immediately with "Error acquiring the state lock".
+          terraform plan -out=tfplan.binary -lock-timeout=5m -detailed-exitcode -no-color 2>&1 | tee tfplan_output.txt || exitcode=$?
           terraform show -json tfplan.binary > tfplan.json
           terraform show -no-color tfplan.binary > tfplan.txt
           echo "exitcode=${exitcode:-0}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 背景 / Problem

Dependabot の terraform PR（例: #316, #291）で **Terraform Plan (DEV)** が失敗表示になっていた。
実際の Terraform エラーではなく、GitHub Actions の **concurrency によるキャンセル**だった:

> `Canceling since a higher priority waiting request for terraform-plan-dev exists`

`terraform-plan-dev` / `terraform-plan-prd` は全PR横断の固定 `concurrency` グループで直列化していたが、
GitHub の concurrency は **1グループにつき pending を1件しか保持できず、それより前の pending をキャンセル**する。
Dependabot が複数の terraform PR を同時に開くと、間に挟まれたPRがキャンセル＝偽失敗になっていた。
（state lock 競合対策が別の偽失敗を生んでいた状態）

## 変更 / Change

- `terraform-plan-dev` / `terraform-plan-prd` の固定 `concurrency` グループを削除
- `terraform plan` に `-lock-timeout=5m` を追加し、共有 DynamoDB state lock を**待つ**ように変更

これにより plan ジョブは並列実行可能になりつつ、ロックは Terraform ネイティブの待機で自然に直列化される。
「Error acquiring the state lock」と「concurrency キャンセルの偽失敗」の両方を解消する。

## 影響 / Notes

- `terraform init` / `validate` は state lock を取らないため変更なし
- `-lock-timeout=5m`: 同時 terraform PR が多数ある場合、末尾ジョブが最大5分ロック待ち。必要なら延長可
- `deploy.yml` の apply は PR plan のレース対象外につきスコープ外

## 検証 / Verification

- 本PRの CI で「Terraform Plan (DEV)」が pass すること（単独実行のため緑見込み）
- マージ後、#291 → #316 を順次 `@dependabot rebase` し、Plan (DEV) が pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)