### PR TITLE
fix(go): Makefile に posts/get_by_slug を追加しローカルビルドと Terraform の乖離を解消

### DIFF
--- a/go-functions/Makefile
+++ b/go-functions/Makefile
@@ -17,10 +17,15 @@ BIN_DIR := bin
 CMD_DIR := cmd
 
 # All Lambda functions (domain/function format)
+# Must stay in sync with the build matrices in .github/workflows/{ci,deploy}.yml
+# and the archive_file sources in terraform/modules/lambda/main.tf.
+# Intentionally excluded: categories/seed (one-off seeding tool, not deployed),
+# scripts/backfill_post_slugs (CLI, see backfill-slugs target).
 FUNCTIONS := \
 	posts/create \
 	posts/get \
 	posts/get_public \
+	posts/get_by_slug \
 	posts/list \
 	posts/update \
 	posts/delete \


### PR DESCRIPTION
## 概要

`go-functions/Makefile` の `FUNCTIONS` に `posts/get_by_slug` が欠けており、ローカルで `make build && terraform apply` すると Terraform が要求する `bin/posts-get_by_slug/bootstrap` が存在せず失敗していた。CI マトリクス(18関数)と一致するよう追加する。

Closes #465

## 変更内容

- `FUNCTIONS` に `posts/get_by_slug` を追加(18関数に)
- CI マトリクス・Terraform と同期が必要である旨、および意図的な除外対象(`categories/seed`, `scripts/backfill_post_slugs`)をコメントで明記

## 検証

- `make build` で 18 関数すべてビルドされ、`bin/posts-get_by_slug/bootstrap` が生成されることを確認済み

## 備考

`cmd/categories/seed`(未デプロイ・認証チェックなし)の削除はレガシー撤去フェーズの別 Issue で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)