### PR TITLE
fix(pre-commit): trivyフックを修正しpre-commitが起動するようにする

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,11 @@ repos:
         files: ^terraform/modules/
 
   # Trivy - Security scanning (Requirements: 12.2, 12.5, 12.10)
-  - repo: https://github.com/aquasecurity/trivy
-    rev: v0.58.1
+  # aquasecurity/trivy does not ship a .pre-commit-hooks.yaml, so it cannot be
+  # used as a hook repo (pre-commit fails to load the manifest for the whole
+  # config). The hook already ran `language: system` against the locally
+  # installed trivy binary, so declare it as a local hook instead.
+  - repo: local
     hooks:
       - id: trivy-config
         name: trivy-terraform-scan
@@ -50,8 +53,11 @@ repos:
           - --severity=HIGH,CRITICAL
           - --exit-code=1
           - --ignorefile=.trivyignore
+          - terraform/
         files: ^terraform/
-        pass_filenames: true
+        # `trivy config` accepts a single target only, so scan terraform/ as a
+        # whole rather than passing each staged file.
+        pass_filenames: false
         language: system
 
   # Gitleaks - Secret scanning on staged files (repo-wide secret history scan runs in CI)


### PR DESCRIPTION
## 問題

`pre-commit` が**どのフックも実行できない**状態でした。CLAUDE.md が push 前に必須としている以下のコマンドが動きません。

```
$ pre-commit run gitleaks --all-files
An error has occurred: InvalidManifestError:
=====> /Users/shin/.cache/pre-commit/repo6a7zhpgd/.pre-commit-hooks.yaml is not a file
```

## 原因（2点）

### 1. `aquasecurity/trivy` はフックリポジトリとして使えない

trivy 本体のリポジトリは `.pre-commit-hooks.yaml` を提供していません（v0.58.1 のクローンを確認済み）。pre-commit は**設定全体を読み込む時点で**全リポジトリの manifest を検証するため、この1件が原因で gitleaks を含む全フックが起動しなくなっていました。

このフックは元々 `language: system` + `entry: trivy config` でローカルの trivy バイナリを呼んでおり、リポジトリのクローンは実質不要でした。そのため `repo: local` として宣言し直します。

### 2. `trivy config` に複数ファイルを渡していた

1 を直すと露呈する既存バグです。

```
FATAL  Fatal error  multiple targets cannot be specified
```

`trivy config` は対象を1つしか受け付けませんが、`pass_filenames: true` によりステージされた terraform ファイルが個別に渡されていました。`terraform/` を一括スキャンする形に変更します。

## 動作確認

```
$ pre-commit run gitleaks --all-files
Detect hardcoded secrets.................................................Passed

$ pre-commit run trivy-config --all-files
trivy-terraform-scan.....................................................Passed
```

`pre-commit validate-config` もエラーなしです。

## 補足

`--severity=HIGH,CRITICAL` `--exit-code=1` `--ignorefile=.trivyignore` および `files: ^terraform/` によるトリガ条件は変更していないため、検出内容の厳しさは従来どおりです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)