### PR TITLE
fix(public-astro): Aboutページのデザインをトップページに統一

### DIFF
--- a/frontend/public-astro/src/pages/about.astro
+++ b/frontend/public-astro/src/pages/about.astro
@@ -18,94 +18,88 @@ const siteMetadata = getSiteMetadata();
 ---
 
 <Layout title={aboutContent.title} description={aboutContent.description}>
-  <div class="about-page">
-    <!-- Hero Section -->
-    <section class="hero-section" aria-labelledby="about-title">
-      <div class="hero-inner">
-        <h1 id="about-title" class="hero-primary">{aboutContent.title}</h1>
-        <p class="hero-secondary">Story, profile &amp; connections</p>
-        <span class="hero-seed" aria-hidden="true"></span>
+  <!-- Hero Section -->
+  <section class="hero-section" aria-labelledby="about-title">
+    <div class="hero-inner">
+      <p class="hero-eyebrow">Story, profile &amp; connections</p>
+      <h1 id="about-title" class="hero-title">{aboutContent.title}</h1>
+      <span class="hero-seed" aria-hidden="true"></span>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="content-container">
+    <!-- About This Blog Section -->
+    {aboutContent.sections.map((section) => (
+      <section class="about-section">
+        <h2 class="section-title">{section.heading}</h2>
+        <div class="section-content">
+          <p set:html={section.content.replace(/\n/g, '<br />')} />
+        </div>
+      </section>
+    ))}
+
+    <!-- Profile Section -->
+    <section class="about-section">
+      <h2 class="section-title">Profile</h2>
+      <div class="profile-card">
+        <div class="profile-avatar">
+          <img src="/profile.png" alt="Profile" class="avatar-image" />
+        </div>
+        <div class="profile-info">
+          <h3 class="profile-name">{siteMetadata.author.name}</h3>
+          {siteMetadata.author.role && (
+            <p class="profile-role">{siteMetadata.author.role}</p>
+          )}
+          {siteMetadata.author.bio && (
+            <p class="profile-bio">{siteMetadata.author.bio}</p>
+          )}
+        </div>
       </div>
     </section>
 
