### PR TITLE
fix(terraform): address Checkov hardening findings

### DIFF
--- a/terraform/modules/auth/main.tf
+++ b/terraform/modules/auth/main.tf
@@ -110,6 +110,7 @@ resource "aws_cognito_user_pool_client" "main" {
 # SSM Parameters for Cognito configuration (used by frontend build)
 # These parameters are managed by Terraform and read by CI/CD pipeline
 resource "aws_ssm_parameter" "user_pool_id" {
+  #checkov:skip=CKV2_AWS_34:Stores a non-sensitive Cognito resource identifier; revisit if this parameter becomes sensitive.
   name        = "/serverless-blog/${var.environment}/cognito/user-pool-id"
   description = "Cognito User Pool ID for ${var.environment} environment"
   type        = "String"
@@ -119,6 +120,7 @@ resource "aws_ssm_parameter" "user_pool_id" {
 }
 
 resource "aws_ssm_parameter" "user_pool_client_id" {
+  #checkov:skip=CKV2_AWS_34:Stores a public Cognito app client identifier; revisit if this parameter becomes sensitive.
   name        = "/serverless-blog/${var.environment}/cognito/user-pool-client-id"
   description = "Cognito User Pool Client ID for ${var.environment} environment"
   type        = "String"

--- a/terraform/modules/cdn/main.tf
+++ b/terraform/modules/cdn/main.tf
@@ -676,6 +676,7 @@ resource "aws_cloudfront_distribution" "main" {
 # SSM Parameters for CDN configuration (used by CI/CD)
 #------------------------------------------------------------------------------
 resource "aws_ssm_parameter" "api_endpoint" {
+  #checkov:skip=CKV2_AWS_34:Stores a public API URL used by CI/CD; revisit if this parameter becomes sensitive.
   name        = "/serverless-blog/${var.environment}/api/endpoint"
   description = "API endpoint URL for ${var.environment} environment (via CloudFront)"
   type        = "String"
@@ -692,6 +693,7 @@ resource "aws_ssm_parameter" "api_endpoint" {
 }
 
 resource "aws_ssm_parameter" "distribution_id" {
+  #checkov:skip=CKV2_AWS_34:Stores a non-sensitive CloudFront resource identifier; revisit if this parameter becomes sensitive.
   name        = "/serverless-blog/${var.environment}/cdn/distribution-id"
   description = "CloudFront distribution ID for ${var.environment} environment"
   type        = "String"
@@ -708,6 +710,7 @@ resource "aws_ssm_parameter" "distribution_id" {
 }
 
 resource "aws_ssm_parameter" "public_url" {
+  #checkov:skip=CKV2_AWS_34:Stores a public site URL used by CI/CD; revisit if this parameter becomes sensitive.
   name        = "/serverless-blog/${var.environment}/cdn/public-url"
   description = "Public site URL for ${var.environment} environment"
   type        = "String"
@@ -722,4 +725,3 @@ resource "aws_ssm_parameter" "public_url" {
     var.tags
   )
 }
-

--- a/terraform/modules/codebuild/main.tf
+++ b/terraform/modules/codebuild/main.tf
@@ -287,6 +287,7 @@ resource "aws_codebuild_project" "astro_build" {
 # =============================================================================
 
 resource "aws_ssm_parameter" "codebuild_project_name" {
+  #checkov:skip=CKV2_AWS_34:Stores a non-sensitive resource name used to trigger builds; revisit if this parameter becomes sensitive.
   name        = "/${var.project_name}/${var.environment}/codebuild/astro-build-project"
   description = "CodeBuild project name for Astro SSG builds"
   type        = "String"

--- a/terraform/modules/dns-route53/main.tf
+++ b/terraform/modules/dns-route53/main.tf
@@ -4,6 +4,8 @@
 
 # Route53 hosted zone for subdomain
 resource "aws_route53_zone" "subdomain" {
+  #checkov:skip=CKV2_AWS_38:This development-only child zone is delegated from Cloudflare; KMS/KSK and DS coordination add outage risk. Revisit if the zone becomes production-critical.
+  #checkov:skip=CKV2_AWS_39:This low-traffic development zone has no DNS forensic workflow; query logging adds CloudWatch cost and operational overhead. Revisit if detection or compliance requires it.
   name    = var.zone_name
   comment = "Hosted zone for ${var.zone_name} - ${var.environment} environment"
 

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -16,6 +16,7 @@ locals {
 
 #trivy:ignore:AVD-AWS-0095 Alarm notifications contain non-sensitive operational data; CMK adds cost
 resource "aws_sns_topic" "alarms" {
+  #checkov:skip=CKV_AWS_26:Carries non-sensitive production alarm metadata; TLS is enforced and CMK misconfiguration could block critical notifications. Revisit for sensitive payloads or compliance requirements.
   count = var.enable_alarms ? 1 : 0
 
   name         = "BlogPlatform-Alarms"

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -73,6 +73,17 @@ resource "aws_s3_bucket_lifecycle_configuration" "access_logs" {
   bucket = aws_s3_bucket.access_logs[0].id
 
   rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
     id     = "expire-access-logs"
     status = "Enabled"
 
@@ -137,6 +148,17 @@ resource "aws_s3_bucket_public_access_block" "images" {
 # Requirement 3.4: Create lifecycle policy for version management
 resource "aws_s3_bucket_lifecycle_configuration" "images" {
   bucket = aws_s3_bucket.images.id
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
 
   rule {
     id     = "transition-to-ia"
@@ -260,6 +282,17 @@ resource "aws_s3_bucket_public_access_block" "public_site" {
 # Requirement 6.7: Lifecycle policy to cleanup old versions (retain for rollback window)
 resource "aws_s3_bucket_lifecycle_configuration" "public_site" {
   bucket = aws_s3_bucket.public_site.id
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
 
   rule {
     id     = "cleanup-old-versions"
@@ -390,6 +423,7 @@ resource "aws_s3_bucket_policy" "admin_site" {
 #------------------------------------------------------------------------------
 
 resource "aws_ssm_parameter" "public_site_bucket_name" {
+  #checkov:skip=CKV2_AWS_34:Stores a non-sensitive bucket name used by CI/CD; revisit if this parameter becomes sensitive.
   name        = "/serverless-blog/${var.environment}/storage/public-site-bucket-name"
   description = "Public site S3 bucket name for ${var.environment} environment"
   type        = "String"
@@ -399,6 +433,7 @@ resource "aws_ssm_parameter" "public_site_bucket_name" {
 }
 
 resource "aws_ssm_parameter" "admin_site_bucket_name" {
+  #checkov:skip=CKV2_AWS_34:Stores a non-sensitive bucket name used by CI/CD; revisit if this parameter becomes sensitive.
   name        = "/serverless-blog/${var.environment}/storage/admin-site-bucket-name"
   description = "Admin site S3 bucket name for ${var.environment} environment"
   type        = "String"

--- a/terraform/modules/storage/tests/storage.tftest.hcl
+++ b/terraform/modules/storage/tests/storage.tftest.hcl
@@ -85,6 +85,16 @@ run "image_bucket_lifecycle" {
     condition     = length(aws_s3_bucket_lifecycle_configuration.images.rule) > 0
     error_message = "Image bucket must have lifecycle rules configured"
   }
+
+  assert {
+    condition = anytrue([
+      for rule in aws_s3_bucket_lifecycle_configuration.images.rule :
+      rule.id == "abort-incomplete-multipart-uploads" &&
+      rule.status == "Enabled" &&
+      rule.abort_incomplete_multipart_upload[0].days_after_initiation == 7
+    ])
+    error_message = "Image bucket must abort incomplete multipart uploads after 7 days"
+  }
 }
 
 # Test 5: Verify public site bucket is created
@@ -326,6 +336,16 @@ run "access_logs_bucket_enabled" {
     condition     = aws_s3_bucket.access_logs[0].bucket != null
     error_message = "Access logs bucket must be created when enable_access_logs is true"
   }
+
+  assert {
+    condition = anytrue([
+      for rule in aws_s3_bucket_lifecycle_configuration.access_logs[0].rule :
+      rule.id == "abort-incomplete-multipart-uploads" &&
+      rule.status == "Enabled" &&
+      rule.abort_incomplete_multipart_upload[0].days_after_initiation == 7
+    ])
+    error_message = "Access logs bucket must abort incomplete multipart uploads after 7 days"
+  }
 }
 
 # Test 18: Verify access logs bucket is NOT created when disabled
@@ -373,6 +393,16 @@ run "public_site_bucket_lifecycle" {
   assert {
     condition     = length(aws_s3_bucket_lifecycle_configuration.public_site.rule) > 0
     error_message = "Public site bucket must have lifecycle rules for version cleanup"
+  }
+
+  assert {
+    condition = anytrue([
+      for rule in aws_s3_bucket_lifecycle_configuration.public_site.rule :
+      rule.id == "abort-incomplete-multipart-uploads" &&
+      rule.status == "Enabled" &&
+      rule.abort_incomplete_multipart_upload[0].days_after_initiation == 7
+    ])
+    error_message = "Public site bucket must abort incomplete multipart uploads after 7 days"
   }
 }
 


### PR DESCRIPTION
## 概要

- access logs、images、public siteのS3ライフサイクルへ、7日経過した未完了マルチパートアップロードの破棄ルールを追加
- 非機密値を保存するSSM Parameter 8件へ、再検討条件を含むCheckov抑制理由を追加
- prd監視通知用SNS topicへ、可用性・費用・非機密性に基づくCheckov抑制理由を追加
- dev専用Route 53 zoneへ、DNSSECとQuery LoggingのCheckov抑制理由を追加
- 3つのS3ライフサイクルルールを検証するTerraformテストを追加

Closes #196

## S3への影響

追加ルールが対象にするのは、開始から7日を超えても完了していないmultipart uploadのupload IDとpartだけです。完成済みオブジェクト、公開サイトの必須ファイル、既存バージョン、既存のIA移行・期限切れルールには影響しません。

## 検証

- [x] `terraform fmt -check -recursive terraform`
- [x] storage module `terraform validate`
- [x] dev/prd `terraform init -backend=false` + `terraform validate`
- [x] storage module tests（21 passed）
- [x] Issue対象Checkov checks（0 failed）
- [x] Trivy HIGH/CRITICAL（0 findings）
- [x] `git diff --check`

## 補足

実AWS stateを使う `terraform plan` は、ローカルAWS SSOセッションが期限切れのため未実行です。CIのTerraform planで実環境差分を確認してください。Checkov全体にはIssue #196対象外の既存指摘が残っています。