### PR TITLE
security(go): カテゴリ変更に管理者グループを必須化する

### DIFF
--- a/go-functions/cmd/categories/bulk_sort/main.go
+++ b/go-functions/cmd/categories/bulk_sort/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
+	"serverless-blog/go-functions/internal/auth"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
 	"serverless-blog/go-functions/internal/middleware"
@@ -53,9 +54,15 @@ var timeNow = func() string {
 // Requirement 4B.2: Require Cognito authorization
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Requirement 4B.2: Check authentication
-	authorID := extractAuthorID(request)
+	authorID := auth.UserID(request)
 	if authorID == "" {
 		return errorResponse(401, "unauthorized")
+	}
+
+	// Categories are site-wide, so being signed in is not enough to change
+	// them: the caller has to be in the admin group.
+	if !auth.IsAdmin(request) {
+		return errorResponse(403, "forbidden")
 	}
 
 	// Parse request body
@@ -114,35 +121,6 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	}
 
 	return middleware.JSONResponse(200, updatedCategories)
-}
-
-// extractAuthorID extracts the user ID from Cognito authorizer claims
-func extractAuthorID(request events.APIGatewayProxyRequest) string {
-	if request.RequestContext.Authorizer == nil {
-		return ""
-	}
-
-	claims, ok := request.RequestContext.Authorizer["claims"]
-	if !ok {
-		return ""
-	}
-
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	sub, ok := claimsMap["sub"]
-	if !ok {
-		return ""
-	}
-
-	subStr, ok := sub.(string)
-	if !ok {
-		return ""
-	}
-
-	return subStr
 }
 
 // verifyCategories verifies all category IDs exist and returns existing categories and invalid IDs

--- a/go-functions/cmd/categories/bulk_sort/main_test.go
+++ b/go-functions/cmd/categories/bulk_sort/main_test.go
@@ -84,7 +84,8 @@ func createAuthenticatedRequest(body string) events.APIGatewayProxyRequest {
 		RequestContext: events.APIGatewayProxyRequestContext{
 			Authorizer: map[string]interface{}{
 				"claims": map[string]interface{}{
-					"sub": testAuthorID,
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"admin"},
 				},
 			},
 		},
