### PR TITLE
chore(deps): golang.org/x/net を v0.55.0 に更新 (GHSA-5cv4-jp36-h3mw)

### DIFF
--- a/go-functions/go.mod
+++ b/go-functions/go.mod
@@ -44,6 +44,6 @@ require (
 	github.com/ikawaha/kagome-dict v1.1.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go-functions/go.sum
+++ b/go-functions/go.sum
@@ -74,8 +74,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.8.4 h1:oat/nd3U6NeQqFEL3xpEJq7d7c86NI+DbSNGAs4xnjA=
 github.com/yuin/goldmark v1.8.4/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## 概要

Dependabot アラート **GHSA-5cv4-jp36-h3mw**（MEDIUM）に対応します。

| | |
|---|---|
| パッケージ | `golang.org/x/net`（indirect） |
| 現行 | `v0.38.0` |
| 更新後 | `v0.55.0` |
| 対象 | `go-functions/go.mod` |

## 動作確認

- `go build ./...` → OK
- `go vet ./...` → OK
- `go test ./...` → 30パッケージすべて通過、失敗なし

## 補足

Dependabot の未対応アラート9件のうち、本PRで解消するのはこの1件です。残る8件はすべて `frontend/public-astro` の `astro` に関するもので、解消には **5.x → 7.1.0 の2メジャーバージョン跨ぎ**が必要です。このリポジトリには過去に Astro 6 へ上げて差し戻した経緯（`hotfix/astro-revert-to-5x`）があるため、本PRとは切り離し別途方針を決めるべきと判断しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)