### PR TITLE
refactor(terraform): remove never-instantiated apex records from dns-route53

### DIFF
--- a/terraform/.checkov.yaml
+++ b/terraform/.checkov.yaml
@@ -304,25 +304,10 @@ skip-check:
   # Mitigation: CloudTrail for audit trail; metrics for long-term trends
   - CKV_AWS_338
 
-  # --------------------------------------
-  # Route53 Rules
-  # --------------------------------------
-
-  # CKV2_AWS_23: Route53 A Record has Attached Resource
-  # Justification: False positive on a resource that is never instantiated.
-  # The check FAILS only for module.dns_route53[0].aws_route53_record.apex
-  # (modules/dns-route53/main.tf:23-35), whose alias target is the variable
-  # cloudfront_domain_name. dev passes "" for that variable to break the
-  # CDN <-> Route53 dependency cycle, so its `count` evaluates to 0 and the
-  # record is never created; prd declares no Route53 records at all. Checkov
-  # evaluates the module statically and cannot resolve the variable, so it
-  # reports the uninstantiated resource as dangling.
-  # The record that is actually created, aws_route53_record.cloudfront_apex in
-  # environments/dev/main.tf, PASSES this check because its alias target
-  # (module.cdn.distribution_domain_name) is resolvable.
-  # Mitigation: terraform plan resolves the alias targets; a genuinely dangling
-  # record would fail apply.
-  - CKV2_AWS_23
+  # Note: CKV2_AWS_23 (Route53 A Record has Attached Resource) was skipped here
+  # while modules/dns-route53 declared apex records that no environment ever
+  # instantiated. Those records have been removed, the check passes on its own,
+  # and the skip is no longer needed.
 
 # ======================================
 # External Check Configuration

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -367,17 +367,18 @@ module "acm" {
 }
 
 # Route53 Hosted Zone for dev subdomain
-# Note: cloudfront_domain_name is NOT passed here to avoid circular dependency
-# The A/AAAA records pointing to CloudFront are created separately below
+# The module owns the hosted zone and the ACM validation records only.
+# The A/AAAA records pointing to CloudFront are created separately below,
+# because declaring them inside the module would close a dependency cycle
+# (CDN -> ACM -> validation records -> zone -> alias -> CDN).
 module "dns_route53" {
   source = "../../modules/dns-route53"
 
   count = var.enable_custom_domain ? 1 : 0
 
-  zone_name              = var.domain_name # dev.boneofmyfallacy.net
-  cloudfront_domain_name = ""              # Created separately after CDN to avoid cycle
-  environment            = var.environment
-  project_name           = var.project_name
+  zone_name    = var.domain_name # dev.boneofmyfallacy.net
+  environment  = var.environment
+  project_name = var.project_name
 
   # ACM validation records
   acm_domain_validation_options = var.enable_custom_domain ? module.acm[0].domain_validation_options : []

--- a/terraform/modules/dns-route53/main.tf
+++ b/terraform/modules/dns-route53/main.tf
@@ -19,35 +19,13 @@ resource "aws_route53_zone" "subdomain" {
   )
 }
 