@@ -863,3 +864,34 @@ func TestHandler_ExceedsMaxItemsLimit(t *testing.T) {
 
 // Ensure unused import warning is silenced
 var _ = aws.String
+
+// createNonAdminRequest builds a request from a signed-in user who is not in
+// the admin group. Categories are site-wide, so this must be rejected.
+func createNonAdminRequest(body string) events.APIGatewayProxyRequest {
+	return events.APIGatewayProxyRequest{
+		Body: body,
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{
+				"claims": map[string]interface{}{
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"editor"},
+				},
+			},
+		},
+	}
+}
+
+// TestHandler_NonAdminForbidden guards the authorization rule added in #488:
+// before it, any authenticated Cognito user could mutate categories.
+func TestHandler_NonAdminForbidden(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	resp, err := Handler(context.Background(), createNonAdminRequest(`{"orders":[{"id":"cat-1","sortOrder":1}]}`))
+	if err != nil {
+		t.Fatalf("Handler returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != 403 {
+		t.Errorf("StatusCode = %d, want 403", resp.StatusCode)
+	}
+}

--- a/go-functions/cmd/categories/create/main.go
+++ b/go-functions/cmd/categories/create/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/google/uuid"
 
+	"serverless-blog/go-functions/internal/auth"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
 	"serverless-blog/go-functions/internal/middleware"
@@ -63,9 +64,15 @@ var timeNow = func() string {
 // Requirement 3.2: Require Cognito authorization
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Requirement 3.2: Check authentication
-	authorID := extractAuthorID(request)
+	authorID := auth.UserID(request)
 	if authorID == "" {
 		return errorResponse(401, "unauthorized")
+	}
+
+	// Categories are site-wide, so being signed in is not enough to change
+	// them: the caller has to be in the admin group.
+	if !auth.IsAdmin(request) {
+		return errorResponse(403, "forbidden")
 	}
 
 	// Parse request body
@@ -179,35 +186,6 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 
 	// Return created category with 201 status
 	return middleware.JSONResponse(201, category)
-}
-
-// extractAuthorID extracts the user ID from Cognito authorizer claims
-func extractAuthorID(request events.APIGatewayProxyRequest) string {
-	if request.RequestContext.Authorizer == nil {
-		return ""
-	}
-
-	claims, ok := request.RequestContext.Authorizer["claims"]
-	if !ok {
-		return ""
-	}
-
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	sub, ok := claimsMap["sub"]
-	if !ok {
-		return ""
-	}
-
-	subStr, ok := sub.(string)
-	if !ok {
-		return ""
-	}
-
-	return subStr
 }
 
 // isTransactionCanceledError checks if the error is a DynamoDB TransactionCanceledException

--- a/go-functions/cmd/categories/create/main_test.go
+++ b/go-functions/cmd/categories/create/main_test.go
@@ -101,7 +101,8 @@ func createAuthenticatedRequest(body string) events.APIGatewayProxyRequest {
 		RequestContext: events.APIGatewayProxyRequestContext{
 			Authorizer: map[string]interface{}{
 				"claims": map[string]interface{}{
-					"sub": testAuthorID,
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"admin"},
 				},
 			},
 		},
@@ -979,3 +980,34 @@ func TestHandler_FirstCategorySortOrder(t *testing.T) {
 
 // Ensure unused import warning is silenced
 var _ = aws.String
+
+// createNonAdminRequest builds a request from a signed-in user who is not in
+// the admin group. Categories are site-wide, so this must be rejected.
+func createNonAdminRequest(body string) events.APIGatewayProxyRequest {
+	return events.APIGatewayProxyRequest{
+		Body: body,
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{
+				"claims": map[string]interface{}{
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"editor"},
+				},
+			},
+		},
+	}
+}
+
+// TestHandler_NonAdminForbidden guards the authorization rule added in #488:
+// before it, any authenticated Cognito user could mutate categories.
+func TestHandler_NonAdminForbidden(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	resp, err := Handler(context.Background(), createNonAdminRequest(`{"name":"テスト"}`))
+	if err != nil {
+		t.Fatalf("Handler returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != 403 {
+		t.Errorf("StatusCode = %d, want 403", resp.StatusCode)
+	}
+}

--- a/go-functions/cmd/categories/delete/main.go
+++ b/go-functions/cmd/categories/delete/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
+	"serverless-blog/go-functions/internal/auth"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
 	"serverless-blog/go-functions/internal/middleware"
@@ -46,9 +47,15 @@ var dynamoClientGetter = func() (DynamoDBClientInterface, error) {
 // Requirement 5.2: Require Cognito authorization
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Requirement 5.2: Check authentication
-	authorID := extractAuthorID(request)
+	authorID := auth.UserID(request)
 	if authorID == "" {
 		return errorResponse(401, "unauthorized")
+	}
+
+	// Categories are site-wide, so being signed in is not enough to change
+	// them: the caller has to be in the admin group.
+	if !auth.IsAdmin(request) {
+		return errorResponse(403, "forbidden")
 	}
 
 	// Validate category ID from path parameters
@@ -106,35 +113,6 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 
 	// Return 204 No Content
 	return noContentResponse()
-}
-
-// extractAuthorID extracts the user ID from Cognito authorizer claims
-func extractAuthorID(request events.APIGatewayProxyRequest) string {
-	if request.RequestContext.Authorizer == nil {
-		return ""
-	}
-
-	claims, ok := request.RequestContext.Authorizer["claims"]
-	if !ok {
-		return ""
-	}
-
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	sub, ok := claimsMap["sub"]
-	if !ok {
-		return ""
-	}
-
-	subStr, ok := sub.(string)
-	if !ok {
-		return ""
-	}
-
-	return subStr
 }
 
 // getExistingCategory retrieves a category by ID

--- a/go-functions/cmd/categories/delete/main_test.go
+++ b/go-functions/cmd/categories/delete/main_test.go
@@ -97,7 +97,8 @@ func createAuthenticatedRequest(categoryID string) events.APIGatewayProxyRequest
 		RequestContext: events.APIGatewayProxyRequestContext{
 			Authorizer: map[string]interface{}{
 				"claims": map[string]interface{}{
-					"sub": testAuthorID,
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"admin"},
 				},
 			},
 		},
