### PR TITLE
security(go): bump Go to 1.25.12 and suppress CKV2_AWS_23 false positive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ permissions:
   id-token: write # Required for AWS OIDC authentication
 
 env:
-  GO_VERSION: '1.25.9'
+  GO_VERSION: '1.25.12'
   TERRAFORM_VERSION: '1.14.0'
   AWS_REGION: 'ap-northeast-1'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ permissions:
 
 env:
   TERRAFORM_VERSION: '1.14.0'
-  GO_VERSION: '1.25.9'
+  GO_VERSION: '1.25.12'
   BUN_VERSION: '1.2.0'
   AWS_REGION: 'ap-northeast-1'
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -127,7 +127,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.12'
           check-latest: true
           cache-dependency-path: go-functions/go.sum
 

--- a/go-functions/go.mod
+++ b/go-functions/go.mod
@@ -1,6 +1,6 @@
 module serverless-blog/go-functions
 
-go 1.25.9
+go 1.25.12
 
 require (
 	github.com/aws/aws-lambda-go v1.54.0

--- a/terraform/.checkov.yaml
+++ b/terraform/.checkov.yaml
@@ -304,6 +304,26 @@ skip-check:
   # Mitigation: CloudTrail for audit trail; metrics for long-term trends
   - CKV_AWS_338
 
+  # --------------------------------------
+  # Route53 Rules
+  # --------------------------------------
+
+  # CKV2_AWS_23: Route53 A Record has Attached Resource
+  # Justification: False positive on a resource that is never instantiated.
+  # The check FAILS only for module.dns_route53[0].aws_route53_record.apex
+  # (modules/dns-route53/main.tf:23-35), whose alias target is the variable
+  # cloudfront_domain_name. dev passes "" for that variable to break the
+  # CDN <-> Route53 dependency cycle, so its `count` evaluates to 0 and the
+  # record is never created; prd declares no Route53 records at all. Checkov
+  # evaluates the module statically and cannot resolve the variable, so it
+  # reports the uninstantiated resource as dangling.
+  # The record that is actually created, aws_route53_record.cloudfront_apex in
+  # environments/dev/main.tf, PASSES this check because its alias target
+  # (module.cdn.distribution_domain_name) is resolvable.
+  # Mitigation: terraform plan resolves the alias targets; a genuinely dangling
+  # record would fail apply.
+  - CKV2_AWS_23
+
 # ======================================
 # External Check Configuration
 # ======================================


### PR DESCRIPTION
## 概要

CI に出ていた Annotations 2種類に対応します。

## 1. govulncheck の指摘10件 — Go 標準ライブラリの脆弱性

「Go Lint (golangci-lint)」というジョブ名で表示されていましたが、実際の出力元は同ジョブ内の別ステップ [`Go vulnerability check`](.github/workflows/ci.yml#L211)（`govulncheck`）です。`continue-on-error: true` のためジョブは成功扱いですが、failure レベルの Annotation が残っていました。

`A calls B, which eventually calls C` は govulncheck の *Example traces found*（脆弱な関数への到達経路）で、**アプリコードではなく Go 標準ライブラリ**が対象です。Go 1.25.9 が影響を受けるのは以下3件でした（`govulncheck` をローカル実行し、Go 脆弱性 DB で 1.25 系の修正版を確認）。

| ID | 内容 | 1.25系 fixed |
| --- | --- | --- |
| GO-2026-5856 / CVE-2026-42505 | crypto/tls: Encrypted Client Hello のプライバシー漏洩 | 1.25.12 |
| GO-2026-5039 / CVE-2026-42507 | net/textproto: 入力が未エスケープでエラーに混入 | 1.25.11 |
| GO-2026-5037 / CVE-2026-27145 | crypto/x509: ホスト名解析の非効率 | 1.25.11 |

3件すべてを満たす **1.25.12** へ、`GO_VERSION`（`ci.yml` / `deploy.yml` / `security-scan.yml`）と `go.mod` の `go` ディレクティブを更新します。**コード変更は不要**です。

`fmt.Fprintf が x509.Certificate.Verify を呼ぶ` といった不可解なトレースや、パスが `.github:496` になっている点は、govulncheck のコールグラフの粗さと Annotation 変換時の誤マッピングによるもので、判断には影響しません。

## 2. Checkov CKV2_AWS_23 — 誤検知

CI ログを確認したところ、**失敗しているのは1リソースのみ**でした。

```
CKV2_AWS_23  PASSED  aws_route53_record.cloudfront_apex[0]            environments/dev/main.tf:418-432
CKV2_AWS_23  FAILED  module.dns_route53[0].aws_route53_record.apex    modules/dns-route53/main.tf:23-35
```

失敗している方は alias 先が変数 `cloudfront_domain_name` です。dev は CDN ↔ Route53 の依存サイクル回避のため [この変数に `""` を渡している](terraform/environments/dev/main.tf#L378)ため `count = 0` となり、**実際には生成されないリソース**です。prd は Route53 レコードを一切持ちません。実際に生成される `aws_route53_record.cloudfront_apex` は alias 先がモジュール出力で解決可能なため PASSED しています。

よって誤検知と判断し、理由と代替策を併記する既存の書式で `.checkov.yaml` の `skip-check` に追加します。

## 検証

- `bun run verify` → exit 0（lint / format:check / typecheck / vitest 923件 / go test 30パッケージ）
- `go build ./...` / `go mod verify` → 成功
- `terraform fmt -check -recursive` → 成功
- `checkov -d terraform --config-file terraform/.checkov.yaml` → `Failed checks: 0`、設定のパースエラーなし

## レビュー時の注意

- ローカルの checkov 3.2.520 は CKV2_AWS_23 をそもそも評価しないため（変更前の設定でも Failed 0）、**抑制が効いていることのローカル再現はできていません**。CI の Checkov ジョブで Annotation が消えることが最終確認になります。設定自体がパースされ全体が Failed 0 であることまでは確認済みです。
- `scripts/local-deploy.sh` の `EXPECTED_GO_VERSION="1.25"` はマイナー単位の比較のため変更していません。

## 補足（本 PR では未対応）

`modules/dns-route53` の `apex` / `apex_ipv6` レコードは、dev がサイクル回避のため環境側に同等のレコードを持つ結果、どの環境でも `count = 0` の実質デッドコードになっています。整理する場合は別 Issue が適切と考えます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
