### PR TITLE
fix(public-astro): robots.txt エンドポイントを追加

### DIFF
--- a/frontend/public-astro/src/pages/__tests__/robots.test.ts
+++ b/frontend/public-astro/src/pages/__tests__/robots.test.ts
@@ -1,0 +1,45 @@
+/**
+ * robots.txt エンドポイントのユニットテスト
+ */
+import { describe, it, expect } from 'vitest';
+import type { APIContext } from 'astro';
+import { GET } from '../robots.txt';
+
+function createContext(site: string | undefined): APIContext {
+  return {
+    site: site ? new URL(site) : undefined,
+  } as APIContext;
+}
+
+describe('robots.txt endpoint', () => {
+  it('text/plain で全クローラー許可のルールを返す', async () => {
+    const response = GET(createContext('https://blog.example.jp'));
+
+    expect(response.headers.get('Content-Type')).toBe(
+      'text/plain; charset=utf-8'
+    );
+
+    const body = await response.text();
+    expect(body).toContain('User-agent: *');
+    expect(body).toContain('Allow: /');
+  });
+
+  it('Sitemap は site 設定ベースの sitemap-index.xml を指す', async () => {
+    const response = GET(createContext('https://blog.example.jp'));
+    const body = await response.text();
+
+    expect(body).toContain(
+      'Sitemap: https://blog.example.jp/sitemap-index.xml'
+    );
+  });
+
+  it('site 末尾のスラッシュを二重にしない', async () => {
+    const response = GET(createContext('https://blog.example.jp/'));
+    const body = await response.text();
+
+    expect(body).toContain(
+      'Sitemap: https://blog.example.jp/sitemap-index.xml'
+    );
+    expect(body).not.toContain('//sitemap-index.xml');
+  });
+});

--- a/frontend/public-astro/src/pages/robots.txt.ts
+++ b/frontend/public-astro/src/pages/robots.txt.ts
@@ -1,0 +1,29 @@
+/**
+ * robots.txt エンドポイント
+ *
+ * ビルド時に呼び出され、dist/robots.txt として生成される。
+ * Sitemap の URL は astro.config.mjs の site (= SITE_URL) から動的に組み立てる。
+ * sitemap-index.xml は @astrojs/sitemap インテグレーションの出力名。
+ */
+import type { APIContext } from 'astro';
+
+export function GET(context: APIContext) {
+  const siteUrl = (context.site?.toString() ?? 'https://example.com').replace(
+    /\/$/,
+    ''
+  );
+
+  const body = [
+    'User-agent: *',
+    'Allow: /',
+    '',
+    `Sitemap: ${siteUrl}/sitemap-index.xml`,
+    '',
+  ].join('\n');
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}


### PR DESCRIPTION
## 概要

公開サイトに robots.txt が存在しなかった(CodeBuild の S3 sync は `--include \"robots.txt\"` 済みで配置する意図はあった)。ドメインをハードコードしないよう Astro エンドポイントとして実装し、Sitemap 行は `astro.config.mjs` の `site`(= SITE_URL)から動的に生成する。

Closes #467

## 変更内容

- `src/pages/robots.txt.ts` 新規作成 — 全クローラー許可 + `Sitemap: <site>/sitemap-index.xml`(@astrojs/sitemap の出力名)
- ユニットテスト 3 件追加(`src/pages/__tests__/robots.test.ts`)

## 検証

- vitest 全 370 件パス(pre-commit で実行)
- `astro check` クリーン

## 備考

本番の Sitemap URL が正しいドメインになるには #463(SITE_URL 未設定)の修正が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)