### PR TITLE
fix(ci): clear Terraform annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,7 +400,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -599,7 +599,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -644,7 +644,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -739,7 +739,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -805,7 +805,7 @@ jobs:
           path: go-functions/bin
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
@@ -874,7 +874,7 @@ jobs:
           retention-days: 3
 
       - name: Comment Plan on PR
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require('fs');
@@ -933,7 +933,7 @@ jobs:
           path: go-functions/bin
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
@@ -995,7 +995,7 @@ jobs:
           retention-days: 3
 
       - name: Comment Plan on PR
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -349,7 +349,7 @@ jobs:
           path: go-functions/bin
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 
@@ -453,7 +453,7 @@ jobs:
           path: go-functions/bin
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
 

--- a/terraform/.checkov.yaml
+++ b/terraform/.checkov.yaml
@@ -50,11 +50,19 @@ skip-check:
   # Mitigation: CloudTrail enabled for all S3 API calls
   - CKV_AWS_18
 
-  # CKV_AWS_145: Ensure that S3 bucket has cross-region replication enabled
+  # CKV_AWS_144: Ensure that S3 bucket has cross-region replication enabled
   # Justification: Cross-region replication is not required for this single-region
-  # blog application. State bucket uses S3 versioning for disaster recovery.
-  # Enabling CRR would double storage costs without matching business requirement.
-  # Mitigation: S3 versioning enabled for point-in-time recovery
+  # blog application. Enabling CRR would require destination buckets, replication
+  # IAM roles, and additional storage and transfer costs without matching the
+  # recovery objectives of this low-traffic personal blog.
+  # Mitigation: S3 regional durability and versioning on mutable content buckets
+  - CKV_AWS_144
+
+  # CKV_AWS_145: Ensure that S3 buckets are encrypted with a customer-managed KMS key
+  # Justification: SSE-S3 and AWS-managed encryption provide sufficient protection
+  # for non-sensitive blog assets and access logs. Customer-managed KMS keys add
+  # recurring cost and key lifecycle dependencies without a compliance requirement.
+  # Mitigation: Server-side encryption is enabled on every bucket
   - CKV_AWS_145
 
   # CKV2_AWS_62: Ensure S3 bucket has event notifications enabled

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -30,6 +30,8 @@ locals {
 
 # Requirement: Enable access logging for production
 resource "aws_s3_bucket" "access_logs" {
+  #checkov:skip=CKV_AWS_21:This bucket stores append-only access logs under unique keys and expires them through lifecycle management. Revisit if it begins storing mutable objects.
+  #checkov:skip=CKV2_AWS_6:False positive: the conditional bucket uses an indexed public access block with all four protections enabled.
   count  = var.enable_access_logs ? 1 : 0
   bucket = local.access_logs_bucket_name
 
@@ -381,6 +383,40 @@ resource "aws_s3_bucket_public_access_block" "admin_site" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+# Enable versioning to support short-term rollback of admin site deployments
+resource "aws_s3_bucket_versioning" "admin_site" {
+  bucket = aws_s3_bucket.admin_site.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Retain previous admin site versions for rollback and clean up incomplete uploads
+resource "aws_s3_bucket_lifecycle_configuration" "admin_site" {
+  bucket = aws_s3_bucket.admin_site.id
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  rule {
+    id     = "cleanup-old-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
 }
 
 # Configure access logging for admin site bucket (when enabled)

--- a/terraform/modules/storage/tests/storage.tftest.hcl
+++ b/terraform/modules/storage/tests/storage.tftest.hcl
@@ -433,3 +433,38 @@ run "all_buckets_created" {
     error_message = "Admin site bucket must be created"
   }
 }
+
+# Test 22: Verify admin site deployment rollback and incomplete upload cleanup
+run "admin_site_bucket_versioning_and_lifecycle" {
+  command = plan
+
+  variables {
+    project_name = "serverless-blog"
+    environment  = "dev"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_versioning.admin_site.versioning_configuration[0].status == "Enabled"
+    error_message = "Admin site bucket must have versioning enabled for deployment rollback"
+  }
+
+  assert {
+    condition = anytrue([
+      for rule in aws_s3_bucket_lifecycle_configuration.admin_site.rule :
+      rule.id == "abort-incomplete-multipart-uploads" &&
+      rule.status == "Enabled" &&
+      rule.abort_incomplete_multipart_upload[0].days_after_initiation == 7
+    ])
+    error_message = "Admin site bucket must abort incomplete multipart uploads after 7 days"
+  }
+
+  assert {
+    condition = anytrue([
+      for rule in aws_s3_bucket_lifecycle_configuration.admin_site.rule :
+      rule.id == "cleanup-old-versions" &&
+      rule.status == "Enabled" &&
+      rule.noncurrent_version_expiration[0].noncurrent_days == 7
+    ])
+    error_message = "Admin site bucket must retain noncurrent versions for a 7-day rollback window"
+  }
+}


### PR DESCRIPTION
## 概要

PR #440 マージ後に確認された Checkov 10件と、GitHub Actions の Node.js 20 非推奨警告4件を解消します。

- access logs bucket の Public Access Block 検出を、実リソースが存在することを明記したうえで誤検知として抑制
- access logs bucket の versioning 指摘を、追記専用・一意キー・ライフサイクル管理という用途に基づき抑制
- admin site bucket の versioning を有効化し、非現行バージョンを7日後に削除するライフサイクルを追加
- Cross-Region Replication（CKV_AWS_144）と KMS CMK（CKV_AWS_145）の抑制理由を分離・明確化
- hashicorp/setup-terraform を v4.0.1、actions/github-script を v8へ更新

Follow-up to #440

## 検証

- [x] Terraform fmt
- [x] Terraform validate
- [x] Trivy IaC Scan
- [x] YAML validation
- [x] storage module tests（22 passed）
- [x] Checkov: 今回報告された10件は解消

## 補足

Checkov 全体では今回の対象外である既存指摘2件（CKV2_AWS_71、CKV2_AWS_23）が残っています。