### PR TITLE
chore(frontend): clear Astro check hints

### DIFF
--- a/frontend/public-astro/src/layouts/Layout.astro
+++ b/frontend/public-astro/src/layouts/Layout.astro
@@ -148,8 +148,7 @@ const {
           if (saved !== 'system') return;
           document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
         };
-        if (mql.addEventListener) mql.addEventListener('change', handler);
-        else if (mql.addListener) mql.addListener(handler);
+        mql.addEventListener('change', handler);
       })();
     </script>
   </body>

--- a/frontend/public-astro/src/lib/backwardCompatibility.test.ts
+++ b/frontend/public-astro/src/lib/backwardCompatibility.test.ts
@@ -23,7 +23,6 @@ import {
   IMAGE_PATHS,
   PUBLIC_URL_STRUCTURE,
   ROLLBACK_CONFIG,
-  type RouteVerificationResult,
   type RollbackConfig,
 } from './backwardCompatibility';
 

--- a/frontend/public-astro/src/lib/performanceUtils.test.ts
+++ b/frontend/public-astro/src/lib/performanceUtils.test.ts
@@ -14,9 +14,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  type PerformanceBudget,
   type BuildArtifact,
-  type PerformanceValidationResult,
   DEFAULT_PERFORMANCE_BUDGET,
   validateBuildArtifact,
   calculateTotalJsSize,


### PR DESCRIPTION
## 概要

- 非推奨の `MediaQueryList.addListener()` フォールバックを削除
- OSテーマ変更の監視を `addEventListener("change", handler)` に統一
- テストファイルの未使用型インポート3件を削除
- Astroチェックの5件のヒントをすべて解消

Closes #437

## 検証

- [x] `bun run check`（0 errors / 0 warnings / 0 hints）
- [x] Astroテスト（363 tests passed）
- [x] pre-commit公開サイトテスト（92 tests passed）
- [x] `git diff --check`

## 変更ファイル

- `frontend/public-astro/src/layouts/Layout.astro`
- `frontend/public-astro/src/lib/backwardCompatibility.test.ts`
- `frontend/public-astro/src/lib/performanceUtils.test.ts`