@@ -323,7 +324,8 @@ func TestHandler_MissingCategoryID(t *testing.T) {
 		RequestContext: events.APIGatewayProxyRequestContext{
 			Authorizer: map[string]interface{}{
 				"claims": map[string]interface{}{
-					"sub": testAuthorID,
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"admin"},
 				},
 			},
 		},
@@ -824,3 +826,34 @@ func TestHandler_SlugReservationIDRejected(t *testing.T) {
 
 // Ensure unused import warning is silenced
 var _ = aws.String
+
+// createNonAdminRequest builds a request from a signed-in user who is not in
+// the admin group. Categories are site-wide, so this must be rejected.
+func createNonAdminRequest(categoryID string) events.APIGatewayProxyRequest {
+	return events.APIGatewayProxyRequest{
+		PathParameters: map[string]string{"id": categoryID},
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{
+				"claims": map[string]interface{}{
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"editor"},
+				},
+			},
+		},
+	}
+}
+
+// TestHandler_NonAdminForbidden guards the authorization rule added in #488:
+// before it, any authenticated Cognito user could mutate categories.
+func TestHandler_NonAdminForbidden(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	resp, err := Handler(context.Background(), createNonAdminRequest("cat-1"))
+	if err != nil {
+		t.Fatalf("Handler returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != 403 {
+		t.Errorf("StatusCode = %d, want 403", resp.StatusCode)
+	}
+}

--- a/go-functions/cmd/categories/update/main.go
+++ b/go-functions/cmd/categories/update/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
+	"serverless-blog/go-functions/internal/auth"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
 	"serverless-blog/go-functions/internal/middleware"
@@ -57,9 +58,15 @@ var timeNow = func() string {
 //nolint:gocyclo // Handler validates multiple fields which increases complexity
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Requirement 4.2: Check authentication
-	authorID := extractAuthorID(request)
+	authorID := auth.UserID(request)
 	if authorID == "" {
 		return errorResponse(401, "unauthorized")
+	}
+
+	// Categories are site-wide, so being signed in is not enough to change
+	// them: the caller has to be in the admin group.
+	if !auth.IsAdmin(request) {
+		return errorResponse(403, "forbidden")
 	}
 
 	// Validate category ID from path parameters
@@ -149,35 +156,6 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	}
 
 	return middleware.JSONResponse(200, updatedCategory)
-}
-
-// extractAuthorID extracts the user ID from Cognito authorizer claims
-func extractAuthorID(request events.APIGatewayProxyRequest) string {
-	if request.RequestContext.Authorizer == nil {
-		return ""
-	}
-
-	claims, ok := request.RequestContext.Authorizer["claims"]
-	if !ok {
-		return ""
-	}
-
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	sub, ok := claimsMap["sub"]
-	if !ok {
-		return ""
-	}
-
-	subStr, ok := sub.(string)
-	if !ok {
-		return ""
-	}
-
-	return subStr
 }
 
 // getExistingCategory retrieves a category by ID

--- a/go-functions/cmd/categories/update/main_test.go
+++ b/go-functions/cmd/categories/update/main_test.go
@@ -106,7 +106,8 @@ func createAuthenticatedRequest(categoryID, body string) events.APIGatewayProxyR
 		RequestContext: events.APIGatewayProxyRequestContext{
 			Authorizer: map[string]interface{}{
 				"claims": map[string]interface{}{
-					"sub": testAuthorID,
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"admin"},
 				},
 			},
 		},
@@ -759,7 +760,8 @@ func TestHandler_MissingCategoryID(t *testing.T) {
 		RequestContext: events.APIGatewayProxyRequestContext{
 			Authorizer: map[string]interface{}{
 				"claims": map[string]interface{}{
-					"sub": testAuthorID,
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"admin"},
 				},
 			},
 		},
@@ -1125,3 +1127,35 @@ func TestHandler_TransactWriteError(t *testing.T) {
 
 // Ensure unused import warning is silenced
 var _ = aws.String
+
+// createNonAdminRequest builds a request from a signed-in user who is not in
+// the admin group. Categories are site-wide, so this must be rejected.
+func createNonAdminRequest(categoryID, body string) events.APIGatewayProxyRequest {
+	return events.APIGatewayProxyRequest{
+		Body:           body,
+		PathParameters: map[string]string{"id": categoryID},
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{
+				"claims": map[string]interface{}{
+					"sub":            testAuthorID,
+					"cognito:groups": []string{"editor"},
+				},
+			},
+		},
+	}
+}
+
+// TestHandler_NonAdminForbidden guards the authorization rule added in #488:
+// before it, any authenticated Cognito user could mutate categories.
+func TestHandler_NonAdminForbidden(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	resp, err := Handler(context.Background(), createNonAdminRequest("cat-1", `{"name":"テスト"}`))
+	if err != nil {
+		t.Fatalf("Handler returned unexpected error: %v", err)
+	}
+	if resp.StatusCode != 403 {
+		t.Errorf("StatusCode = %d, want 403", resp.StatusCode)
+	}
+}

