### PR TITLE
fix(deploy): Cognito 設定が取得できない場合にローカルデプロイを中断する

### DIFF
--- a/scripts/local-deploy.sh
+++ b/scripts/local-deploy.sh
@@ -881,14 +881,32 @@ build_frontend() {
         local cognito_pool_id
         local cognito_client_id
 
+        # Vite embeds VITE_* at build time. Building without the Cognito config
+        # produces an admin bundle whose Amplify.configure() receives undefined
+        # values, so every login / password-reset fails at runtime with
+        # "AuthUserPoolException: Auth UserPool not configured." — and nothing
+        # in the deploy itself looks broken. So: never build without it.
         if cognito_pool_id=$(fetch_ssm "$ssm_pool_path" false) && \
-           cognito_client_id=$(fetch_ssm "$ssm_client_path" false); then
+           cognito_client_id=$(fetch_ssm "$ssm_client_path" false) && \
+           [[ -n "$cognito_pool_id" && "$cognito_pool_id" != "None" ]] && \
+           [[ -n "$cognito_client_id" && "$cognito_client_id" != "None" ]]; then
             export VITE_COGNITO_USER_POOL_ID="$cognito_pool_id"
             export VITE_COGNITO_USER_POOL_CLIENT_ID="$cognito_client_id"
-            export VITE_API_URL="/api"
+            export VITE_API_URL="${VITE_API_URL:-/api}"
             log_success "Cognito config loaded from SSM"
+        elif [[ -n "${VITE_COGNITO_USER_POOL_ID:-}" && -n "${VITE_COGNITO_USER_POOL_CLIENT_ID:-}" ]]; then
+            export VITE_API_URL="${VITE_API_URL:-/api}"
+            log_warning "Could not fetch Cognito config from SSM; using pre-set environment variables"
         else
-            log_warning "Could not fetch Cognito config, using environment variables"
+            log_error "Admin Site: Cognito config unavailable — aborting before build"
+            log_error "  SSM: $ssm_pool_path"
+            log_error "  SSM: $ssm_client_path"
+            log_error "  Building now would ship an admin site where login and password"
+            log_error "  reset fail with 'Auth UserPool not configured'."
+            log_error "  Fix: refresh AWS credentials ('aws sso login') and retry,"
+            log_error "  or export VITE_COGNITO_USER_POOL_ID / VITE_COGNITO_USER_POOL_CLIENT_ID."
+            FAILED_STEPS+=("Frontend Admin Cognito Config")
+            return 1
         fi
 
         cd "$PROJECT_ROOT/frontend/admin"
@@ -914,6 +932,17 @@ build_frontend() {
         if [[ "$VERBOSE" == true ]]; then
             echo "$build_output"
         fi
+
+        # Verify the User Pool ID actually made it into the bundle. Guards
+        # against future regressions in how the config reaches the build.
+        if ! grep -rqF "$VITE_COGNITO_USER_POOL_ID" dist/assets 2>/dev/null; then
+            log_error "Admin Site: built bundle does not contain the Cognito User Pool ID"
+            log_error "  Expected to find: $VITE_COGNITO_USER_POOL_ID"
+            log_error "  Deploying this build would break login and password reset."
+            FAILED_STEPS+=("Frontend Admin Build Verification")
+            return 1
+        fi
+        log_verbose "Cognito config embedded in bundle: verified"
 
         local admin_size
         admin_size=$(du -sh dist 2>/dev/null | cut -f1)


### PR DESCRIPTION
## 背景

dev 環境の管理画面で、ログインとパスワードリセットが以下のエラーで失敗していました。

```
Amplify has not been configured. Please call Amplify.configure() before using this service.
AuthUserPoolException: Auth UserPool not configured.
```

原因は認証情報ではなく、**配信されている管理画面のバンドルに Cognito 設定が埋め込まれていない**ことでした。

`frontend/admin/src/config/amplify.ts` は `import.meta.env.VITE_COGNITO_USER_POOL_ID` / `VITE_COGNITO_USER_POOL_CLIENT_ID` を参照します。Vite はこれらを**ビルド時**に埋め込むため、未設定のままビルドすると `Amplify.configure()` に `undefined` が渡り、実行時に上記エラーで全ての認証が失敗します。

`scripts/local-deploy.sh` は SSM から設定を取得できなかったとき、**警告を出すだけでビルドを継続**していました。そのため AWS 認証が切れた状態でローカルデプロイすると、壊れたバンドルがそのまま配信されます。デプロイ自体は成功して見えるため気付けません。

なお GitHub Actions（`deploy.yml:551-555`）は SSM 取得に失敗するとステップごと落ちるため、CI 経由のデプロイではこの状態になりません。

## 変更内容

### 1. Cognito 設定が無いままビルドしない

従来の「警告して続行」を3分岐に変更しました。

| 状況 | 挙動 |
|---|---|
| SSM から取得成功（空・`None` でない） | そのまま使用 |
| SSM 失敗だが `VITE_COGNITO_*` が事前に export 済み | 警告して環境変数を使用（従来メッセージの本来の意図） |
| どちらも無い | **エラーで中断**（`FAILED_STEPS` に記録して `return 1`） |

中断時は原因と対処（`aws sso login` する、または `VITE_COGNITO_*` を export する）をエラーメッセージに表示します。SSM が空文字や `None` を返すケースも無効として弾きます。

### 2. ビルド成果物の検証

ビルド後に `dist/assets` へ User Pool ID が実際に埋め込まれたかを確認し、未埋め込みならデプロイ前に中断します。設定の受け渡し経路が将来変わっても、壊れたバンドルが S3 に上がらない歯止めになります。

## 検証

- `bash -n scripts/local-deploy.sh`: 構文エラーなし（CI に shellcheck の設定は無いため未実行）
- **正常系**: 実際の SSM 値（`/serverless-blog/dev/cognito/*`）を渡して `frontend/admin` をビルド → バンドル内に User Pool ID を検出し、検証を通過
- **異常系**: 環境変数なしでビルド → 検出されず、追加した検証が中断させることを確認

## 補足

このスクリプト修正だけでは dev 環境は復旧しません。SSM のパラメータは正常に存在することを確認済みなので、**管理画面を再ビルド・再デプロイすれば解消します**（修正後のスクリプト、または CI の dev デプロイ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)