### PR TITLE
ci: dedupe concurrent CI runs per PR to fix flaky Terraform Plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,22 @@ on:
       - main
       - develop
 
+# Deduplicate concurrent CI runs for the SAME pull request.
+# Dependabot opening a PR, combined with the auto-labeler firing `labeled` /
+# `unlabeled` events, launches several CI runs against one commit at nearly the
+# same instant. Each run executes Terraform Plan against the shared DEV/PRD
+# state backend and races on the S3/DynamoDB state lock, surfacing as a flaky
+# "Terraform Plan" failure even though the plan itself is clean.
+#
+# Scoping the group to the PR number (not a fixed string) keeps plans for
+# DIFFERENT PRs running in parallel — they rely on `-lock-timeout` for the
+# shared lock — while cancelling only the now-stale earlier runs of THIS same
+# PR. This avoids the false cross-PR "cancelled" failures a fixed shared group
+# previously caused.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write # Required for actions/labeler to add labels
@@ -761,11 +777,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-labels, terraform-validate-dev, terraform-merge-artifacts]
     environment: dev
-    # NOTE: Plan jobs are NOT serialized via a shared `concurrency` group.
-    # A single fixed group only keeps one pending run and cancels the rest, so
-    # concurrent Dependabot PRs surfaced as false "cancelled" failures.
-    # Instead we let plans run in parallel and wait politely for the shared
-    # DynamoDB state lock via `terraform plan -lock-timeout` (see the Plan step).
+    # NOTE: Duplicate CI runs for the *same* PR (from the `labeled`/`unlabeled`
+    # event storm) are de-duplicated by the workflow-level `concurrency` group
+    # keyed on the PR number (see top of file). Plans for *different* PRs still
+    # run in parallel and wait politely for the shared DynamoDB state lock via
+    # `terraform plan -lock-timeout` (see the Plan step). We intentionally do NOT
+    # use a fixed shared group, which would cancel cross-PR plans as false
+    # "cancelled" failures.
     if: |
       always() &&
       needs.setup-labels.outputs.has-terraform == 'true' &&
@@ -887,11 +905,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup-labels, terraform-validate-prd, terraform-merge-artifacts]
     environment: prod
-    # NOTE: Plan jobs are NOT serialized via a shared `concurrency` group.
-    # A single fixed group only keeps one pending run and cancels the rest, so
-    # concurrent Dependabot PRs surfaced as false "cancelled" failures.
-    # Instead we let plans run in parallel and wait politely for the shared
-    # DynamoDB state lock via `terraform plan -lock-timeout` (see the Plan step).
+    # NOTE: Duplicate CI runs for the *same* PR (from the `labeled`/`unlabeled`
+    # event storm) are de-duplicated by the workflow-level `concurrency` group
+    # keyed on the PR number (see top of file). Plans for *different* PRs still
+    # run in parallel and wait politely for the shared DynamoDB state lock via
+    # `terraform plan -lock-timeout` (see the Plan step). We intentionally do NOT
+    # use a fixed shared group, which would cancel cross-PR plans as false
+    # "cancelled" failures.
     if: |
       always() &&
       needs.setup-labels.outputs.has-terraform == 'true' &&


### PR DESCRIPTION
## 背景 / 問題

PR #379（Dependabot: aws provider 6.51.0→6.52.0 in `terraform/environments/dev`）の **Terraform Plan (DEV)** が失敗していた。

調査の結果、依存更新自体の問題ではなく **CIの並行実行に起因するフレーキー（一過性）な失敗**だった:

- Dependabot のPRオープン ＋ オートラベラーの `labeled`/`unlabeled` イベント連発により、**同一コミットに対してCI runが4本ほぼ同時に起動**（`2026-06-30T18:05:17〜18Z`）。
- 各runが**共有のDEV/PRD Terraform state（S3 + DynamoDB ロック）に対して同時にplan**を実行し、state ロックを奪い合う。
- 結果、同一コミットにもかかわらず **3本は `✅ No changes` で成功・1本だけ `Terraform Plan` ステップで失敗**（plan内容はクリーン）。

## 対応

ワークフローレベルの `concurrency` グループを追加:

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

### 設計方針
- **グループキーをPR番号でスコープ** → 同一PRの多重run（label イベントストーム）を1本に集約し、共有ロックの同時アクセス競合を解消。
- **PRごとにグループが分離** → 別PR同士のplanは従来どおり並列実行され、共有ロックは `terraform plan -lock-timeout=5m` で待ち合わせる。
- 以前作者が試して失敗した「**固定グループで別PRまでキャンセルされ false cancelled になる**」構成は回避。

あわせて plan ジョブ（DEV/PRD）の古いNOTEコメントを新方針に更新。

## 検証
- YAML構文の妥当性、`concurrency` ブロックのパースを確認済み。

## 補足（別スコープ）
plan ステップには別途、真のエラーを隠蔽する潜在バグ（`set -o pipefail` 欠如 + ガードなしの `terraform show` により plan 失敗が汎用 `exit code 1` に化ける）が残っている。本PRのスコープ外だが、恒久的なエラー可視化のため別途対応を推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)