-# Apex record (A alias) → CloudFront
-resource "aws_route53_record" "apex" {
-  count = var.cloudfront_domain_name != "" ? 1 : 0
-
-  zone_id = aws_route53_zone.subdomain.zone_id
-  name    = var.zone_name
-  type    = "A"
-
-  alias {
-    name                   = var.cloudfront_domain_name
-    zone_id                = var.cloudfront_hosted_zone_id
-    evaluate_target_health = false
-  }
-}
-
-# IPv6 apex record (AAAA alias) → CloudFront
-resource "aws_route53_record" "apex_ipv6" {
-  count = var.cloudfront_domain_name != "" && var.create_ipv6_records ? 1 : 0
-
-  zone_id = aws_route53_zone.subdomain.zone_id
-  name    = var.zone_name
-  type    = "AAAA"
-
-  alias {
-    name                   = var.cloudfront_domain_name
-    zone_id                = var.cloudfront_hosted_zone_id
-    evaluate_target_health = false
-  }
-}
+# Apex A/AAAA alias records are NOT defined here.
+#
+# Pointing them at CloudFront from inside this module creates a dependency
+# cycle: the CDN needs the ACM certificate, the certificate needs the
+# validation records in this zone, and the alias would need the CDN. Each
+# environment therefore declares its apex records next to the CDN instead —
+# see aws_route53_record.cloudfront_apex in environments/dev/main.tf.
 
 # ACM certificate DNS validation records
 resource "aws_route53_record" "acm_validation" {

--- a/terraform/modules/dns-route53/outputs.tf
+++ b/terraform/modules/dns-route53/outputs.tf
@@ -13,11 +13,6 @@ output "name_servers" {
   description = "Route53 nameservers for NS delegation in Cloudflare"
 }
 
-output "apex_record_fqdn" {
-  value       = var.cloudfront_domain_name != "" ? aws_route53_record.apex[0].fqdn : null
-  description = "FQDN of the apex domain record"
-}
-
 output "acm_validation_record_fqdns" {
   value       = [for record in aws_route53_record.acm_validation : record.fqdn]
   description = "FQDNs of ACM validation records (for aws_acm_certificate_validation)"

--- a/terraform/modules/dns-route53/variables.tf
+++ b/terraform/modules/dns-route53/variables.tf
@@ -3,18 +3,6 @@ variable "zone_name" {
   description = "Route53 hosted zone name (e.g., dev.boneofmyfallacy.net)"
 }
 
-variable "cloudfront_domain_name" {
-  type        = string
-  default     = ""
-  description = "CloudFront distribution domain name (e.g., d1234567890.cloudfront.net)"
-}
-
-variable "cloudfront_hosted_zone_id" {
-  type        = string
-  default     = "Z2FDTNDATAQYW2"
-  description = "CloudFront hosted zone ID (always Z2FDTNDATAQYW2 for CloudFront)"
-}
-
 variable "environment" {
   type        = string
   description = "Environment identifier (dev, prd)"
@@ -29,12 +17,6 @@ variable "project_name" {
   type        = string
   default     = "serverless-blog"
   description = "Project name for resource naming and tagging"
-}
-
-variable "create_ipv6_records" {
-  type        = bool
-  default     = true
-  description = "Whether to create AAAA (IPv6) alias records"
 }
 
 variable "acm_domain_validation_options" {


### PR DESCRIPTION
## 背景

#460 で Checkov `CKV2_AWS_23` を誤検知として抑制しましたが、その調査で `modules/dns-route53` の apex レコードが**どの環境でも生成されないデッドコード**であることが判明しました。本 PR で原因そのものを取り除き、あわせて #460 で入れた抑制を撤回します。

## デッドコードである根拠

| 確認項目 | 結果 |
| --- | --- |
| `modules/dns-route53` の利用箇所 | `environments/dev/main.tf` のみ |
| dev が渡す `cloudfront_domain_name` | `""`（CDN ↔ Route53 のサイクル回避のため）→ `count = 0` |
| prd | `dns-cloudflare` を使用。`dns-route53` を参照していない |
| 出力 `apex_record_fqdn` | モジュール外から参照ゼロ |
| `.tftest.hcl` からの参照 | なし |

実際の apex レコードは `aws_route53_record.cloudfront_apex`（CDN の隣で宣言）が担っており、こちらは `CKV2_AWS_23` を PASSED しています。

## 変更内容

- `aws_route53_record.apex` / `apex_ipv6` を削除
- `output "apex_record_fqdn"` を削除
- 上記削除により未使用となる変数 `cloudfront_domain_name` / `cloudfront_hosted_zone_id` / `create_ipv6_records` を削除
- `environments/dev/main.tf` のモジュール呼び出しから `cloudfront_domain_name = ""` を削除
- `.checkov.yaml` の `CKV2_AWS_23` skip-check を撤回（レコードが無くなりチェックが素通りするため）

「サイクル回避のため意図的にモジュール外へ置いている」設計意図は、モジュール側と呼び出し側の双方にコメントとして残しています。

## 検証

| 項目 | 結果 |
| --- | --- |
| `terraform fmt -check -recursive` | ✅ |
| `terraform validate`（dev / prd 両方） | ✅ Success |
| `terraform test` | ✅ 19 passed, 0 failed |
| `checkov -d terraform --config-file terraform/.checkov.yaml` | ✅ Failed checks: 0、`CKV2_AWS_23` の FAILED 0件 |

## レビュー時の注意

- **state への影響はない想定です。** 削除対象は `count = 0` で state に存在しないためです。ただし最終確認は CI の `Terraform Plan (DEV)` で行ってください。**plan に destroy が現れないこと**が期待値です。
- `.terraform.lock.hcl` にローカル検証で darwin_arm64 のハッシュが付きましたが、本 PR には**含めていません**（CI は linux のため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
