### PR TITLE
fix(public-astro): 全デプロイ経路に SITE_URL を配線し example.com フォールバックを撲滅

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -758,6 +758,15 @@ jobs:
         with:
           working-directory: frontend/public-astro
 
+      - name: Set site URL
+        id: site
+        run: |
+          if [ "${{ needs.detect-changes.outputs.target-env }}" == "prd" ]; then
+            echo "url=https://boneofmyfallacy.net" >> $GITHUB_OUTPUT
+          else
+            echo "url=https://dev.boneofmyfallacy.net" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build Astro project
         working-directory: frontend/public-astro
         # Requirement 9.10: API_URL as environment variable
@@ -777,6 +786,7 @@ jobs:
           NODE_ENV: production
           PUBLIC_API_URL: ${{ steps.api.outputs.api_url }}
           API_URL: ${{ steps.api.outputs.api_url }}
+          SITE_URL: ${{ steps.site.outputs.url }}
 
       - name: Validate build output
         working-directory: frontend/public-astro

--- a/frontend/public-astro/astro.config.mjs
+++ b/frontend/public-astro/astro.config.mjs
@@ -3,6 +3,19 @@ import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 
+// Deploy builds (CodeBuild / GitHub Actions) must set SITE_URL explicitly:
+// the https://example.com fallback would ship broken sitemap / canonical /
+// OGP / RSS URLs to production (Issue #463). Local dev keeps the fallback.
+const isDeployBuild =
+  !!process.env.CODEBUILD_BUILD_ID || process.env.GITHUB_ACTIONS === 'true';
+if (!process.env.SITE_URL && isDeployBuild) {
+  throw new Error(
+    'SITE_URL is not set. Deploy builds must provide the canonical site URL ' +
+      '(e.g. https://boneofmyfallacy.net) or every sitemap/canonical/RSS URL ' +
+      'will point at https://example.com.'
+  );
+}
+
 // https://astro.build/config
 export default defineConfig({
   // SSG (Static Site Generation) mode - generates static HTML files

--- a/frontend/public-astro/tests/rss.test.ts
+++ b/frontend/public-astro/tests/rss.test.ts
@@ -21,7 +21,8 @@ import { stripHtml } from '../src/lib/postUtils';
 
 const projectDir = join(import.meta.dirname, '..');
 const distDir = join(projectDir, 'dist');
-const SITE_URL = 'https://example.com';
+// ビルド時の SITE_URL と同じ値で検証する（build-with-mock.sh のデフォルトは example.com）
+const SITE_URL = process.env.SITE_URL ?? 'https://example.com';
 
 /**
  * RSSフィードからアイテム要素を抽出

--- a/frontend/public-astro/tests/seo-integration.test.ts
+++ b/frontend/public-astro/tests/seo-integration.test.ts
@@ -18,7 +18,8 @@ import { join } from 'path';
 import { mockPosts } from './mock-api-server';
 
 const distDir = join(import.meta.dirname, '../dist');
-const SITE_URL = 'https://example.com';
+// ビルド時の SITE_URL と同じ値で検証する（build-with-mock.sh のデフォルトは example.com）
+const SITE_URL = process.env.SITE_URL ?? 'https://example.com';
 const SITE_NAME = 'bone of my fallacy';
 
 /**

--- a/frontend/public-astro/tests/sitemap.test.ts
+++ b/frontend/public-astro/tests/sitemap.test.ts
@@ -20,7 +20,8 @@ import { extractLocUrls, extractSitemapUrls } from '../src/lib/sitemapUtils';
 
 const projectDir = join(import.meta.dirname, '..');
 const distDir = join(projectDir, 'dist');
-const SITE_URL = 'https://example.com';
+// ビルド時の SITE_URL と同じ値で検証する（build-with-mock.sh のデフォルトは example.com）
+const SITE_URL = process.env.SITE_URL ?? 'https://example.com';
 
 describe('Sitemap Generation (Task 3.3)', () => {
   beforeAll(() => {

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -331,6 +331,7 @@ module "codebuild" {
   public_site_bucket_arn     = module.storage.public_site_bucket_arn
   cloudfront_distribution_id = module.cdn.distribution_id
   api_url                    = module.cdn.api_base_url
+  site_url                   = var.enable_custom_domain ? "https://${var.domain_name}" : "https://${module.cdn.distribution_domain_name}"
 
   # GitHub source configuration for Astro SSG builds
   github_repo   = "https://github.com/okshin-yk-private/serverlessBlog.git"

--- a/terraform/modules/codebuild/main.tf
+++ b/terraform/modules/codebuild/main.tf
@@ -39,6 +39,7 @@ version: 0.2
 env:
   variables:
     API_URL: "${var.api_url}"
+    SITE_URL: "${var.site_url}"
     DEPLOYMENT_BUCKET: "${var.public_site_bucket_name}"
     CLOUDFRONT_DISTRIBUTION_ID: "${var.cloudfront_distribution_id}"
   shell: bash

--- a/terraform/modules/codebuild/tests/codebuild.tftest.hcl
+++ b/terraform/modules/codebuild/tests/codebuild.tftest.hcl
@@ -5,6 +5,11 @@
 # Mock provider for testing without AWS credentials
 mock_provider "aws" {}
 
+# File-level variables shared by every run block (run-level variables merge on top)
+variables {
+  site_url = "https://dev.example.test"
+}
+
 # =============================================================================
 # Test Group 1: CodeBuild Project Creation
 # =============================================================================
@@ -92,6 +97,7 @@ run "codebuild_timeout" {
 # =============================================================================
 
 # Test 5: Verify API_URL environment variable is set
+# (renamed from PUBLIC_API_URL in #113; the assert lagged behind)
 run "codebuild_env_api_url" {
   command = plan
 
@@ -107,9 +113,9 @@ run "codebuild_env_api_url" {
   assert {
     condition = anytrue([
       for env_var in aws_codebuild_project.astro_build.environment[0].environment_variable :
-      env_var.name == "PUBLIC_API_URL" && env_var.value == "https://example.cloudfront.net/api"
+      env_var.name == "API_URL" && env_var.value == "https://example.cloudfront.net/api"
     ])
-    error_message = "CodeBuild must have PUBLIC_API_URL environment variable set"
+    error_message = "CodeBuild must have API_URL environment variable set"
   }
 }
 
@@ -467,5 +473,27 @@ run "buildspec_configured" {
   assert {
     condition     = aws_codebuild_project.astro_build.source[0].buildspec != null && aws_codebuild_project.astro_build.source[0].buildspec != ""
     error_message = "CodeBuild must have buildspec configured"
+  }
+}
+
+# Test 22: Verify SITE_URL is passed into the buildspec
+# Without it the Astro build falls back to https://example.com for
+# sitemap / canonical / OGP / RSS URLs (Issue #463)
+run "buildspec_contains_site_url" {
+  command = plan
+
+  variables {
+    project_name               = "serverless-blog"
+    environment                = "dev"
+    public_site_bucket_name    = "serverless-blog-public-site-dev-123456789012"
+    public_site_bucket_arn     = "arn:aws:s3:::serverless-blog-public-site-dev-123456789012"
+    cloudfront_distribution_id = "E1234567890ABC"
+    api_url                    = "https://example.cloudfront.net/api"
+    site_url                   = "https://blog.example.test"
+  }
+
+  assert {
+    condition     = strcontains(aws_codebuild_project.astro_build.source[0].buildspec, "SITE_URL: \"https://blog.example.test\"")
+    error_message = "BuildSpec must export SITE_URL to the Astro build"
   }
 }

--- a/terraform/modules/codebuild/variables.tf
+++ b/terraform/modules/codebuild/variables.tf
@@ -36,6 +36,15 @@ variable "api_url" {
   description = "API URL for Astro build (PUBLIC_API_URL environment variable)"
 }
 
+variable "site_url" {
+  type        = string
+  description = "Canonical site URL for the Astro build (SITE_URL environment variable). Drives sitemap, canonical links, OGP and RSS URLs — without it the build falls back to https://example.com."
+  validation {
+    condition     = can(regex("^https://", var.site_url))
+    error_message = "site_url must be an https:// URL"
+  }
+}
+
 variable "build_timeout" {
   type        = number
   description = "Build timeout in minutes"


### PR DESCRIPTION
## 概要

どのデプロイ経路も `SITE_URL` を設定しておらず、本番の sitemap・canonical・`og:url`・RSS の `<link>`/`<guid>` がすべてフォールバックの `https://example.com` を指していた。全経路に配線し、デプロイビルドではフォールバック発動を fail にする。

Closes #463

## 変更内容

- **CodeBuild モジュール**: 必須変数 `site_url`(https:// バリデーション付き)を新設し buildspec に `SITE_URL` を追加。dev 環境はカスタムドメイン(無効時は CloudFront ドメイン)を渡す
- **deploy.yml `build-astro`**: 環境別に `SITE_URL` を設定(dev: `https://dev.boneofmyfallacy.net` / prd: `https://boneofmyfallacy.net`。既存 admin ビルドと同じパターン)
- **astro.config.mjs**: CodeBuild / GitHub Actions 上で `SITE_URL` 未設定ならビルドを即失敗させるガードを追加(ローカル開発はフォールバック維持)
- **統合テスト**: `example.com` ハードコードを `process.env.SITE_URL` ベースに変更(これがバグを検知できなかった原因)
- **既存 tftest の修復**: #113 の `PUBLIC_API_URL`→`API_URL` リネームに追随していなかった `codebuild_env_api_url` を修正(モジュールテストがどこでも実行されていなかったため放置されていた)

## 検証

- `terraform test`(codebuild モジュール): 22 件全パス
- `terraform validate`(environments/dev): OK
- ガード動作確認: `GITHUB_ACTIONS=true` で SITE_URL なし → ビルド即失敗 / あり → 成功
- `build-with-mock.sh` + 統合テスト 146 件: デフォルト(example.com)と独自ドメイン(`SITE_URL=https://smoke.example.jp`)の両方でパス
- vitest ユニット 367 件 + `astro check` クリーン

## 備考

- prd は CodeBuild モジュール未使用(deploy.yml 経由のみ)のため Terraform 変更は dev のみ
- prd デプロイ後の canonical ドメイン恒久チェックは P1 の post-deploy スモークテスト Issue で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)