-    <!-- Main Content -->
-    <main class="content-container">
-      <!-- About This Blog Section -->
-      {aboutContent.sections.map((section) => (
-        <section class="about-section">
-          <h2 class="section-title">{section.heading}</h2>
-          <div class="section-content">
-            <p set:html={section.content.replace(/\n/g, '<br />')} />
-          </div>
-        </section>
-      ))}
-
-      <!-- Profile Section -->
-      <section class="about-section">
-        <h2 class="section-title">Profile</h2>
-        <div class="profile-card">
-          <div class="profile-avatar">
-            <img src="/profile.png" alt="Profile" class="avatar-image" />
-          </div>
-          <div class="profile-info">
-            <h3 class="profile-name">{siteMetadata.author.name}</h3>
-            {siteMetadata.author.role && (
-              <p class="profile-role">{siteMetadata.author.role}</p>
+    <!-- Social Links Section -->
+    <section class="about-section">
+      <h2 class="section-title">Connect</h2>
+      <div class="social-links">
+        {siteMetadata.socialLinks.map((link) => (
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="social-link"
+            title={link.name}
+          >
+            {link.name === 'X' ? (
+              <svg viewBox="0 0 24 24" fill="currentColor" class="social-icon">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 24 24" fill="currentColor" class="social-icon">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
             )}
-            {siteMetadata.author.bio && (
-              <p class="profile-bio">{siteMetadata.author.bio}</p>
-            )}
-          </div>
-        </div>
-      </section>
+            <span class="social-name">{link.name}</span>
+          </a>
+        ))}
+      </div>
+    </section>
 
-      <!-- Social Links Section -->
-      <section class="about-section">
-        <h2 class="section-title">Connect</h2>
-        <div class="social-links">
-          {siteMetadata.socialLinks.map((link) => (
-            <a
-              href={link.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="social-link"
-              title={link.name}
-            >
-              {link.name === 'X' ? (
-                <svg viewBox="0 0 24 24" fill="currentColor" class="social-icon">
-                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                </svg>
-              ) : (
-                <svg viewBox="0 0 24 24" fill="currentColor" class="social-icon">
-                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-                </svg>
-              )}
-              <span class="social-name">{link.name}</span>
-            </a>
-          ))}
-        </div>
-      </section>
-
-      <!-- Back to Home -->
-      <nav class="navigation">
-        <a href="/" class="back-link">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M19 12H5"></path>
-            <path d="M12 19l-7-7 7-7"></path>
-          </svg>
-          ホームに戻る
-        </a>
-      </nav>
-    </main>
-  </div>
+    <!-- Back to Home -->
+    <nav class="navigation">
+      <a href="/" class="back-link">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M19 12H5"></path>
+          <path d="M12 19l-7-7 7-7"></path>
+        </svg>
+        ホームに戻る
+      </a>
+    </nav>
+  </main>
 </Layout>
 
 <style>
-  .about-page {
-    min-height: 100vh;
-    background: var(--color-bg);
-  }
-
+  /* Hero: index.astro (トップページ) と同一のトーン・タイポグラフィ */
   .hero-section {
     position: relative;
     overflow: hidden;
@@ -145,25 +139,24 @@ const siteMetadata = getSiteMetadata();
     margin: 0 auto;
   }
 
-  .hero-primary {
-    margin: 0 0 18px;
+  .hero-eyebrow {
+    margin: 0 0 20px;
     color: var(--color-text-muted);
     font-family: var(--font-display);
-    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-size: 0.8rem;
     font-weight: 600;
-    letter-spacing: 0.16em;
-    line-height: 1.25;
+    letter-spacing: 0.22em;
     text-transform: uppercase;
   }
 
-  .hero-secondary {
+  .hero-title {
     margin: 0;
     color: var(--color-text-muted);
     font-family: var(--font-body);
-    font-size: 0.84rem;
-    font-weight: 400;
-    letter-spacing: 0.08em;
-    line-height: 1.6;
+    font-size: clamp(1.25rem, 2.4vw, 1.75rem);
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    line-height: 1.45;
   }
 
   .hero-seed {
@@ -181,7 +174,7 @@ const siteMetadata = getSiteMetadata();
   .content-container {
     max-width: 900px;
     margin: 0 auto;
-    padding: 88px 32px 112px;
+    padding: 52px 40px 112px;
   }
 
   .about-section {
@@ -192,28 +185,30 @@ const siteMetadata = getSiteMetadata();
     margin-bottom: 0;
   }
 
+  /* セクション見出しはヒーローの eyebrow と同じマイクロラベル表現 */
   .section-title {
     font-family: var(--font-display);
-    font-size: 0.78rem;
+    font-size: 0.8rem;
     font-weight: 600;
     color: var(--color-text-muted);
     margin: 0 0 20px;
-    letter-spacing: 0.16em;
+    letter-spacing: 0.22em;
     text-transform: uppercase;
   }
 
-  .section-content {
+  /* カードは PostCard (トップページ) と同一の面・角丸・余白 */
+  .section-content,
+  .profile-card {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: 24px;
-    padding: 40px;
-    box-shadow: var(--shadow-card);
+    padding: 32px;
   }
 
   .section-content p {
-    color: var(--color-text);
-    font-size: 1rem;
-    line-height: 1.8;
+    color: var(--color-text-muted);
+    font-size: 0.93rem;
+    line-height: 1.85;
     margin: 0;
   }
 
@@ -223,10 +218,6 @@ const siteMetadata = getSiteMetadata();
 
   /* Profile Card */
   .profile-card {
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 24px;
-    padding: 40px;
     display: flex;
     gap: 32px;
     align-items: flex-start;
@@ -251,26 +242,33 @@ const siteMetadata = getSiteMetadata();
 
   .profile-name {
     font-family: var(--font-display);
-    font-size: 1.65rem;
+    font-size: clamp(1.2rem, 1.6vw, 1.55rem);
     font-weight: 600;
-    color: var(--color-primary);
-    margin: 0 0 8px 0;
+    color: var(--color-text-heading);
+    letter-spacing: -0.035em;
+    line-height: 1.35;
+    margin: 0 0 12px;
   }
 
+  /* PostCard のカテゴリバッジと同じ表現 */
   .profile-role {
+    display: inline-block;
+    background: var(--color-primary-soft);
+    padding: 5px 12px;
+    border-radius: 999px;
     font-family: var(--font-display);
-    font-size: 0.72rem;
-    color: var(--color-accent);
+    font-size: 0.7rem;
+    color: var(--color-primary);
     font-weight: 700;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    margin: 0 0 16px 0;
+    margin: 0 0 18px;
   }
 
   .profile-bio {
-    color: var(--color-text);
-    font-size: 1rem;
-    line-height: 1.8;
+    color: var(--color-text-muted);
+    font-size: 0.93rem;
+    line-height: 1.85;
     margin: 0;
   }
 
@@ -293,13 +291,14 @@ const siteMetadata = getSiteMetadata();
     color: var(--color-text);
     font-family: var(--font-display);
     font-weight: 600;
-    transition: all 0.2s ease;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease,
+      color 0.25s ease;
   }
 
   .social-link:hover {
-    border-color: var(--color-primary);
-    color: var(--color-primary);
-    transform: translateY(-2px);
+    border-color: var(--color-border-strong);
+    color: var(--color-accent);
+    transform: translateY(-5px);
     box-shadow: var(--shadow-card-strong);
   }
 
@@ -339,13 +338,13 @@ const siteMetadata = getSiteMetadata();
       padding: 50px 20px;
     }
 
-    .hero-primary {
-      margin-bottom: 14px;
-      font-size: 1.35rem;
+    .hero-eyebrow {
+      margin-bottom: 16px;
+      font-size: 0.68rem;
     }
 
-    .hero-secondary {
-      font-size: 0.72rem;
+    .hero-title {
+      font-size: 1.05rem;
     }
 
     .hero-seed {
@@ -355,11 +354,20 @@ const siteMetadata = getSiteMetadata();
     }
 
     .content-container {
-      padding: 60px 20px 80px;
+      padding: 38px 20px 72px;
+    }
+
+    .about-section {
+      margin-bottom: 56px;
+    }
+
+    .section-content,
+    .profile-card {
+      padding: 28px;
+      border-radius: 20px;
     }
 
     .profile-card {
-      padding: 32px 24px;
       flex-direction: column;
       align-items: center;
       text-align: center;


### PR DESCRIPTION
## 概要

Aboutページのデザインをトップページ（`index.astro`）に合わせて統一しました。背景色・ヒーローのフォント/サイズ/配置に加え、カードや本文などのトークンも揃えています。

## 変更内容

### 背景
- `.about-page { min-height: 100vh; background: var(--color-bg); }` ラッパーを削除
  - これが `body` の放射グラデーション（`radial-gradient` × 2）を単色で覆っており、Aboutページだけ背景がフラットになっていた

### ヒーロー（トップページと完全一致）
- 構成順を反転：ラベル（`hero-eyebrow`）→ 見出し（`hero-title`）→ シード画像
- 見出しを `hero-primary`（display系・大文字・600・clamp 1.5〜2rem・字間 0.16em）から、トップと同じ `hero-title`（`var(--font-body)`・500・`clamp(1.25rem, 2.4vw, 1.75rem)`・字間 0.06em・行間 1.45）へ
- ラベルは `hero-eyebrow`（0.8rem / 600 / 字間 0.22em / 大文字）に統一

### その他の統一
- カード（`section-content` / `profile-card`）を PostCard と同じ `padding: 32px` / `border-radius: 24px`（モバイル 28px / 20px）に。Aboutのみ付いていた常時 `box-shadow` を削除
- 本文テキストをカード抜粋と同じ `0.93rem` / `line-height: 1.85` / muted 色に
- プロフィール名を PostCard タイトルと同じ指定に、ロールは記事カテゴリのピルバッジ表現に
- セクション見出しをヒーローのラベルと同じマイクロラベル（0.8rem / 字間 0.22em）に
- ソーシャルリンクのホバーをカードと同じ挙動（-5px リフト＋`--shadow-card-strong`＋`--color-border-strong`）に
- コンテンツ上端余白を 88px → 52px にしてヒーロー下のリズムを合わせる

本文幅は読みやすさを優先して 900px のまま残しています（トップは3カラムのカードグリッドのため 1240px）。

## 検証

- `bun run astro check`: 0 errors / 0 warnings / 0 hints
- モックAPIビルド成功（`tests/build-with-mock.sh`）
- `bun test tests/build-output.test.ts`: 31 pass / 0 fail
- pre-commit フック（vitest 363 tests）: 全パス
- ビルド後CSSを比較し、`hero-section` / `hero-inner` / `hero-eyebrow` / `hero-title` / `hero-seed` の各ルール（モバイル指定含む）がトップページと一致することを確認

### 未実施
ブラウザでの実描画確認（スクリーンショット）は、作業環境に Playwright のブラウザ依存ライブラリ（libglib-2.0 等）が無く実行できませんでした。マージ前に `bun run dev` での目視確認を推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)