### PR TITLE
fix(admin): CategoryEditPageのアンマウント後setStateを解消

### DIFF
--- a/docs/ai-shared-rules.md
+++ b/docs/ai-shared-rules.md
@@ -30,10 +30,6 @@ Run `bun run verify` before reporting a code change as done.
 - CI runs `typecheck` on every PR (no label gate). The vitest suites for `frontend/admin`,
   `frontend/public` and `frontend/public-astro` run only on PRs carrying the `frontend`
   label, so a PR outside those paths still needs `bun run verify` locally.
-- `frontend/admin` has a flaky unhandled rejection: `CategoryEditPage` calls `setSaving`
-  in a `finally` after teardown, so a full-suite run occasionally fails with
-  `ReferenceError: window is not defined` while all 468 tests still pass. Re-run before
-  treating it as your regression.
 
 ## Repository etiquette
 

--- a/frontend/admin/src/pages/CategoryEditPage.test.tsx
+++ b/frontend/admin/src/pages/CategoryEditPage.test.tsx
@@ -181,6 +181,40 @@ describe('CategoryEditPage', () => {
         expect(mockNavigate).toHaveBeenCalledWith('/categories');
       });
     });
+
+    it('保存成功後は不要な setSaving(false) を呼ばない（アンマウント後のstate更新防止）', async () => {
+      // navigate 実行後、実際のアプリではコンポーネントがアンマウントされるため
+      // setSaving(false) を呼んではいけない。このテストでは navigate をモックしており
+      // 実際にはアンマウントされないので、保存成功後もボタンが「保存中...」のまま
+      // 変化しないことをもって、setSaving(false) が呼ばれていないことを確認する。
+      const user = userEvent.setup();
+      const newCategory = {
+        id: 'new-id',
+        name: 'テストカテゴリ',
+        slug: 'test-category',
+        description: '',
+        sortOrder: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      };
+
+      mockCreateCategory.mockResolvedValue(newCategory);
+
+      renderCategoryEditPageNewMode();
+
+      const nameInput = screen.getByLabelText(/カテゴリ名/i);
+      const submitButton = screen.getByRole('button', { name: /保存/i });
+
+      await user.type(nameInput, 'テストカテゴリ');
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/categories');
+      });
+
+      expect(submitButton).toBeDisabled();
+      expect(submitButton).toHaveTextContent('保存中...');
+    });
   });
 
   describe('編集モード', () => {

--- a/frontend/admin/src/pages/CategoryEditPage.tsx
+++ b/frontend/admin/src/pages/CategoryEditPage.tsx
@@ -48,6 +48,7 @@ const CategoryEditPage = () => {
 
         if (!category) {
           setNotFound(true);
+          setLoading(false);
           return;
         }
 
@@ -56,10 +57,10 @@ const CategoryEditPage = () => {
           slug: category.slug,
           description: category.description || '',
         });
+        setLoading(false);
       } catch (err) {
         console.error('カテゴリ取得エラー:', err);
         setError('カテゴリの取得に失敗しました');
-      } finally {
         setLoading(false);
       }
     };
@@ -106,6 +107,8 @@ const CategoryEditPage = () => {
         await createCategory(categoryData);
       }
 
+      // 保存成功時は一覧ページへ遷移してこのコンポーネントはアンマウントされる。
+      // ここで setSaving(false) を呼ぶとアンマウント後の state 更新になるため呼ばない。
       navigate('/categories');
     } catch (err) {
       console.error('保存エラー:', err);
@@ -118,7 +121,7 @@ const CategoryEditPage = () => {
         // 一般的なエラー（ネットワークエラー等）
         setError('カテゴリの保存に失敗しました');
       }
-    } finally {
+      // エラー時はこのページに留まるため、保存ボタンを再度押せるように戻す
       setSaving(false);
     }
   };


### PR DESCRIPTION
## 概要

- `CategoryEditPage.tsx` の `handleSubmit` は保存成功時に `navigate('/categories')` を呼んだ後、`finally { setSaving(false); }` を必ず実行していた。`navigate` によりコンポーネントがアンマウントされるため、この `setSaving(false)` はアンマウント後の state 更新となり、admin のフルスイート実行時に断続的に `ReferenceError: window is not defined` の unhandled rejection を引き起こしていた。
- 修正方針として `finally` をやめ、保存成功パス（`navigate` する経路）では state 更新を行わず、エラーパスでのみ `setSaving(false)` を呼ぶ形にした。保存失敗時の挙動（エラーメッセージ表示・保存ボタンの再活性化）は変えていない。
- 同ファイルの取得処理（`useEffect` 内の `fetchCategory`）も同じ `finally` パターンだったため、同様に `finally` をやめて各分岐（取得成功・notFound・エラー）で明示的に `setLoading(false)` を呼ぶ形に統一した。`notFound` 表示に必要な `setLoading(false)` はそのまま残しており、挙動は変更していない。
- `docs/ai-shared-rules.md` にあった本件に関する flaky 注記（CategoryEditPage の `setSaving` が原因で `window is not defined` が出る、という記述）を削除した。

## 変更内容

- `frontend/admin/src/pages/CategoryEditPage.tsx`
  - `handleSubmit`: `finally` を廃止し、エラー時のみ `setSaving(false)` を呼ぶように変更
  - `fetchCategory`（`useEffect` 内）: `finally` を廃止し、各分岐で明示的に `setLoading(false)` を呼ぶように変更（挙動は不変）
- `frontend/admin/src/pages/CategoryEditPage.test.tsx`
  - 保存成功後に `setSaving(false)` が呼ばれない（＝保存ボタンが「保存中...」のままになる）ことを検証する回帰テストを追加
- `docs/ai-shared-rules.md`
  - 解消済みとなった flaky テストの注記を削除

## 検証

worktree ルートで `bun install` および `frontend/admin` で `bun install` を実行後:

1. `cd frontend/admin && bun run test -- --run` をフルスイートで **3回** 実行し、いずれも **477 passed | 5 skipped**、unhandled rejection なしを確認（新規テスト追加分で従来の476から+1）。加えて、コミット時の pre-commit フックでも同スイートが自動実行され、同様に全件パス・unhandled rejection なしを確認（計4回連続クリーン）。
2. `cd frontend/admin && bunx tsc --noEmit` — クリーン（エラーなし）。
3. `cd frontend/admin && bun run lint` — エラーなし（`public/mockServiceWorker.js` に既存の無関係な警告が1件あるのみで、本PRの変更はコミットしていません）。

## テスト計画

- [x] `bun run test -- --run`（frontend/admin）を3回連続実行し、全件パス・unhandled rejectionなしを確認
- [x] `bunx tsc --noEmit`（frontend/admin）がクリーン
- [x] `bun run lint`（frontend/admin）がクリーン
- [x] 保存失敗時のエラーメッセージ表示・保存ボタン再活性化の既存挙動が変わっていないことを既存テストで確認

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)