--- a/go-functions/cmd/posts/build_status/main.go
+++ b/go-functions/cmd/posts/build_status/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
 	"github.com/aws/aws-sdk-go-v2/service/codebuild/types"
 
+	"serverless-blog/go-functions/internal/auth"
 	"serverless-blog/go-functions/internal/buildtrigger"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
@@ -47,7 +48,7 @@ type BuildStatusResponse struct {
 
 // Handler handles GET /admin/posts/{id}/build-status.
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	if userID := getUserIDFromRequest(request); userID == "" {
+	if userID := auth.UserID(request); userID == "" {
 		return errorResponse(401, "unauthorized")
 	}
 
@@ -126,29 +127,6 @@ func mapBuildStatus(status types.StatusType) string {
 	default:
 		return "idle"
 	}
-}
-
-func getUserIDFromRequest(request events.APIGatewayProxyRequest) string {
-	if request.RequestContext.Authorizer == nil {
-		return ""
-	}
-	claims, ok := request.RequestContext.Authorizer["claims"]
-	if !ok || claims == nil {
-		return ""
-	}
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-	sub, ok := claimsMap["sub"]
-	if !ok {
-		return ""
-	}
-	userID, ok := sub.(string)
-	if !ok {
-		return ""
-	}
-	return userID
 }
 
 func errorResponse(statusCode int, message string) (events.APIGatewayProxyResponse, error) {

--- a/go-functions/cmd/posts/create/main.go
+++ b/go-functions/cmd/posts/create/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/google/uuid"
 
+	"serverless-blog/go-functions/internal/auth"
 	"serverless-blog/go-functions/internal/buildtrigger"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
@@ -70,7 +71,7 @@ var uuidGenerator = func() string {
 //nolint:gocyclo // validates auth, body, slug uniqueness, and triggers CodeBuild — branches add up but flow is linear.
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Extract author ID from Cognito claims (authentication check)
-	authorID := extractAuthorID(request)
+	authorID := auth.UserID(request)
 	if authorID == "" {
 		return errorResponse(401, "unauthorized")
 	}
@@ -182,35 +183,6 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 
 	// Return created post with 201 status
 	return middleware.JSONResponse(201, post)
-}
-
-// extractAuthorID extracts the user ID from Cognito authorizer claims
-func extractAuthorID(request events.APIGatewayProxyRequest) string {
-	if request.RequestContext.Authorizer == nil {
-		return ""
-	}
-
-	claims, ok := request.RequestContext.Authorizer["claims"]
-	if !ok {
-		return ""
-	}
-
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	sub, ok := claimsMap["sub"]
-	if !ok {
-		return ""
-	}
-
-	subStr, ok := sub.(string)
-	if !ok {
-		return ""
-	}
-
-	return subStr
 }
 
 // errorResponse creates an error response with CORS headers

--- a/go-functions/cmd/posts/delete/main.go
+++ b/go-functions/cmd/posts/delete/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 
+	"serverless-blog/go-functions/internal/auth"
 	"serverless-blog/go-functions/internal/buildtrigger"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
@@ -63,7 +64,7 @@ var codebuildClientGetter = clients.GetCodeBuild
 // Handler handles DELETE /posts/:id requests
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Validate authentication first
-	userID := getUserIDFromRequest(request)
+	userID := auth.UserID(request)
 	if userID == "" {
 		return errorResponse(401, "unauthorized")
 	}
@@ -239,41 +240,6 @@ func extractS3KeyFromURL(imageURL string) string {
 
 	// Remove leading slash from path
 	return strings.TrimPrefix(parsedURL.Path, "/")
-}
-
-// getUserIDFromRequest extracts the user ID from the request context
-// Returns empty string if user is not authenticated
-func getUserIDFromRequest(request events.APIGatewayProxyRequest) string {
-	// Check if authorizer is present
-	if request.RequestContext.Authorizer == nil {
-		return ""
-	}
-
-	// Get claims from authorizer
-	claims, ok := request.RequestContext.Authorizer["claims"]
-	if !ok || claims == nil {
-		return ""
-	}
-
-	// Type assert claims to map
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	// Get sub (user ID) from claims
-	sub, ok := claimsMap["sub"]
-	if !ok {
-		return ""
-	}
-
-	// Type assert sub to string
-	userID, ok := sub.(string)
-	if !ok || userID == "" {
-		return ""
-	}
-
-	return userID
 }
 
 // errorResponse creates an error response with CORS headers

--- a/go-functions/cmd/posts/get/main.go
+++ b/go-functions/cmd/posts/get/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
+	"serverless-blog/go-functions/internal/auth"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
 	"serverless-blog/go-functions/internal/middleware"
@@ -35,7 +36,7 @@ var dynamoClientGetter = func() (DynamoDBClientInterface, error) {
 // Handler handles GET /posts/:id requests (authenticated)
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Validate authentication first
-	userID := getUserIDFromRequest(request)
+	userID := auth.UserID(request)
 	if userID == "" {
 		return errorResponse(401, "unauthorized")
 	}
@@ -89,41 +90,6 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	}
 
 	return middleware.JSONResponse(200, post)
-}
-
-// getUserIDFromRequest extracts the user ID from the request context
-// Returns empty string if user is not authenticated
-func getUserIDFromRequest(request events.APIGatewayProxyRequest) string {
-	// Check if authorizer is present
-	if request.RequestContext.Authorizer == nil {
-		return ""
-	}
-
-	// Get claims from authorizer
-	claims, ok := request.RequestContext.Authorizer["claims"]
-	if !ok || claims == nil {
-		return ""
-	}
-
-	// Type assert claims to map
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	// Get sub (user ID) from claims
-	sub, ok := claimsMap["sub"]
-	if !ok {
-		return ""
-	}
-
-	// Type assert sub to string
-	userID, ok := sub.(string)
-	if !ok || userID == "" {
-		return ""
-	}
-
-	return userID
 }
 
 // errorResponse creates an error response with CORS headers

--- a/go-functions/cmd/posts/update/main.go
+++ b/go-functions/cmd/posts/update/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
+	"serverless-blog/go-functions/internal/auth"
 	"serverless-blog/go-functions/internal/buildtrigger"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
@@ -137,7 +138,7 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 // Returns postID, request, userID, and error response
 func validateAndParseRequest(request events.APIGatewayProxyRequest) (postID string, req *domain.UpdatePostRequest, userID string, errResp *events.APIGatewayProxyResponse) {
 	// Validate authentication
-	userID = getUserIDFromRequest(request)
+	userID = auth.UserID(request)
 	if userID == "" {
 		resp, _ := errorResponse(401, "unauthorized")
 		return "", nil, "", &resp
@@ -440,41 +441,6 @@ type validationError struct {
 
 func (e *validationError) Error() string {
 	return e.message
-}
-
-// getUserIDFromRequest extracts the user ID from the request context
-// Returns empty string if user is not authenticated
-func getUserIDFromRequest(request events.APIGatewayProxyRequest) string {
-	// Check if authorizer is present
-	if request.RequestContext.Authorizer == nil {
-		return ""
-	}
-
-	// Get claims from authorizer
-	claims, ok := request.RequestContext.Authorizer["claims"]
-	if !ok || claims == nil {
-		return ""
-	}
-
-	// Type assert claims to map
-	claimsMap, ok := claims.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	// Get sub (user ID) from claims
-	sub, ok := claimsMap["sub"]
-	if !ok {
-		return ""
-	}
-
-	// Type assert sub to string
-	userID, ok := sub.(string)
-	if !ok || userID == "" {
-		return ""
-	}
-
-	return userID
 }
 
 // errorResponse creates an error response with CORS headers

--- a/go-functions/internal/auth/claims.go
+++ b/go-functions/internal/auth/claims.go
@@ -1,0 +1,128 @@
+// Package auth reads identity information out of the Cognito authorizer
+// claims that API Gateway attaches to a Lambda proxy request.
+//
+// Every handler used to carry its own copy of the "pull sub out of the
+// claims map" logic. Keeping it in one place is what makes an authorization
+// rule like RequireGroup possible to apply consistently.
+package auth
+
+import (
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// AdminGroup is the Cognito group required to mutate site-wide resources
+// such as categories.
+const AdminGroup = "admin"
+
+// claimsMap returns the Cognito claims attached by the API Gateway
+// authorizer, or nil when the request is unauthenticated.
+func claimsMap(request events.APIGatewayProxyRequest) map[string]interface{} {
+	if request.RequestContext.Authorizer == nil {
+		return nil
+	}
+
+	claims, ok := request.RequestContext.Authorizer["claims"]
+	if !ok || claims == nil {
+		return nil
+	}
+
+	claimsMap, ok := claims.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return claimsMap
+}
+
+// UserID returns the Cognito subject (the stable user identifier) for the
+// request, or an empty string when the request carries no usable claims.
+func UserID(request events.APIGatewayProxyRequest) string {
+	claims := claimsMap(request)
+	if claims == nil {
+		return ""
+	}
+
+	sub, ok := claims["sub"]
+	if !ok {
+		return ""
+	}
+
+	subStr, ok := sub.(string)
+	if !ok {
+		return ""
+	}
+
+	return subStr
+}
+
+// Groups returns the Cognito groups the caller belongs to.
+//
+// The shape of the cognito:groups claim depends on how it reaches the
+// handler: API Gateway flattens the JWT's array claim, so it can arrive as a
+// real slice, as a bracketed string ("[admin editor]"), or as a plain
+// comma/space separated list. All three are accepted rather than assuming
+// one, because getting this wrong fails open or locks everyone out.
+func Groups(request events.APIGatewayProxyRequest) []string {
+	claims := claimsMap(request)
+	if claims == nil {
+		return nil
+	}
+
+	raw, ok := claims["cognito:groups"]
+	if !ok || raw == nil {
+		return nil
+	}
+
+	switch v := raw.(type) {
+	case []string:
+		return normalizeGroups(v)
+	case []interface{}:
+		groups := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				groups = append(groups, s)
+			}
+		}
+		return normalizeGroups(groups)
+	case string:
+		trimmed := strings.TrimSpace(v)
+		trimmed = strings.TrimPrefix(trimmed, "[")
+		trimmed = strings.TrimSuffix(trimmed, "]")
+		fields := strings.FieldsFunc(trimmed, func(r rune) bool {
+			return r == ',' || r == ' '
+		})
+		return normalizeGroups(fields)
+	default:
+		return nil
+	}
+}
+
+func normalizeGroups(groups []string) []string {
+	normalized := make([]string, 0, len(groups))
+	for _, g := range groups {
+		if trimmed := strings.TrimSpace(g); trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+// HasGroup reports whether the caller belongs to the named Cognito group.
+func HasGroup(request events.APIGatewayProxyRequest, group string) bool {
+	for _, g := range Groups(request) {
+		if g == group {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAdmin reports whether the caller may mutate site-wide resources.
+func IsAdmin(request events.APIGatewayProxyRequest) bool {
+	return HasGroup(request, AdminGroup)
+}

--- a/go-functions/internal/auth/claims_test.go
+++ b/go-functions/internal/auth/claims_test.go
@@ -1,0 +1,162 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func requestWithClaims(claims map[string]interface{}) events.APIGatewayProxyRequest {
+	return events.APIGatewayProxyRequest{
+		RequestContext: events.APIGatewayProxyRequestContext{
+			Authorizer: map[string]interface{}{"claims": claims},
+		},
+	}
+}
+
+func TestUserID(t *testing.T) {
+	tests := []struct {
+		name    string
+		request events.APIGatewayProxyRequest
+		want    string
+	}{
+		{
+			name:    "returns the sub claim",
+			request: requestWithClaims(map[string]interface{}{"sub": "user-123"}),
+			want:    "user-123",
+		},
+		{
+			name:    "empty when there is no authorizer",
+			request: events.APIGatewayProxyRequest{},
+			want:    "",
+		},
+		{
+			name: "empty when claims are missing",
+			request: events.APIGatewayProxyRequest{
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "empty when claims are not a map",
+			request: events.APIGatewayProxyRequest{
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{"claims": "not-a-map"},
+				},
+			},
+			want: "",
+		},
+		{
+			name:    "empty when sub is absent",
+			request: requestWithClaims(map[string]interface{}{"email": "a@example.com"}),
+			want:    "",
+		},
+		{
+			name:    "empty when sub is not a string",
+			request: requestWithClaims(map[string]interface{}{"sub": 42}),
+			want:    "",
+		},
+		{
+			name: "empty when claims are nil",
+			request: events.APIGatewayProxyRequest{
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: map[string]interface{}{"claims": nil},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UserID(tt.request); got != tt.want {
+				t.Errorf("UserID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// API Gateway does not deliver the cognito:groups array claim in a single
+// shape, so every form we might receive has to resolve to the same answer.
+func TestGroupsAcceptsEveryClaimShape(t *testing.T) {
+	tests := []struct {
+		name  string
+		claim interface{}
+		want  []string
+	}{
+		{name: "string slice", claim: []string{"admin", "editor"}, want: []string{"admin", "editor"}},
+		{name: "interface slice", claim: []interface{}{"admin", "editor"}, want: []string{"admin", "editor"}},
+		{name: "bracketed space separated", claim: "[admin editor]", want: []string{"admin", "editor"}},
+		{name: "comma separated", claim: "admin,editor", want: []string{"admin", "editor"}},
+		{name: "comma space separated", claim: "admin, editor", want: []string{"admin", "editor"}},
+		{name: "single value", claim: "admin", want: []string{"admin"}},
+		{name: "bracketed single value", claim: "[admin]", want: []string{"admin"}},
+		{name: "empty string", claim: "", want: nil},
+		{name: "empty brackets", claim: "[]", want: nil},
+		{name: "empty slice", claim: []string{}, want: nil},
+		{name: "unexpected type", claim: 42, want: nil},
+		{name: "slice with non-strings", claim: []interface{}{"admin", 7}, want: []string{"admin"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Groups(requestWithClaims(map[string]interface{}{"cognito:groups": tt.claim}))
+			if len(got) != len(tt.want) {
+				t.Fatalf("Groups() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("Groups()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGroupsWithoutClaim(t *testing.T) {
+	if got := Groups(requestWithClaims(map[string]interface{}{"sub": "user-123"})); got != nil {
+		t.Errorf("Groups() = %v, want nil", got)
+	}
+	if got := Groups(events.APIGatewayProxyRequest{}); got != nil {
+		t.Errorf("Groups() = %v, want nil", got)
+	}
+	if got := Groups(requestWithClaims(map[string]interface{}{"cognito:groups": nil})); got != nil {
+		t.Errorf("Groups() = %v, want nil", got)
+	}
+}
+
+func TestIsAdmin(t *testing.T) {
+	tests := []struct {
+		name  string
+		claim interface{}
+		want  bool
+	}{
+		{name: "member of admin", claim: []string{"admin"}, want: true},
+		{name: "member of admin among others", claim: "[editor admin]", want: true},
+		{name: "not a member", claim: []string{"editor"}, want: false},
+		{name: "no groups at all", claim: nil, want: false},
+		// Guards against a prefix match letting the wrong group through.
+		{name: "similar group name", claim: []string{"administrators"}, want: false},
+		{name: "case mismatch is not a member", claim: []string{"Admin"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := map[string]interface{}{"sub": "user-123"}
+			if tt.claim != nil {
+				claims["cognito:groups"] = tt.claim
+			}
+			if got := IsAdmin(requestWithClaims(claims)); got != tt.want {
+				t.Errorf("IsAdmin() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasGroupOnUnauthenticatedRequest(t *testing.T) {
+	if HasGroup(events.APIGatewayProxyRequest{}, AdminGroup) {
+		t.Error("HasGroup() = true for an unauthenticated request, want false")
+	}
+}

--- a/terraform/modules/auth/main.tf
+++ b/terraform/modules/auth/main.tf
@@ -128,3 +128,20 @@ resource "aws_ssm_parameter" "user_pool_client_id" {
 
   tags = local.tags
 }
+
+# Admin group
+# Categories are site-wide resources. The category Lambdas require the caller
+# to be in this group, so being a signed-in Cognito user is not by itself
+# enough to change them (see issue #488).
+#
+# Membership is NOT managed here: the user pool's users are created out of
+# band (allow_admin_create_user_only = true), so Terraform has no list of
+# usernames to attach. Add an existing user with:
+#   aws cognito-idp admin-add-user-to-group \
+#     --user-pool-id <pool-id> --username <username> --group-name admin
+resource "aws_cognito_user_group" "admin" {
+  name         = "admin"
+  user_pool_id = aws_cognito_user_pool.main.id
+  description  = "Users allowed to manage site-wide resources such as categories"
+  precedence   = 0
+}


### PR DESCRIPTION
## 概要

カテゴリはサイト全体で共有されるリソースなのに、変更系4ハンドラは **Cognito の `sub` クレームが存在すること**しか見ていなかった。記事には `authorID` による所有者チェックがあるのに、カテゴリは認証さえ通れば誰でも作成・改名・削除できる状態だった。

Closes #488

## 危険度について（正直に）

Cognito は `allow_admin_create_user_only = true` で**自己登録が無効**なため、プールに存在するのはあなたが手動作成したユーザーのみ。したがってこれは**現に悪用可能な穴ではなく、多層防御の欠落**。緊急度は高くないが、ユーザーを増やした瞬間に実害化する類のもの。

## ⚠️ マージ後に必要な手動作業

**この PR は認可を即時有効化します。** グループは空の状態で作られるため、あなた自身をグループに追加するまでカテゴリの作成・編集・削除が 403 になります。デプロイ後に1度だけ実行してください:

```bash
aws cognito-idp admin-add-user-to-group \
  --user-pool-id $(aws ssm get-parameter --name "/serverless-blog/dev/cognito/user-pool-id" --query "Parameter.Value" --output text) \
  --username <あなたのユーザー名> \
  --group-name admin
```

prd も同様（`/serverless-blog/prd/...`）。ユーザーはプール外で作成されているため Terraform では所属を管理できません（その旨をコード内コメントにも残しています）。読み取り系（`GET /categories`）と記事側は影響を受けません。

## 変更内容

**`internal/auth` パッケージを新設**
- 9ハンドラにコピペされていた `extractAuthorID` / `getUserIDFromRequest` を集約（実装は完全に同一だった）
- `Groups()` は API Gateway が `cognito:groups` を渡しうる**すべての形**を受け付ける（実スライス / `[admin editor]` のような角括弧付き文字列 / カンマ区切り / スペース区切り）。ここを1つの形だけ想定すると、外した場合に**fail open になるか全員を締め出すか**のどちらかになるため、防御的に実装した

**認可の追加**
- `categories/{create,update,delete,bulk_sort}` が管理者グループ非所属なら 403
- チェックはボディ解析より**前**に置いた（403 が確実に認可由来であることをテストで担保できる）

**Terraform**
- `aws_cognito_user_group.admin` を追加

## 検証

| 対象 | 結果 |
|---|---|
| `internal/auth` 単体 | **100% カバレッジ**（クレーム形状12パターン + 境界ケース） |
| Go 全体テスト | 29パッケージ green、**総カバレッジ 91.8%**（90% ゲート維持） |
| `make build` | 18関数すべて成功 |
| `golangci-lint`（CI と同じ v2.11 + Go 1.25.12） | **0 issues** |
| `terraform validate`（modules/auth） | Success |

各ハンドラに **403 の回帰テスト**を追加した（`TestHandler_NonAdminForbidden`）。「認証済みだが admin ではない」ユーザーが弾かれることを検証しており、この認可が将来消えたら落ちる。

`Groups()` のテストには「`administrators` が `admin` として通らないこと」「大文字小文字違いが通らないこと」も含めた（前方一致で誤って通す実装を防ぐため）。

### 既存の失敗について

`terraform/modules/auth` の `terraform test` は **21 passed / 4 failed** ですが、develop でも同じ4件が失敗することを確認済みです（`aws_cognito_user_pool_client` の name と refresh_token_validity に関するもので、本 PR とは無関係）。別途対応が必要なら Issue 化します。

## スコープから外したもの

Issue には `errorResponse`（18ハンドラに複製）の共通化も含めていましたが、**本 PR では行いませんでした**。#490（ハンドラへのログ導入）でエラー応答の作りを見直すため、そこで一緒に片付けるほうが同じファイルを2度大きく触らずに済むためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)