### PR TITLE
chore(git): docs/reviews/ をコミット対象から外しローカル保管にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,6 +236,11 @@ layers/**/*.js
 # Project Specific
 # ===================================
 
+# Security/architecture review notes (keep local)
+# 稼働中システムの弱点をファイル名・行番号付きで列挙した内容を含むため、
+# 公開リポジトリである本リポジトリにはコミットしない。
+docs/reviews/
+
 # Serena (AI Assistant)
 .serena/memories/
 .serena/cache/


### PR DESCRIPTION
## 概要

`docs/reviews/` を `.gitignore` に追加し、レビュー文書はリポジトリ外でローカル保管する方針にします。

## 理由

このリポジトリは **PUBLIC** です（組織名が `okshin-yk-private` のため紛らわしいですが、`gh repo view` で `visibility=PUBLIC` を確認済み）。

`docs/reviews/aws-review-2026-05-08.md` は AWS 構成レビューの結果で、稼働中システムの弱点を**優先度順に、ファイル名と行番号付きで**列挙した内容を含みます。

- CloudFront / API Gateway とも WAF 未アタッチ（レビュー内で `✗` Critical 判定）
- Basic 認証情報が CloudFront Function コードに埋め込まれており `describe-function` で取得可能
- 管理者用 Cognito の MFA が `OPTIONAL`
- OAuth `implicit` フロー有効、dev の CORS が `*`

秘密情報そのもの（アカウントID / ARN / アクセスキー / 平文パスワード / 実ドメイン）は**含まれていないことを確認済み**ですが、公開リポジトリに置くと攻撃者向けの手引きとして機能してしまうため、コミットは見送ります。

## 確認済み

- `git check-ignore` で `docs/reviews/` 配下が IGNORED になること
- `docs/SECURITY_SCANNING.md` など **`docs/` 配下の他ドキュメントは影響を受けない**こと
- `docs/reviews/` に追跡中のファイルが 0 件であること（追跡解除の必要なし）
- ローカルのファイルはそのまま残ること

## 補足

将来 `✗` / HIGH 相当の指摘を解消した後であれば、「対処済みの記録」として公開する判断もあり得ます。その場合はこの ignore を外してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)