### PR TITLE
fix(admin): 共通 API クライアントでセッション失効(401)をハンドリング

### DIFF
--- a/frontend/admin/src/api/categories.test.ts
+++ b/frontend/admin/src/api/categories.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import axios from 'axios';
-import * as authUtils from '../utils/auth';
+import { apiClient } from './client';
 import {
   fetchCategories,
   createCategory,
@@ -13,16 +12,24 @@ import {
   UpdateSortOrderRequest,
 } from './categories';
 
-vi.mock('axios');
-vi.mock('../utils/auth');
+// 認証ヘッダーの付与・401リフレッシュは client.ts のインターセプタに集約されている
+// （client.test.ts で検証）。ここではエンドポイント呼び出しとエラー変換を検証する。
+vi.mock('./client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+  AUTH_SESSION_EXPIRED_EVENT: 'auth:session-expired',
+}));
 
-const mockedAxios = vi.mocked(axios, true);
-const mockedGetAuthToken = vi.mocked(authUtils.getAuthToken);
+const mockedClient = vi.mocked(apiClient, true);
 
 describe('categories API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockedGetAuthToken.mockReturnValue('test-auth-token');
   });
 
   afterEach(() => {
@@ -50,16 +57,16 @@ describe('categories API', () => {
           sortOrder: 2,
         },
       ];
-      mockedAxios.get.mockResolvedValue({ data: mockCategories });
+      mockedClient.get.mockResolvedValue({ data: mockCategories });
 
       const result = await fetchCategories();
 
-      expect(mockedAxios.get).toHaveBeenCalledWith('/categories');
+      expect(mockedClient.get).toHaveBeenCalledWith('/categories');
       expect(result).toEqual(mockCategories);
     });
 
     it('カテゴリが存在しない場合は空配列を返す', async () => {
-      mockedAxios.get.mockResolvedValue({ data: [] });
+      mockedClient.get.mockResolvedValue({ data: [] });
 
       const result = await fetchCategories();
 
@@ -73,7 +80,7 @@ describe('categories API', () => {
           data: { message: 'Internal Server Error' },
         },
       };
-      mockedAxios.get.mockRejectedValue(error);
+      mockedClient.get.mockRejectedValue(error);
 
       await expect(fetchCategories()).rejects.toMatchObject({
         message: 'Internal Server Error',
@@ -82,7 +89,7 @@ describe('categories API', () => {
     });
 
     it('ネットワークエラー時はエラーをスローする', async () => {
-      mockedAxios.get.mockRejectedValue(new Error('Network Error'));
+      mockedClient.get.mockRejectedValue(new Error('Network Error'));
 
       await expect(fetchCategories()).rejects.toMatchObject({
         message: 'ネットワークエラーが発生しました。接続を確認してください。',
@@ -103,38 +110,15 @@ describe('categories API', () => {
         ...createRequest,
         id: 'new-id',
       };
-      mockedAxios.post.mockResolvedValue({ data: createdCategory });
+      mockedClient.post.mockResolvedValue({ data: createdCategory });
 
       const result = await createCategory(createRequest);
 
-      expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect(mockedClient.post).toHaveBeenCalledWith(
         '/admin/categories',
-        createRequest,
-        {
-          headers: {
-            Authorization: 'Bearer test-auth-token',
-            'Content-Type': 'application/json',
-          },
-        }
+        createRequest
       );
       expect(result).toEqual(createdCategory);
-    });
-
-    it('認証トークンを含めてリクエストする', async () => {
-      mockedGetAuthToken.mockReturnValue('another-token');
-      mockedAxios.post.mockResolvedValue({ data: mockCategory });
-
-      await createCategory(createRequest);
-
-      expect(mockedAxios.post).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(Object),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'Bearer another-token',
-          }),
-        })
-      );
     });
 
     it('400エラー（バリデーションエラー）時はエラーをスローする', async () => {
@@ -144,7 +128,7 @@ describe('categories API', () => {
           data: { message: 'nameは必須です' },
         },
       };
-      mockedAxios.post.mockRejectedValue(error);
+      mockedClient.post.mockRejectedValue(error);
 
       await expect(createCategory(createRequest)).rejects.toMatchObject({
         message: 'nameは必須です',
@@ -159,7 +143,7 @@ describe('categories API', () => {
           data: { message: 'このslugは既に使用されています' },
         },
       };
-      mockedAxios.post.mockRejectedValue(error);
+      mockedClient.post.mockRejectedValue(error);
 
       await expect(createCategory(createRequest)).rejects.toMatchObject({
         message: 'このslugは既に使用されています',
@@ -175,19 +159,13 @@ describe('categories API', () => {
 
     it('PUT /admin/categories/{id} を呼び出してカテゴリを更新する', async () => {
       const updatedCategory = { ...mockCategory, ...updateRequest };
-      mockedAxios.put.mockResolvedValue({ data: updatedCategory });
+      mockedClient.put.mockResolvedValue({ data: updatedCategory });
 
       const result = await updateCategory('cat-1', updateRequest);
 
-      expect(mockedAxios.put).toHaveBeenCalledWith(
+      expect(mockedClient.put).toHaveBeenCalledWith(
         '/admin/categories/cat-1',
-        updateRequest,
-        {
-          headers: {
-            Authorization: 'Bearer test-auth-token',
-            'Content-Type': 'application/json',
-          },
-        }
+        updateRequest
       );
       expect(result).toEqual(updatedCategory);
     });
@@ -195,14 +173,13 @@ describe('categories API', () => {
     it('部分更新（slugのみ）ができる', async () => {
       const partialUpdate: UpdateCategoryRequest = { slug: 'new-slug' };
       const updatedCategory = { ...mockCategory, slug: 'new-slug' };
-      mockedAxios.put.mockResolvedValue({ data: updatedCategory });
+      mockedClient.put.mockResolvedValue({ data: updatedCategory });
 
       const result = await updateCategory('cat-1', partialUpdate);
 
-      expect(mockedAxios.put).toHaveBeenCalledWith(
+      expect(mockedClient.put).toHaveBeenCalledWith(
         '/admin/categories/cat-1',
-        partialUpdate,
-        expect.any(Object)
+        partialUpdate
       );
       expect(result.slug).toBe('new-slug');
     });
@@ -214,7 +191,7 @@ describe('categories API', () => {
           data: { message: 'カテゴリが見つかりません' },
         },
       };
-      mockedAxios.put.mockRejectedValue(error);
+      mockedClient.put.mockRejectedValue(error);
 
       await expect(
         updateCategory('non-existent', updateRequest)
@@ -231,7 +208,7 @@ describe('categories API', () => {
           data: { message: 'このslugは既に使用されています' },
         },
       };
-      mockedAxios.put.mockRejectedValue(error);
+      mockedClient.put.mockRejectedValue(error);
 
       await expect(
         updateCategory('cat-1', { slug: 'existing-slug' })
@@ -261,19 +238,13 @@ describe('categories API', () => {
           sortOrder: 1,
         },
       ];
-      mockedAxios.patch.mockResolvedValue({ data: updatedCategories });
+      mockedClient.patch.mockResolvedValue({ data: updatedCategories });
 
       const result = await updateCategorySortOrders(sortOrderRequest);
 
-      expect(mockedAxios.patch).toHaveBeenCalledWith(
+      expect(mockedClient.patch).toHaveBeenCalledWith(
         '/admin/categories/sort',
-        sortOrderRequest,
-        {
-          headers: {
-            Authorization: 'Bearer test-auth-token',
-            'Content-Type': 'application/json',
-          },
-        }
+        sortOrderRequest
       );
       expect(result).toEqual(updatedCategories);
     });
@@ -285,7 +256,7 @@ describe('categories API', () => {
           data: { message: '無効なカテゴリID: invalid-id' },
         },
       };
-      mockedAxios.patch.mockRejectedValue(error);
+      mockedClient.patch.mockRejectedValue(error);
 
       await expect(
         updateCategorySortOrders(sortOrderRequest)
@@ -298,17 +269,12 @@ describe('categories API', () => {
 
   describe('deleteCategory', () => {
     it('DELETE /admin/categories/{id} を呼び出してカテゴリを削除する', async () => {
-      mockedAxios.delete.mockResolvedValue({ status: 204 });
+      mockedClient.delete.mockResolvedValue({ status: 204 });
 
       await deleteCategory('cat-1');
 
-      expect(mockedAxios.delete).toHaveBeenCalledWith(
-        '/admin/categories/cat-1',
-        {
-          headers: {
-            Authorization: 'Bearer test-auth-token',
-          },
-        }
+      expect(mockedClient.delete).toHaveBeenCalledWith(
+        '/admin/categories/cat-1'
       );
     });
 
@@ -319,7 +285,7 @@ describe('categories API', () => {
           data: { message: 'カテゴリが見つかりません' },
         },
       };
-      mockedAxios.delete.mockRejectedValue(error);
+      mockedClient.delete.mockRejectedValue(error);
 
       await expect(deleteCategory('non-existent')).rejects.toMatchObject({
         message: 'カテゴリが見つかりません',
@@ -336,7 +302,7 @@ describe('categories API', () => {
           },
         },
       };
-      mockedAxios.delete.mockRejectedValue(error);
+      mockedClient.delete.mockRejectedValue(error);
 
       await expect(deleteCategory('cat-1')).rejects.toMatchObject({
         message: 'このカテゴリは記事で使用されているため削除できません',
@@ -353,7 +319,7 @@ describe('categories API', () => {
           data: {},
         },
       };
-      mockedAxios.get.mockRejectedValue(error);
+      mockedClient.get.mockRejectedValue(error);
 
       await expect(fetchCategories()).rejects.toMatchObject({
         message: 'エラーが発生しました',
@@ -362,7 +328,7 @@ describe('categories API', () => {
     });
 
     it('response自体がない場合（ネットワークエラー）を処理する', async () => {
-      mockedAxios.get.mockRejectedValue(new Error('Network Error'));
+      mockedClient.get.mockRejectedValue(new Error('Network Error'));
 
       await expect(fetchCategories()).rejects.toMatchObject({
         message: 'ネットワークエラーが発生しました。接続を確認してください。',

--- a/frontend/admin/src/api/categories.ts
+++ b/frontend/admin/src/api/categories.ts
@@ -1,8 +1,4 @@
-import axios from 'axios';
-import { getAuthToken } from '../utils/auth';
-
-// E2Eテスト時は空文字列を使用して相対パスにする（MSWは同一オリジンのリクエストをインターセプトできる）
-const API_URL = import.meta.env.VITE_API_URL ?? '/api';
+import { apiClient } from './client';
 
 /**
  * カテゴリエンティティ
@@ -98,7 +94,7 @@ const handleError = (error: unknown): never => {
  */
 export const fetchCategories = async (): Promise<Category[]> => {
   try {
-    const response = await axios.get<Category[]>(`${API_URL}/categories`);
+    const response = await apiClient.get<Category[]>('/categories');
     return response.data;
   } catch (error) {
     handleError(error);
@@ -113,17 +109,7 @@ export const createCategory = async (
   data: CreateCategoryRequest
 ): Promise<Category> => {
   try {
-    const token = getAuthToken();
-    const response = await axios.post<Category>(
-      `${API_URL}/admin/categories`,
-      data,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      }
-    );
+    const response = await apiClient.post<Category>('/admin/categories', data);
     return response.data;
   } catch (error) {
     handleError(error);
@@ -139,16 +125,9 @@ export const updateCategory = async (
   data: UpdateCategoryRequest
 ): Promise<Category> => {
   try {
-    const token = getAuthToken();
-    const response = await axios.put<Category>(
-      `${API_URL}/admin/categories/${id}`,
-      data,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      }
+    const response = await apiClient.put<Category>(
+      `/admin/categories/${id}`,
+      data
     );
     return response.data;
   } catch (error) {
@@ -164,16 +143,9 @@ export const updateCategorySortOrders = async (
   data: UpdateSortOrderRequest
 ): Promise<Category[]> => {
   try {
-    const token = getAuthToken();
-    const response = await axios.patch<Category[]>(
-      `${API_URL}/admin/categories/sort`,
-      data,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      }
+    const response = await apiClient.patch<Category[]>(
+      '/admin/categories/sort',
+      data
     );
     return response.data;
   } catch (error) {
@@ -187,12 +159,7 @@ export const updateCategorySortOrders = async (
  */
 export const deleteCategory = async (id: string): Promise<void> => {
   try {
-    const token = getAuthToken();
-    await axios.delete(`${API_URL}/admin/categories/${id}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
+    await apiClient.delete(`/admin/categories/${id}`);
   } catch (error) {
     handleError(error);
   }

--- a/frontend/admin/src/api/client.test.ts
+++ b/frontend/admin/src/api/client.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AxiosError, type InternalAxiosRequestConfig } from 'axios';
+import { fetchAuthSession } from 'aws-amplify/auth';
+import * as authUtils from '../utils/auth';
+import { apiClient, AUTH_SESSION_EXPIRED_EVENT } from './client';
+
+vi.mock('aws-amplify/auth', () => ({
+  fetchAuthSession: vi.fn(),
+}));
+vi.mock('../utils/auth');
+
+const mockedFetchAuthSession = vi.mocked(fetchAuthSession);
+const mockedGetAuthToken = vi.mocked(authUtils.getAuthToken);
+const mockedSaveAuthToken = vi.mocked(authUtils.saveAuthToken);
+const mockedRemoveAuthToken = vi.mocked(authUtils.removeAuthToken);
+
+/**
+ * axios のアダプタを差し替えて、インターセプタを含む
+ * リクエストパイプライン全体を実際に通して検証する。
+ */
+const createAdapter = (
+  ...statuses: Array<{ status: number; data?: unknown }>
+) => {
+  let call = 0;
+  return vi.fn((config: InternalAxiosRequestConfig) => {
+    const { status, data } = statuses[Math.min(call, statuses.length - 1)];
+    call += 1;
+    const response = {
+      data: data ?? {},
+      status,
+      statusText: String(status),
+      headers: {},
+      config,
+    };
+    // 実際のアダプタと同様に、エラーステータスは AxiosError で reject する
+    if (status >= 200 && status < 300) {
+      return Promise.resolve(response);
+    }
+    return Promise.reject(
+      new AxiosError(
+        `Request failed with status code ${status}`,
+        AxiosError.ERR_BAD_REQUEST,
+        config,
+        undefined,
+        response as never
+      )
+    );
+  });
+};
+
+const mockSession = (idToken: string | undefined) => {
+  mockedFetchAuthSession.mockResolvedValue({
+    tokens: idToken
+      ? ({ idToken: { toString: () => idToken } } as never)
+      : undefined,
+  } as never);
+};
+
+describe('apiClient', () => {
+  let sessionExpiredListener: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetAuthToken.mockReturnValue('initial-token');
+    sessionExpiredListener = vi.fn();
+    window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, sessionExpiredListener);
+  });
+
+  afterEach(() => {
+    window.removeEventListener(
+      AUTH_SESSION_EXPIRED_EVENT,
+      sessionExpiredListener
+    );
+  });
+
+  it('リクエストに Authorization ヘッダーを自動付与する', async () => {
+    const adapter = createAdapter({ status: 200 });
+    apiClient.defaults.adapter = adapter;
+
+    await apiClient.get('/admin/posts');
+
+    const config = adapter.mock.calls[0][0];
+    expect(config.headers.Authorization).toBe('Bearer initial-token');
+  });
+
+  it('トークンがない場合は Authorization ヘッダーを付けない', async () => {
+    mockedGetAuthToken.mockReturnValue(null);
+    const adapter = createAdapter({ status: 200 });
+    apiClient.defaults.adapter = adapter;
+
+    await apiClient.get('/categories');
+
+    const config = adapter.mock.calls[0][0];
+    expect(config.headers.Authorization).toBeUndefined();
+  });
+
+  it('401 受信時はトークンを再取得して1回だけリトライする', async () => {
+    const adapter = createAdapter(
+      { status: 401 },
+      { status: 200, data: { ok: true } }
+    );
+    apiClient.defaults.adapter = adapter;
+    mockSession('refreshed-token');
+    // saveAuthToken 後は getAuthToken が新トークンを返す（実際のストアと同じ挙動）
+    let storedToken = 'initial-token';
+    mockedGetAuthToken.mockImplementation(() => storedToken);
+    mockedSaveAuthToken.mockImplementation((token) => {
+      storedToken = token;
+    });
+
+    const response = await apiClient.get('/admin/posts');
+
+    expect(response.data).toEqual({ ok: true });
+    expect(mockedFetchAuthSession).toHaveBeenCalledWith({ forceRefresh: true });
+    expect(mockedSaveAuthToken).toHaveBeenCalledWith('refreshed-token');
+    expect(adapter).toHaveBeenCalledTimes(2);
+    const retryConfig = adapter.mock.calls[1][0];
+    expect(retryConfig.headers.Authorization).toBe('Bearer refreshed-token');
+    expect(sessionExpiredListener).not.toHaveBeenCalled();
+  });
+
+  it('リフレッシュでトークンが得られない場合はセッション失効として扱う', async () => {
+    const adapter = createAdapter({ status: 401 });
+    apiClient.defaults.adapter = adapter;
+    mockSession(undefined);
+
+    await expect(apiClient.get('/admin/posts')).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+
+    expect(mockedRemoveAuthToken).toHaveBeenCalled();
+    expect(sessionExpiredListener).toHaveBeenCalledTimes(1);
+    expect(adapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('リフレッシュ自体が失敗した場合もセッション失効として扱う', async () => {
+    const adapter = createAdapter({ status: 401 });
+    apiClient.defaults.adapter = adapter;
+    mockedFetchAuthSession.mockRejectedValue(new Error('refresh failed'));
+
+    await expect(apiClient.get('/admin/posts')).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+
+    expect(mockedRemoveAuthToken).toHaveBeenCalled();
+    expect(sessionExpiredListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('リトライ後も 401 の場合は再リフレッシュせずエラーを返す', async () => {
+    const adapter = createAdapter({ status: 401 }, { status: 401 });
+    apiClient.defaults.adapter = adapter;
+    mockSession('refreshed-token');
+
+    await expect(apiClient.get('/admin/posts')).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+
+    expect(mockedFetchAuthSession).toHaveBeenCalledTimes(1);
+    expect(adapter).toHaveBeenCalledTimes(2);
+  });
+
+  it('401 以外のエラーはリフレッシュせずそのまま返す', async () => {
+    const adapter = createAdapter({
+      status: 500,
+      data: { message: 'server error' },
+    });
+    apiClient.defaults.adapter = adapter;
+
+    await expect(apiClient.get('/admin/posts')).rejects.toMatchObject({
+      response: { status: 500 },
+    });
+
+    expect(mockedFetchAuthSession).not.toHaveBeenCalled();
+    expect(sessionExpiredListener).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/admin/src/api/client.ts
+++ b/frontend/admin/src/api/client.ts
@@ -1,0 +1,76 @@
+import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
+import { fetchAuthSession } from 'aws-amplify/auth';
+import { getAuthToken, saveAuthToken, removeAuthToken } from '../utils/auth';
+
+// E2Eテスト時は空文字列を使用して相対パスにする（MSWは同一オリジンのリクエストをインターセプトできる）
+const API_URL = import.meta.env.VITE_API_URL ?? '/api';
+
+/**
+ * セッション失効時に window へ発火するイベント名。
+ * AuthContext が購読して認証状態をクリアし、AuthGuard 経由で /login へ遷移させる。
+ */
+export const AUTH_SESSION_EXPIRED_EVENT = 'auth:session-expired';
+
+/**
+ * 管理画面 API 共通クライアント
+ *
+ * - リクエスト時に Authorization ヘッダーを自動付与
+ * - 401 受信時は Cognito セッションからトークンを再取得して1回だけリトライ
+ * - 再取得できない場合はトークンを破棄し AUTH_SESSION_EXPIRED_EVENT を発火
+ */
+export const apiClient = axios.create({ baseURL: API_URL });
+
+apiClient.interceptors.request.use((config) => {
+  const token = getAuthToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+/**
+ * Cognito セッションから ID トークンを再取得する。
+ * E2E (MSW) モードでは Amplify が構成されていないため常に null。
+ */
+const refreshAuthToken = async (): Promise<string | null> => {
+  if (import.meta.env.VITE_ENABLE_MSW_MOCK === 'true') {
+    return null;
+  }
+  const session = await fetchAuthSession({ forceRefresh: true });
+  const idToken = session.tokens?.idToken?.toString();
+  if (!idToken) {
+    return null;
+  }
+  saveAuthToken(idToken);
+  return idToken;
+};
+
+interface RetriableConfig extends InternalAxiosRequestConfig {
+  _retriedAfterRefresh?: boolean;
+}
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const config = error.config as RetriableConfig | undefined;
+    if (
+      error.response?.status === 401 &&
+      config &&
+      !config._retriedAfterRefresh
+    ) {
+      config._retriedAfterRefresh = true;
+      try {
+        const token = await refreshAuthToken();
+        if (token) {
+          config.headers.Authorization = `Bearer ${token}`;
+          return apiClient(config);
+        }
+      } catch {
+        // リフレッシュ失敗はセッション失効として扱う
+      }
+      removeAuthToken();
+      window.dispatchEvent(new Event(AUTH_SESSION_EXPIRED_EVENT));
+    }
+    return Promise.reject(error);
+  }
+);

--- a/frontend/admin/src/api/posts.ts
+++ b/frontend/admin/src/api/posts.ts
@@ -1,8 +1,5 @@
 import axios from 'axios';
-import { getAuthToken } from '../utils/auth';
-
-// E2Eテスト時は空文字列を使用して相対パスにする（MSWは同一オリジンのリクエストをインターセプトできる）
-const API_URL = import.meta.env.VITE_API_URL ?? '/api';
+import { apiClient } from './client';
 
 export interface Post {
   id: string;
@@ -45,13 +42,7 @@ export interface UpdatePostRequest {
  * 記事を作成
  */
 export const createPost = async (data: CreatePostRequest): Promise<Post> => {
-  const token = getAuthToken();
-  const response = await axios.post(`${API_URL}/admin/posts`, data, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-  });
+  const response = await apiClient.post('/admin/posts', data);
   return response.data;
 };
 
@@ -62,13 +53,7 @@ export const updatePost = async (
   id: string,
   data: UpdatePostRequest
 ): Promise<Post> => {
-  const token = getAuthToken();
-  const response = await axios.put(`${API_URL}/admin/posts/${id}`, data, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-  });
+  const response = await apiClient.put(`/admin/posts/${id}`, data);
   return response.data;
 };
 
@@ -76,12 +61,7 @@ export const updatePost = async (
  * 記事を取得
  */
 export const getPost = async (id: string): Promise<Post> => {
-  const token = getAuthToken();
-  const response = await axios.get(`${API_URL}/admin/posts/${id}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  const response = await apiClient.get(`/admin/posts/${id}`);
   return response.data;
 };
 
@@ -92,17 +72,10 @@ export const getUploadUrl = async (
   filename: string,
   contentType: string
 ): Promise<{ uploadUrl: string; imageUrl: string }> => {
-  const token = getAuthToken();
-  const response = await axios.post(
-    `${API_URL}/admin/images/upload-url`,
-    { fileName: filename, contentType },
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    }
-  );
+  const response = await apiClient.post('/admin/images/upload-url', {
+    fileName: filename,
+    contentType,
+  });
   // バックエンドは "url" を返すが、フロントエンドは "imageUrl" を期待するためマッピング
   return {
     uploadUrl: response.data.uploadUrl,
@@ -117,7 +90,7 @@ export const uploadImage = async (file: File): Promise<string> => {
   // Pre-signed URL取得
   const { uploadUrl, imageUrl } = await getUploadUrl(file.name, file.type);
 
-  // S3に直接アップロード
+  // S3に直接アップロード（Pre-signed URLのため Authorization ヘッダーを付けない素の axios を使う）
   await axios.put(uploadUrl, file, {
     headers: {
       'Content-Type': file.type,
@@ -145,7 +118,6 @@ export interface GetPostsResponse {
 export const getPosts = async (
   params?: GetPostsParams
 ): Promise<GetPostsResponse> => {
-  const token = getAuthToken();
   const queryParams = new URLSearchParams();
 
   if (params?.publishStatus) {
@@ -158,13 +130,8 @@ export const getPosts = async (
     queryParams.append('nextToken', params.nextToken);
   }
 
-  const response = await axios.get(
-    `${API_URL}/admin/posts?${queryParams.toString()}`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }
+  const response = await apiClient.get(
+    `/admin/posts?${queryParams.toString()}`
   );
 
   return {
@@ -178,12 +145,7 @@ export const getPosts = async (
  * 記事を削除
  */
 export const deletePost = async (id: string): Promise<void> => {
-  const token = getAuthToken();
-  await axios.delete(`${API_URL}/admin/posts/${id}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  await apiClient.delete(`/admin/posts/${id}`);
 };
 
 /**
@@ -206,14 +168,8 @@ export interface BuildStatusResponse {
 export const fetchBuildStatus = async (
   postId: string
 ): Promise<BuildStatusResponse> => {
-  const token = getAuthToken();
-  const response = await axios.get<BuildStatusResponse>(
-    `${API_URL}/admin/posts/${postId}/build-status`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }
+  const response = await apiClient.get<BuildStatusResponse>(
+    `/admin/posts/${postId}/build-status`
   );
   return response.data;
 };
@@ -247,13 +203,8 @@ export const extractImageKey = (imageUrl: string): string => {
  * @param imageUrl CloudFront形式の画像URL（例: https://xxxxx.cloudfront.net/user-id/image.jpg）
  */
 export const deleteImage = async (imageUrl: string): Promise<void> => {
-  const token = getAuthToken();
   const key = extractImageKey(imageUrl);
   const encodedKey = encodeURIComponent(key);
 
-  await axios.delete(`${API_URL}/admin/images/${encodedKey}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
+  await apiClient.delete(`/admin/images/${encodedKey}`);
 };

--- a/frontend/admin/src/components/AuthGuard.test.tsx
+++ b/frontend/admin/src/components/AuthGuard.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import { AuthGuard } from './AuthGuard';
+import { consumeRedirectPath } from '../utils/auth';
 
 // モックのuseAuth
 const mockUseAuth = vi.fn();
@@ -11,6 +12,10 @@ vi.mock('../hooks/useAuth', () => ({
 }));
 
 describe('AuthGuard', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
   it('認証済みの場合は子要素を表示する', () => {
     mockUseAuth.mockReturnValue({
       isAuthenticated: true,
@@ -122,5 +127,41 @@ describe('AuthGuard', () => {
 
     // userがnullの場合はリダイレクトされる
     expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+  });
+
+  it('未認証リダイレクト時に遷移元パスを保存する（ログイン後の復帰用）', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      user: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/posts?page=2']}>
+        <AuthGuard>
+          <div>Protected Content</div>
+        </AuthGuard>
+      </MemoryRouter>
+    );
+
+    expect(consumeRedirectPath()).toBe('/posts?page=2');
+  });
+
+  it('/login 上では遷移元パスを保存しない', () => {
+    mockUseAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      user: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <AuthGuard>
+          <div>Protected Content</div>
+        </AuthGuard>
+      </MemoryRouter>
+    );
+
+    expect(consumeRedirectPath()).toBeNull();
   });
 });

--- a/frontend/admin/src/components/AuthGuard.tsx
+++ b/frontend/admin/src/components/AuthGuard.tsx
@@ -1,6 +1,7 @@
-import React, { type ReactNode } from 'react';
-import { Navigate } from 'react-router-dom';
+import React, { useEffect, type ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import { saveRedirectPath } from '../utils/auth';
 
 interface AuthGuardProps {
   children: ReactNode;
@@ -12,6 +13,17 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({
   loadingMessage = '読み込み中...',
 }) => {
   const { isAuthenticated, isLoading, user } = useAuth();
+  const location = useLocation();
+  const shouldRedirect = !isLoading && (!isAuthenticated || !user);
+
+  // ログイン成功後に元のページへ戻れるよう、遷移元を保存してからリダイレクトする。
+  // Navigate の state で渡すと /login 上で再レンダーごとに state が変わり
+  // 無限ナビゲーションになるため、sessionStorage 経由で受け渡す
+  useEffect(() => {
+    if (shouldRedirect && location.pathname !== '/login') {
+      saveRedirectPath(location.pathname + location.search);
+    }
+  }, [shouldRedirect, location.pathname, location.search]);
 
   // 認証確認中はローディング表示
   if (isLoading) {
@@ -23,7 +35,7 @@ export const AuthGuard: React.FC<AuthGuardProps> = ({
   }
 
   // 未認証またはユーザー情報がない場合はログインページにリダイレクト
-  if (!isAuthenticated || !user) {
+  if (shouldRedirect) {
     return <Navigate to="/login" replace />;
   }
 

--- a/frontend/admin/src/contexts/AuthContext.tsx
+++ b/frontend/admin/src/contexts/AuthContext.tsx
@@ -19,6 +19,7 @@ import {
   migrateFromLocalStorage,
 } from '../utils/auth';
 import { loginAPI } from '../api/auth';
+import { AUTH_SESSION_EXPIRED_EVENT } from '../api/client';
 
 /**
  * ユーザー情報の型定義
@@ -79,6 +80,21 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   // 初期化時に既存のセッションをチェック
   useEffect(() => {
     checkAuthStatus();
+  }, []);
+
+  // APIクライアントがトークン再取得に失敗した場合（セッション失効）は
+  // 認証状態をクリアし、AuthGuard 経由でログインページへ誘導する
+  useEffect(() => {
+    const handleSessionExpired = () => {
+      setUser(null);
+    };
+    window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, handleSessionExpired);
+    return () => {
+      window.removeEventListener(
+        AUTH_SESSION_EXPIRED_EVENT,
+        handleSessionExpired
+      );
+    };
   }, []);
 
   const checkAuthStatus = async () => {

--- a/frontend/admin/src/pages/LoginPage.tsx
+++ b/frontend/admin/src/pages/LoginPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { LoginForm } from '../components/LoginForm';
 import { useAuth } from '../hooks/useAuth';
-import { validatePassword } from '../utils/auth';
+import { validatePassword, consumeRedirectPath } from '../utils/auth';
 
 /**
  * エラーオブジェクトの型ガード
@@ -45,9 +45,10 @@ const LoginPage = () => {
       setError(null);
       const result = await login(credentials.email, credentials.password);
 
-      // 新パスワードが必要な場合はダッシュボードに遷移しない（LoginPageが新パスワード設定画面を表示）
+      // 新パスワードが必要な場合は遷移しない（LoginPageが新パスワード設定画面を表示）
       if (!result.requiresNewPassword) {
-        navigate('/dashboard');
+        // AuthGuard が保存した遷移元（セッション失効時など）があればそこへ戻る
+        navigate(consumeRedirectPath() ?? '/dashboard', { replace: true });
       }
     } catch (err) {
       console.error('ログインエラー:', err);
@@ -94,7 +95,7 @@ const LoginPage = () => {
     setIsSubmitting(true);
     try {
       await confirmNewPassword(newPassword);
-      navigate('/dashboard');
+      navigate(consumeRedirectPath() ?? '/dashboard', { replace: true });
     } catch (err) {
       console.error('パスワード変更エラー:', err);
       if (isErrorWithMessage(err)) {

--- a/frontend/admin/src/utils/auth.ts
+++ b/frontend/admin/src/utils/auth.ts
@@ -103,6 +103,34 @@ export const removeAuthToken = (): void => {
   }
 };
 
+// 未認証リダイレクト時の遷移元パスを保持するsessionStorageのキー
+const REDIRECT_PATH_KEY = 'auth_redirect_path';
+
+/**
+ * ログイン後に戻るべきパスを保存
+ * AuthGuard が /login へリダイレクトする際に呼ばれる
+ */
+export const saveRedirectPath = (path: string): void => {
+  try {
+    sessionStorage.setItem(REDIRECT_PATH_KEY, path);
+  } catch {
+    // sessionStorageが使えない場合は復帰先なしで動作
+  }
+};
+
+/**
+ * ログイン後に戻るべきパスを取り出す（取り出したら削除）
+ */
+export const consumeRedirectPath = (): string | null => {
+  try {
+    const path = sessionStorage.getItem(REDIRECT_PATH_KEY);
+    sessionStorage.removeItem(REDIRECT_PATH_KEY);
+    return path;
+  } catch {
+    return null;
+  }
+};
+
 /**
  * localStorageからの移行処理
  * 既存のlocalStorageトークンをsessionStorageに移行し、localStorageから削除


### PR DESCRIPTION
## 概要

管理画面は Cognito ID トークンをサインイン時に一度取得したきりで、約1時間の失効後は全 API が汎用エラーになり手動リロードまで復旧しなかった。共通 axios クライアントを導入し、401 時のトークン再取得・リトライとログイン画面への誘導を実装する。

Closes #466

## 変更内容

- **`api/client.ts` 新設**: リクエスト毎に Authorization を自動付与。401 受信時は `fetchAuthSession({ forceRefresh: true })` で ID トークンを再取得して1回だけリトライ。再取得不能ならトークンを破棄し `auth:session-expired` イベントを発火
- **AuthContext**: イベントを購読して user をクリア → AuthGuard 経由で `/login` へ
- **AuthGuard / LoginPage**: 遷移元パスを sessionStorage に保存し、ログイン成功後に元のページへ復帰
  - 当初 `Navigate state={{ from: location }}` で実装したが、`/login` 上で location.state が自己ネストして無限ナビゲーション → OOM になるため sessionStorage 方式を採用
- **posts / categories API**: 共通クライアントへ移行(トークン付与のボイラープレート削除)。S3 presigned アップロードのみ Authorization を付けない素の axios を維持
- **テスト**: `client.test.ts` 新設(アダプタ差し替えでリクエストパイプライン全体を検証、7件)、AuthGuard に復帰フローのテスト2件追加、categories.test.ts をクライアントモックに移行

## 検証

- admin vitest 全 28 ファイル / 476 件パス(既存 skip 5 件)、フルスイートで既知 flaky も未発生
- `tsc --noEmit` / `eslint .` クリーン

## 備考

リフレッシュトークンの HttpOnly cookie 化はスコープ外(改善計画 P3)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)