### PR TITLE
security(terraform): Lambda IAM ロールを最小権限に分割する

### DIFF
--- a/terraform/modules/lambda/README.md
+++ b/terraform/modules/lambda/README.md
@@ -55,9 +55,13 @@ module "lambda" {
 | Name | Type |
 |------|------|
 | aws_lambda_function.* | resource |
-| aws_iam_role.lambda_posts | resource |
+| aws_iam_role.lambda_posts_read | resource |
+| aws_iam_role.lambda_posts_write | resource |
+| aws_iam_role.lambda_posts_build_status | resource |
 | aws_iam_role.lambda_auth | resource |
 | aws_iam_role.lambda_images | resource |
+| aws_iam_role.lambda_categories_read | resource |
+| aws_iam_role.lambda_categories_write | resource |
 | aws_iam_policy.* | resource |
 | aws_cloudwatch_log_group.* | resource |
 | data.archive_file.* | data source |
@@ -86,9 +90,13 @@ module "lambda" {
 | function_arns | Map of Lambda function ARNs |
 | function_invoke_arns | Map of Lambda function Invoke ARNs for API Gateway |
 | function_names | List of all Lambda function names |
-| posts_role_arn | Posts domain Lambda execution role ARN |
+| posts_read_role_arn | Posts domain read-only Lambda execution role ARN |
+| posts_write_role_arn | Posts domain write Lambda execution role ARN |
+| posts_build_status_role_arn | Posts domain build-status Lambda execution role ARN |
 | auth_role_arn | Auth domain Lambda execution role ARN |
 | images_role_arn | Images domain Lambda execution role ARN |
+| categories_read_role_arn | Categories domain read-only Lambda execution role ARN |
+| categories_write_role_arn | Categories domain write Lambda execution role ARN |
 | *_function_arn | 個別の関数ARN |
 | *_function_name | 個別の関数名 |
 
@@ -131,16 +139,71 @@ module "lambda" {
 
 ## IAMロール構成
 
-最小権限原則に基づき、関数グループ別にIAMロールを分離:
+最小権限原則に基づき、関数グループ別・読み取り/書き込み別にIAMロールを分離しています
+（issue #493）。各アクションは go-functions/cmd/** の実装から直接確認したものです。
 
-### posts ロール
+### posts_read ロール
+
+対象: get_post, get_public_post, list_posts, get_post_by_slug
+
+```
+- dynamodb:GetItem
+- dynamodb:Query
+- logs:CreateLogGroup
+- logs:CreateLogStream
+- logs:PutLogEvents
+```
+
+### posts_write ロール
+
+対象: create_post, update_post, delete_post
 
 ```
 - dynamodb:GetItem
 - dynamodb:PutItem
-- dynamodb:UpdateItem
 - dynamodb:DeleteItem
 - dynamodb:Query
+- s3:DeleteObject / s3:DeleteObjects   (delete_post の画像カスケード削除)
+- codebuild:StartBuild / ListBuildsForProject / BatchGetBuilds
+- logs:CreateLogGroup
+- logs:CreateLogStream
+- logs:PutLogEvents
+```
+
+### posts_build_status ロール
+
+対象: build_status_post のみ。ビルド状態のポーリングのみを行い、DynamoDB/S3には
+アクセスせず、ビルドの開始（StartBuild）もしない。
+
+```
+- codebuild:ListBuildsForProject / BatchGetBuilds
+- logs:CreateLogGroup
+- logs:CreateLogStream
+- logs:PutLogEvents
+```
+
+### categories_read ロール
+
+対象: list_categories のみ（認証不要・公開）
+
+```
+- dynamodb:Scan
+- logs:CreateLogGroup
+- logs:CreateLogStream
+- logs:PutLogEvents
+```
+
+### categories_write ロール
+
+対象: create_category, update_category, delete_category, update_categories_sort_order
+
+Categories テーブル、BlogPosts テーブルの双方にアクセスする（update_category は
+カテゴリのスラッグ変更時に該当カテゴリの全記事の category フィールドを
+TransactWriteItems で書き換えるため）。
+
+```
+- dynamodb:Scan / PutItem / GetItem / UpdateItem / DeleteItem / Query / BatchGetItem  (Categoriesテーブル)
+- dynamodb:Query / UpdateItem  (BlogPostsテーブル - update_category のカスケード更新用)
 - logs:CreateLogGroup
 - logs:CreateLogStream
 - logs:PutLogEvents
@@ -193,8 +256,8 @@ import {
 }
 
 import {
-  to = aws_iam_role.lambda_posts
-  id = "lambda-posts-role"
+  to = aws_iam_role.lambda_posts_write
+  id = "blog-lambda-posts-write-role"
 }
 ```
 

--- a/terraform/modules/lambda/iam.tf
+++ b/terraform/modules/lambda/iam.tf
@@ -1,11 +1,27 @@
 # Lambda IAM Roles and Policies
 # Requirements: 4.2, 6.5, 12.6
 #
-# This file implements function group-specific IAM roles following
-# the principle of least privilege:
-# - Posts domain: DynamoDB access + S3 read for delete cascade
-# - Auth domain: Cognito access only
-# - Images domain: S3 access only
+# Issue #493: split the former domain-wide roles into least-privilege
+# read/write roles so a public, read-only Lambda never holds write or
+# delete permissions. Every action below was verified directly against
+# the Go handler source under go-functions/cmd/** (not assumed) — see the
+# API audit table in the PR description for the per-handler evidence.
+#
+# - Posts domain:
+#   - lambda_posts_read         - GetItem/Query only (public + admin reads)
+#   - lambda_posts_write        - GetItem/PutItem/DeleteItem/Query + S3 delete
+#                                 cascade + CodeBuild trigger (create/update/delete)
+#   - lambda_posts_build_status - CodeBuild List/BatchGet only (polls build
+#                                 status; never starts a build, never touches
+#                                 DynamoDB or S3)
+# - Auth domain: Cognito access only (unchanged - already least privilege)
+# - Images domain: S3 access only (unchanged - out of scope for #493)
+# - Categories domain:
+#   - lambda_categories_read  - Scan only (list_categories, public)
+#   - lambda_categories_write - full Categories table access (including
+#                               TransactWriteItems-backed slug reservation)
+#                               plus BlogPosts Query/UpdateItem for the
+#                               category-rename cascade
 
 # ======================
 # IAM Assume Role Policy (shared)
@@ -24,46 +40,42 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 # ======================
-# Posts Domain IAM Role
+# Posts Domain - Read-Only Role
+# Used by: get_post, get_public_post, list_posts, get_post_by_slug
+# All four handlers only ever call dynamodb GetItem/Query (verified: none
+# of them import the S3 or CodeBuild SDK clients).
 # ======================
 
-resource "aws_iam_role" "lambda_posts" {
-  name               = "blog-lambda-posts-role"
+resource "aws_iam_role" "lambda_posts_read" {
+  name               = "blog-lambda-posts-read-role"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
   tags               = local.common_tags
 }
 
-# Basic execution policy for CloudWatch Logs
-resource "aws_iam_role_policy_attachment" "lambda_posts_basic_execution" {
-  role       = aws_iam_role.lambda_posts.name
+resource "aws_iam_role_policy_attachment" "lambda_posts_read_basic_execution" {
+  role       = aws_iam_role.lambda_posts_read.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
-# X-Ray policy (prd only)
-resource "aws_iam_role_policy_attachment" "lambda_posts_xray" {
+resource "aws_iam_role_policy_attachment" "lambda_posts_read_xray" {
   count      = var.enable_xray ? 1 : 0
-  role       = aws_iam_role.lambda_posts.name
+  role       = aws_iam_role.lambda_posts_read.name
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 }
 
-# DynamoDB access policy for Posts domain
-resource "aws_iam_role_policy" "lambda_posts_dynamodb" {
-  name = "blog-lambda-posts-dynamodb-policy"
-  role = aws_iam_role.lambda_posts.id
+resource "aws_iam_role_policy" "lambda_posts_read_dynamodb" {
+  name = "blog-lambda-posts-read-dynamodb-policy"
+  role = aws_iam_role.lambda_posts_read.id
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "DynamoDBTableAccess"
+        Sid    = "DynamoDBTableReadOnly"
         Effect = "Allow"
         Action = [
           "dynamodb:GetItem",
-          "dynamodb:PutItem",
-          "dynamodb:UpdateItem",
-          "dynamodb:DeleteItem",
-          "dynamodb:Query",
-          "dynamodb:Scan"
+          "dynamodb:Query"
         ]
         Resource = [
           var.table_arn,
@@ -74,10 +86,67 @@ resource "aws_iam_role_policy" "lambda_posts_dynamodb" {
   })
 }
 
-# S3 read/delete access for delete cascade (deletePost needs to delete images)
-resource "aws_iam_role_policy" "lambda_posts_s3_cascade" {
-  name = "blog-lambda-posts-s3-cascade-policy"
-  role = aws_iam_role.lambda_posts.id
+# ======================
+# Posts Domain - Write Role
+# Used by: create_post, update_post, delete_post
+#
+# API usage confirmed per handler:
+#   create_post -> dynamodb PutItem, Query (slug uniqueness check)
+#   update_post -> dynamodb GetItem, PutItem, Query (slug change check)
+#   delete_post -> dynamodb GetItem, DeleteItem; s3 DeleteObjects (image
+#                  cascade, only when the post has ImageURLs)
+# None of the three call dynamodb UpdateItem or Scan directly, so those
+# actions are intentionally omitted.
+# All three conditionally trigger a site rebuild via CodeBuild.
+# ======================
+
+resource "aws_iam_role" "lambda_posts_write" {
+  name               = "blog-lambda-posts-write-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_posts_write_basic_execution" {
+  role       = aws_iam_role.lambda_posts_write.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_posts_write_xray" {
+  count      = var.enable_xray ? 1 : 0
+  role       = aws_iam_role.lambda_posts_write.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+# DynamoDB access policy for Posts write role
+resource "aws_iam_role_policy" "lambda_posts_write_dynamodb" {
+  name = "blog-lambda-posts-write-dynamodb-policy"
+  role = aws_iam_role.lambda_posts_write.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "DynamoDBTableReadWrite"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query"
+        ]
+        Resource = [
+          var.table_arn,
+          "${var.table_arn}/index/*"
+        ]
+      }
+    ]
+  })
+}
+
+# S3 delete access for delete cascade (deletePost needs to delete images)
+resource "aws_iam_role_policy" "lambda_posts_write_s3_cascade" {
+  name = "blog-lambda-posts-write-s3-cascade-policy"
+  role = aws_iam_role.lambda_posts_write.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -98,10 +167,10 @@ resource "aws_iam_role_policy" "lambda_posts_s3_cascade" {
 # CodeBuild access for triggering site rebuilds
 # Requirement 10.4: Lambda execution role with codebuild:StartBuild permission
 # Requirement 10.3: ListBuildsForProject and BatchGetBuilds for idempotency handling
-resource "aws_iam_role_policy" "lambda_posts_codebuild" {
+resource "aws_iam_role_policy" "lambda_posts_write_codebuild" {
   count = var.codebuild_project_arn != "" ? 1 : 0
-  name  = "blog-lambda-posts-codebuild-policy"
-  role  = aws_iam_role.lambda_posts.id
+  name  = "blog-lambda-posts-write-codebuild-policy"
+  role  = aws_iam_role.lambda_posts_write.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -121,7 +190,59 @@ resource "aws_iam_role_policy" "lambda_posts_codebuild" {
 }
 
 # ======================
+# Posts Domain - Build Status Role
+# Used by: build_status_post only.
+#
+# Confirmed this handler never calls dynamodb or s3 (it only polls
+# CodeBuild), and never calls codebuild:StartBuild - it only reads the
+# status of builds someone else started. Giving it the full write role
+# would hand a read-only "poll build status" endpoint the ability to
+# start arbitrary builds and mutate posts/images, which is exactly the
+# over-provisioning issue #493 exists to fix.
+# ======================
+
+resource "aws_iam_role" "lambda_posts_build_status" {
+  name               = "blog-lambda-posts-build-status-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_posts_build_status_basic_execution" {
+  role       = aws_iam_role.lambda_posts_build_status.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_posts_build_status_xray" {
+  count      = var.enable_xray ? 1 : 0
+  role       = aws_iam_role.lambda_posts_build_status.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+resource "aws_iam_role_policy" "lambda_posts_build_status_codebuild" {
+  count = var.codebuild_project_arn != "" ? 1 : 0
+  name  = "blog-lambda-posts-build-status-codebuild-policy"
+  role  = aws_iam_role.lambda_posts_build_status.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CodeBuildStatusPoll"
+        Effect = "Allow"
+        Action = [
+          "codebuild:ListBuildsForProject",
+          "codebuild:BatchGetBuilds"
+        ]
+        Resource = var.codebuild_project_arn
+      }
+    ]
+  })
+}
+
+# ======================
 # Auth Domain IAM Role
+# Out of scope for #493 - already scoped to InitiateAuth /
+# RespondToAuthChallenge / GlobalSignOut only (no DynamoDB/S3 access).
 # ======================
 
 resource "aws_iam_role" "lambda_auth" {
@@ -167,6 +288,10 @@ resource "aws_iam_role_policy" "lambda_auth_cognito" {
 
 # ======================
 # Images Domain IAM Role
+# Out of scope for #493 - both functions genuinely need S3 read/write/delete
+# on the shared bucket (get_upload_url presigns a PUT, which requires
+# s3:PutObject on the signing credentials even though the Lambda itself
+# never calls S3; delete_image calls s3:DeleteObject directly).
 # ======================
 
 resource "aws_iam_role" "lambda_images" {
@@ -211,35 +336,100 @@ resource "aws_iam_role_policy" "lambda_images_s3" {
 }
 
 # ======================
-# Categories Domain IAM Role
-# Requirement 2.2: Lambda function IAM role with Categories table Scan permission
+# Categories Domain - Read-Only Role
+# Used by: list_categories only (public, no auth).
+# Confirmed this handler only ever calls dynamodb Scan on the base table
+# (no Query/GetItem, no index usage) to load and sort all categories.
 # ======================
 
-resource "aws_iam_role" "lambda_categories" {
-  name               = "blog-lambda-categories-role"
+resource "aws_iam_role" "lambda_categories_read" {
+  name               = "blog-lambda-categories-read-role"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
   tags               = local.common_tags
 }
 
-# Basic execution policy for CloudWatch Logs
-resource "aws_iam_role_policy_attachment" "lambda_categories_basic_execution" {
-  role       = aws_iam_role.lambda_categories.name
+resource "aws_iam_role_policy_attachment" "lambda_categories_read_basic_execution" {
+  role       = aws_iam_role.lambda_categories_read.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
-# X-Ray policy (prd only)
-resource "aws_iam_role_policy_attachment" "lambda_categories_xray" {
+resource "aws_iam_role_policy_attachment" "lambda_categories_read_xray" {
   count      = var.enable_xray ? 1 : 0
-  role       = aws_iam_role.lambda_categories.name
+  role       = aws_iam_role.lambda_categories_read.name
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 }
 
-# DynamoDB access policy for Categories domain
-# Requirement 2.2, 3.2, 4.2, 5.2: Scan, PutItem, GetItem, UpdateItem, DeleteItem, Query permissions for Categories table
-# Requirement 4.2, 5.2: Query, UpdateItem permissions for BlogPosts table (for category slug update cascade and delete validation)
-resource "aws_iam_role_policy" "lambda_categories_dynamodb" {
-  name = "blog-lambda-categories-dynamodb-policy"
-  role = aws_iam_role.lambda_categories.id
+resource "aws_iam_role_policy" "lambda_categories_read_dynamodb" {
+  name = "blog-lambda-categories-read-dynamodb-policy"
+  role = aws_iam_role.lambda_categories_read.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DynamoDBCategoriesScan"
+        Effect   = "Allow"
+        Action   = ["dynamodb:Scan"]
+        Resource = var.categories_table_arn
+      }
+    ]
+  })
+}
+
+# ======================
+# Categories Domain - Write Role
+# Used by: create_category, update_category, delete_category,
+#          update_categories_sort_order
+#
+# API usage confirmed per handler (all use TransactWriteItems for atomic
+# slug-reservation / bulk updates; per AWS docs, TransactWriteItems is
+# authorized via the underlying PutItem/UpdateItem/DeleteItem permissions
+# for each table touched, not a separate "TransactWriteItems" action):
+#   create_category -> Scan (conditional, computes max sortOrder when the
+#                       caller omits one), TransactWriteItems: Put category
+#                       + Put SLUG# reservation (both on Categories table)
+#   update_category -> GetItem, Query (SlugIndex), PutItem (non-slug-change
+#                       path); on slug change: TransactWriteItems spanning
+#                       BOTH tables in the same call - Put/Delete/Put on
+#                       Categories (category + slug reservation swap) AND
+#                       Update on BlogPosts (rewrites `category` on every
+#                       post in the renamed category, paginated at 100
+#                       items/call after a Query on BlogPosts CategoryIndex)
+#   delete_category -> GetItem (Categories); Query on BlogPosts
+#                       CategoryIndex (read-only in-use check - never
+#                       writes to BlogPosts); TransactWriteItems: Delete
+#                       category + Delete slug reservation (Categories only)
+#   update_categories_sort_order (bulk_sort) -> BatchGetItem (verifies all
+#                       category IDs exist), TransactWriteItems: N Updates
+#                       for sortOrder/updatedAt (Categories only)
+#
+# NOTE: dynamodb:BatchGetItem was NOT present in the pre-#493 combined
+# lambda_categories policy even though update_categories_sort_order calls
+# it on every invocation (go-functions/cmd/categories/bulk_sort/main.go)
+# - this was a latent gap in the original role. It is included here.
+# ======================
+
+resource "aws_iam_role" "lambda_categories_write" {
+  name               = "blog-lambda-categories-write-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_categories_write_basic_execution" {
+  role       = aws_iam_role.lambda_categories_write.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_categories_write_xray" {
+  count      = var.enable_xray ? 1 : 0
+  role       = aws_iam_role.lambda_categories_write.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+# DynamoDB access policy for Categories write role
+resource "aws_iam_role_policy" "lambda_categories_write_dynamodb" {
+  name = "blog-lambda-categories-write-dynamodb-policy"
+  role = aws_iam_role.lambda_categories_write.id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -253,7 +443,8 @@ resource "aws_iam_role_policy" "lambda_categories_dynamodb" {
           "dynamodb:GetItem",
           "dynamodb:UpdateItem",
           "dynamodb:DeleteItem",
-          "dynamodb:Query"
+          "dynamodb:Query",
+          "dynamodb:BatchGetItem"
         ]
         Resource = [
           var.categories_table_arn,

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -332,7 +332,7 @@ data "archive_file" "delete_image" {
 resource "aws_lambda_function" "create_post" {
   function_name = local.lambda_functions.create_post.name
   description   = local.lambda_functions.create_post.description
-  role          = aws_iam_role.lambda_posts.arn
+  role          = aws_iam_role.lambda_posts_write.arn
 
   filename         = data.archive_file.create_post.output_path
   source_code_hash = data.archive_file.create_post.output_base64sha256
@@ -362,7 +362,7 @@ resource "aws_lambda_function" "create_post" {
 resource "aws_lambda_function" "get_post" {
   function_name = local.lambda_functions.get_post.name
   description   = local.lambda_functions.get_post.description
-  role          = aws_iam_role.lambda_posts.arn
+  role          = aws_iam_role.lambda_posts_read.arn
 
   filename         = data.archive_file.get_post.output_path
   source_code_hash = data.archive_file.get_post.output_base64sha256
@@ -390,7 +390,7 @@ resource "aws_lambda_function" "get_post" {
 resource "aws_lambda_function" "get_public_post" {
   function_name = local.lambda_functions.get_public_post.name
   description   = local.lambda_functions.get_public_post.description
-  role          = aws_iam_role.lambda_posts.arn
+  role          = aws_iam_role.lambda_posts_read.arn
 
   filename         = data.archive_file.get_public_post.output_path
   source_code_hash = data.archive_file.get_public_post.output_base64sha256
@@ -418,7 +418,7 @@ resource "aws_lambda_function" "get_public_post" {
 resource "aws_lambda_function" "list_posts" {
   function_name = local.lambda_functions.list_posts.name
   description   = local.lambda_functions.list_posts.description
-  role          = aws_iam_role.lambda_posts.arn
+  role          = aws_iam_role.lambda_posts_read.arn
 
   filename         = data.archive_file.list_posts.output_path
   source_code_hash = data.archive_file.list_posts.output_base64sha256
@@ -447,7 +447,7 @@ resource "aws_lambda_function" "list_posts" {
 resource "aws_lambda_function" "update_post" {
   function_name = local.lambda_functions.update_post.name
   description   = local.lambda_functions.update_post.description
-  role          = aws_iam_role.lambda_posts.arn
+  role          = aws_iam_role.lambda_posts_write.arn
 
   filename         = data.archive_file.update_post.output_path
   source_code_hash = data.archive_file.update_post.output_base64sha256
@@ -478,7 +478,7 @@ resource "aws_lambda_function" "update_post" {
 resource "aws_lambda_function" "delete_post" {
   function_name = local.lambda_functions.delete_post.name
   description   = local.lambda_functions.delete_post.description
-  role          = aws_iam_role.lambda_posts.arn
+  role          = aws_iam_role.lambda_posts_write.arn
 
   filename         = data.archive_file.delete_post.output_path
   source_code_hash = data.archive_file.delete_post.output_base64sha256
@@ -510,7 +510,7 @@ resource "aws_lambda_function" "delete_post" {
 resource "aws_lambda_function" "build_status_post" {
   function_name = local.lambda_functions.build_status_post.name
   description   = local.lambda_functions.build_status_post.description
-  role          = aws_iam_role.lambda_posts.arn
+  role          = aws_iam_role.lambda_posts_build_status.arn
 
   filename         = data.archive_file.build_status_post.output_path
   source_code_hash = data.archive_file.build_status_post.output_base64sha256
@@ -538,12 +538,12 @@ resource "aws_lambda_function" "build_status_post" {
 
 # GET /posts/by-slug/{slug} - Public post fetch by friendly slug (PR7).
 # No-auth public endpoint that powers Astro's slug-based static routing.
-# Reuses the lambda_posts role: dynamodb:Query on SlugIndex is already
+# Uses the lambda_posts_read role: dynamodb:Query on SlugIndex is already
 # permitted via the existing index/* grant.
 resource "aws_lambda_function" "get_post_by_slug" {
   function_name = local.lambda_functions.get_post_by_slug.name
   description   = local.lambda_functions.get_post_by_slug.description
-  role          = aws_iam_role.lambda_posts.arn
+  role          = aws_iam_role.lambda_posts_read.arn
 
   filename         = data.archive_file.get_post_by_slug.output_path
   source_code_hash = data.archive_file.get_post_by_slug.output_base64sha256
@@ -737,7 +737,7 @@ data "archive_file" "list_categories" {
 resource "aws_lambda_function" "list_categories" {
   function_name = local.lambda_functions.list_categories.name
   description   = local.lambda_functions.list_categories.description
-  role          = aws_iam_role.lambda_categories.arn
+  role          = aws_iam_role.lambda_categories_read.arn
 
   filename         = data.archive_file.list_categories.output_path
   source_code_hash = data.archive_file.list_categories.output_base64sha256
@@ -785,7 +785,7 @@ data "archive_file" "create_category" {
 resource "aws_lambda_function" "create_category" {
   function_name = local.lambda_functions.create_category.name
   description   = local.lambda_functions.create_category.description
-  role          = aws_iam_role.lambda_categories.arn
+  role          = aws_iam_role.lambda_categories_write.arn
 
   filename         = data.archive_file.create_category.output_path
   source_code_hash = data.archive_file.create_category.output_base64sha256
@@ -832,7 +832,7 @@ data "archive_file" "update_category" {
 resource "aws_lambda_function" "update_category" {
   function_name = local.lambda_functions.update_category.name
   description   = local.lambda_functions.update_category.description
-  role          = aws_iam_role.lambda_categories.arn
+  role          = aws_iam_role.lambda_categories_write.arn
 
   filename         = data.archive_file.update_category.output_path
   source_code_hash = data.archive_file.update_category.output_base64sha256
@@ -881,7 +881,7 @@ data "archive_file" "update_categories_sort_order" {
 resource "aws_lambda_function" "update_categories_sort_order" {
   function_name = local.lambda_functions.update_categories_sort_order.name
   description   = local.lambda_functions.update_categories_sort_order.description
-  role          = aws_iam_role.lambda_categories.arn
+  role          = aws_iam_role.lambda_categories_write.arn
 
   filename         = data.archive_file.update_categories_sort_order.output_path
   source_code_hash = data.archive_file.update_categories_sort_order.output_base64sha256
@@ -928,7 +928,7 @@ data "archive_file" "delete_category" {
 resource "aws_lambda_function" "delete_category" {
   function_name = local.lambda_functions.delete_category.name
   description   = local.lambda_functions.delete_category.description
-  role          = aws_iam_role.lambda_categories.arn
+  role          = aws_iam_role.lambda_categories_write.arn
 
   filename         = data.archive_file.delete_category.output_path
   source_code_hash = data.archive_file.delete_category.output_base64sha256

--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -89,15 +89,35 @@ output "function_names" {
 # IAM Role Outputs (Function Group-Specific)
 # ======================
 
-# Posts Domain Role
-output "posts_role_arn" {
-  value       = aws_iam_role.lambda_posts.arn
-  description = "Posts domain Lambda execution role ARN"
+# Posts Domain Roles (split into read/write/build-status - see issue #493)
+output "posts_read_role_arn" {
+  value       = aws_iam_role.lambda_posts_read.arn
+  description = "Posts domain read-only Lambda execution role ARN"
 }
 
-output "posts_role_name" {
-  value       = aws_iam_role.lambda_posts.name
-  description = "Posts domain Lambda execution role name"
+output "posts_read_role_name" {
+  value       = aws_iam_role.lambda_posts_read.name
+  description = "Posts domain read-only Lambda execution role name"
+}
+
+output "posts_write_role_arn" {
+  value       = aws_iam_role.lambda_posts_write.arn
+  description = "Posts domain write Lambda execution role ARN"
+}
+
+output "posts_write_role_name" {
+  value       = aws_iam_role.lambda_posts_write.name
+  description = "Posts domain write Lambda execution role name"
+}
+
+output "posts_build_status_role_arn" {
+  value       = aws_iam_role.lambda_posts_build_status.arn
+  description = "Posts domain build-status Lambda execution role ARN"
+}
+
+output "posts_build_status_role_name" {
+  value       = aws_iam_role.lambda_posts_build_status.name
+  description = "Posts domain build-status Lambda execution role name"
 }
 
 # Auth Domain Role
@@ -124,13 +144,13 @@ output "images_role_name" {
 
 # Legacy alias for backward compatibility
 output "execution_role_arn" {
-  value       = aws_iam_role.lambda_posts.arn
-  description = "Lambda execution role ARN (deprecated, use posts_role_arn)"
+  value       = aws_iam_role.lambda_posts_write.arn
+  description = "Lambda execution role ARN (deprecated, use posts_write_role_arn)"
 }
 
 output "execution_role_name" {
-  value       = aws_iam_role.lambda_posts.name
-  description = "Lambda execution role name (deprecated, use posts_role_name)"
+  value       = aws_iam_role.lambda_posts_write.name
+  description = "Lambda execution role name (deprecated, use posts_write_role_name)"
 }
 
 # ======================
@@ -284,15 +304,25 @@ output "delete_image_function_name" {
 # Categories Domain Outputs
 # ======================
 
-# Categories Domain Role
-output "categories_role_arn" {
-  value       = aws_iam_role.lambda_categories.arn
-  description = "Categories domain Lambda execution role ARN"
+# Categories Domain Roles (split into read/write - see issue #493)
+output "categories_read_role_arn" {
+  value       = aws_iam_role.lambda_categories_read.arn
+  description = "Categories domain read-only Lambda execution role ARN"
 }
 
-output "categories_role_name" {
-  value       = aws_iam_role.lambda_categories.name
-  description = "Categories domain Lambda execution role name"
+output "categories_read_role_name" {
+  value       = aws_iam_role.lambda_categories_read.name
+  description = "Categories domain read-only Lambda execution role name"
+}
+
+output "categories_write_role_arn" {
+  value       = aws_iam_role.lambda_categories_write.arn
+  description = "Categories domain write Lambda execution role ARN"
+}
+
+output "categories_write_role_name" {
+  value       = aws_iam_role.lambda_categories_write.name
+  description = "Categories domain write Lambda execution role name"
 }
 
 output "list_categories_function_arn" {

--- a/terraform/modules/lambda/tests/lambda.tftest.hcl
+++ b/terraform/modules/lambda/tests/lambda.tftest.hcl
@@ -8,12 +8,66 @@
 # - Environment variables
 # - X-Ray tracing (production only)
 
-# Mock AWS provider with data source override for IAM policy document
+# Mock AWS provider with data source override for IAM policy document, plus
+# resource overrides so each role's computed ARN is well-formed and known
+# at plan time (mock_provider otherwise generates opaque placeholder
+# strings for computed attributes, which fail the AWS provider's own
+# "role must be an ARN" validation on aws_lambda_function - and are
+# unknown, not comparable, at plan time without an override).
 mock_provider "aws" {
   override_data {
     target = data.aws_iam_policy_document.lambda_assume_role
     values = {
       json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_role.lambda_posts_read
+    values = {
+      arn = "arn:aws:iam::123456789012:role/blog-lambda-posts-read-role"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_role.lambda_posts_write
+    values = {
+      arn = "arn:aws:iam::123456789012:role/blog-lambda-posts-write-role"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_role.lambda_posts_build_status
+    values = {
+      arn = "arn:aws:iam::123456789012:role/blog-lambda-posts-build-status-role"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_role.lambda_auth
+    values = {
+      arn = "arn:aws:iam::123456789012:role/blog-lambda-auth-role"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_role.lambda_images
+    values = {
+      arn = "arn:aws:iam::123456789012:role/blog-lambda-images-role"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_role.lambda_categories_read
+    values = {
+      arn = "arn:aws:iam::123456789012:role/blog-lambda-categories-read-role"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_role.lambda_categories_write
+    values = {
+      arn = "arn:aws:iam::123456789012:role/blog-lambda-categories-write-role"
     }
   }
 }
@@ -393,15 +447,33 @@ run "xray_tracing_enabled_in_prd" {
 }
 
 # ======================
-# IAM Role Tests (Domain-specific roles per design.md)
+# IAM Role Tests (Domain-specific, least-privilege roles - issue #493)
 # ======================
 
-run "lambda_posts_role_created" {
+run "lambda_posts_read_role_created" {
   command = plan
 
   assert {
-    condition     = aws_iam_role.lambda_posts.name == "blog-lambda-posts-role"
-    error_message = "Lambda posts role should be created with correct name"
+    condition     = aws_iam_role.lambda_posts_read.name == "blog-lambda-posts-read-role"
+    error_message = "Lambda posts read role should be created with correct name"
+  }
+}
+
+run "lambda_posts_write_role_created" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role.lambda_posts_write.name == "blog-lambda-posts-write-role"
+    error_message = "Lambda posts write role should be created with correct name"
+  }
+}
+
+run "lambda_posts_build_status_role_created" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role.lambda_posts_build_status.name == "blog-lambda-posts-build-status-role"
+    error_message = "Lambda posts build-status role should be created with correct name"
   }
 }
 
@@ -423,12 +495,175 @@ run "lambda_images_role_created" {
   }
 }
 
-run "lambda_posts_role_trust_policy" {
+run "lambda_categories_read_role_created" {
   command = plan
 
   assert {
-    condition     = can(jsondecode(aws_iam_role.lambda_posts.assume_role_policy))
-    error_message = "Lambda posts role should have valid trust policy"
+    condition     = aws_iam_role.lambda_categories_read.name == "blog-lambda-categories-read-role"
+    error_message = "Lambda categories read role should be created with correct name"
+  }
+}
+
+run "lambda_categories_write_role_created" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role.lambda_categories_write.name == "blog-lambda-categories-write-role"
+    error_message = "Lambda categories write role should be created with correct name"
+  }
+}
+
+run "lambda_posts_read_role_trust_policy" {
+  command = plan
+
+  assert {
+    condition     = can(jsondecode(aws_iam_role.lambda_posts_read.assume_role_policy))
+    error_message = "Lambda posts read role should have valid trust policy"
+  }
+}
+
+run "lambda_posts_write_role_trust_policy" {
+  command = plan
+
+  assert {
+    condition     = can(jsondecode(aws_iam_role.lambda_posts_write.assume_role_policy))
+    error_message = "Lambda posts write role should have valid trust policy"
+  }
+}
+
+# ======================
+# Function-to-Role Assignment Tests (least privilege - issue #493)
+# ======================
+
+run "read_only_posts_functions_use_read_role" {
+  # Role ARNs are only known after apply; mock_provider makes apply safe
+  # here (no real AWS calls are made).
+  command = apply
+
+  assert {
+    condition     = aws_lambda_function.get_post.role == aws_iam_role.lambda_posts_read.arn
+    error_message = "get_post must use the read-only posts role"
+  }
+
+  assert {
+    condition     = aws_lambda_function.get_public_post.role == aws_iam_role.lambda_posts_read.arn
+    error_message = "get_public_post must use the read-only posts role"
+  }
+
+  assert {
+    condition     = aws_lambda_function.list_posts.role == aws_iam_role.lambda_posts_read.arn
+    error_message = "list_posts must use the read-only posts role"
+  }
+
+  assert {
+    condition     = aws_lambda_function.get_post_by_slug.role == aws_iam_role.lambda_posts_read.arn
+    error_message = "get_post_by_slug must use the read-only posts role"
+  }
+}
+
+run "write_posts_functions_use_write_role" {
+  command = apply
+
+  assert {
+    condition     = aws_lambda_function.create_post.role == aws_iam_role.lambda_posts_write.arn
+    error_message = "create_post must use the posts write role"
+  }
+
+  assert {
+    condition     = aws_lambda_function.update_post.role == aws_iam_role.lambda_posts_write.arn
+    error_message = "update_post must use the posts write role"
+  }
+
+  assert {
+    condition     = aws_lambda_function.delete_post.role == aws_iam_role.lambda_posts_write.arn
+    error_message = "delete_post must use the posts write role"
+  }
+}
+
+run "build_status_function_uses_build_status_role" {
+  command = apply
+
+  assert {
+    condition     = aws_lambda_function.build_status_post.role == aws_iam_role.lambda_posts_build_status.arn
+    error_message = "build_status_post must use the dedicated build-status role, not the write role"
+  }
+}
+
+run "read_only_categories_function_uses_read_role" {
+  command = apply
+
+  assert {
+    condition     = aws_lambda_function.list_categories.role == aws_iam_role.lambda_categories_read.arn
+    error_message = "list_categories must use the read-only categories role"
+  }
+}
+
+run "write_categories_functions_use_write_role" {
+  command = apply
+
+  assert {
+    condition     = aws_lambda_function.create_category.role == aws_iam_role.lambda_categories_write.arn
+    error_message = "create_category must use the categories write role"
+  }
+
+  assert {
+    condition     = aws_lambda_function.update_category.role == aws_iam_role.lambda_categories_write.arn
+    error_message = "update_category must use the categories write role"
+  }
+
+  assert {
+    condition     = aws_lambda_function.delete_category.role == aws_iam_role.lambda_categories_write.arn
+    error_message = "delete_category must use the categories write role"
+  }
+
+  assert {
+    condition     = aws_lambda_function.update_categories_sort_order.role == aws_iam_role.lambda_categories_write.arn
+    error_message = "update_categories_sort_order must use the categories write role"
+  }
+}
+
+# ======================
+# Policy Content Tests (least privilege - issue #493)
+# ======================
+
+run "posts_read_policy_excludes_write_actions" {
+  command = plan
+
+  assert {
+    condition = !contains(
+      jsondecode(aws_iam_role_policy.lambda_posts_read_dynamodb.policy).Statement[0].Action,
+      "dynamodb:PutItem"
+    )
+    error_message = "Posts read policy must not grant dynamodb:PutItem"
+  }
+
+  assert {
+    condition = !contains(
+      jsondecode(aws_iam_role_policy.lambda_posts_read_dynamodb.policy).Statement[0].Action,
+      "dynamodb:DeleteItem"
+    )
+    error_message = "Posts read policy must not grant dynamodb:DeleteItem"
+  }
+}
+
+run "categories_read_policy_only_grants_scan" {
+  command = plan
+
+  assert {
+    condition     = jsondecode(aws_iam_role_policy.lambda_categories_read_dynamodb.policy).Statement[0].Action == ["dynamodb:Scan"]
+    error_message = "Categories read policy must grant only dynamodb:Scan"
+  }
+}
+
+run "categories_write_policy_includes_batch_get_item" {
+  command = plan
+
+  assert {
+    condition = contains(
+      jsondecode(aws_iam_role_policy.lambda_categories_write_dynamodb.policy).Statement[0].Action,
+      "dynamodb:BatchGetItem"
+    )
+    error_message = "Categories write policy must grant dynamodb:BatchGetItem (required by update_categories_sort_order)"
   }
 }
 
@@ -581,9 +816,12 @@ run "lambda_function_names_output" {
 run "lambda_execution_role_name_output" {
   command = plan
 
-  # execution_role_name is a legacy alias for posts_role_name
+  # execution_role_name is a legacy alias, now pointing at the posts write
+  # role (issue #493 split posts_role into posts_read/posts_write/
+  # posts_build_status; write is the closest equivalent to the old
+  # combined role for backward-compatible callers).
   assert {
-    condition     = output.execution_role_name == "blog-lambda-posts-role"
-    error_message = "execution_role_name output should have correct value (alias to posts_role_name)"
+    condition     = output.execution_role_name == "blog-lambda-posts-write-role"
+    error_message = "execution_role_name output should have correct value (alias to posts_write_role_name)"
   }
 }

--- a/terraform/tests/lambda_iam.tftest.hcl
+++ b/terraform/tests/lambda_iam.tftest.hcl
@@ -4,6 +4,12 @@
 #
 # Note: These tests validate IAM role names and basic configuration.
 # Detailed role-policy relationships are tested in the lambda module tests.
+#
+# Issue #493: the former domain-wide lambda_posts / lambda_categories roles
+# were split into least-privilege read/write (+ build-status) roles. These
+# tests were updated accordingly - see terraform/modules/lambda/iam.tf and
+# terraform/modules/lambda/tests/lambda.tftest.hcl for the full API audit
+# and function-to-role assignment coverage.
 
 # Mock providers for testing with override for IAM policy document
 mock_provider "aws" {
@@ -32,9 +38,16 @@ variables {
   enable_xray         = false
   go_binary_path      = "../../go-functions/bin"
   tags                = { Test = "true" }
+
+  # CodeBuild + Categories table references, needed to exercise the
+  # count-conditioned CodeBuild policies and the categories write policy.
+  codebuild_project_name = "test-codebuild-project"
+  codebuild_project_arn  = "arn:aws:codebuild:ap-northeast-1:123456789012:project/test-codebuild-project"
+  categories_table_name  = "test-blog-categories-table"
+  categories_table_arn   = "arn:aws:dynamodb:ap-northeast-1:123456789012:table/test-blog-categories-table"
 }
 
-# Test 1: Verify Posts domain IAM role name
+# Test 1: Verify Posts domain IAM role names (split into read/write/build-status)
 run "verify_posts_iam_role" {
   command = plan
 
@@ -43,8 +56,18 @@ run "verify_posts_iam_role" {
   }
 
   assert {
-    condition     = aws_iam_role.lambda_posts.name == "blog-lambda-posts-role"
-    error_message = "Posts domain role name must be 'blog-lambda-posts-role'"
+    condition     = aws_iam_role.lambda_posts_read.name == "blog-lambda-posts-read-role"
+    error_message = "Posts domain read role name must be 'blog-lambda-posts-read-role'"
+  }
+
+  assert {
+    condition     = aws_iam_role.lambda_posts_write.name == "blog-lambda-posts-write-role"
+    error_message = "Posts domain write role name must be 'blog-lambda-posts-write-role'"
+  }
+
+  assert {
+    condition     = aws_iam_role.lambda_posts_build_status.name == "blog-lambda-posts-build-status-role"
+    error_message = "Posts domain build-status role name must be 'blog-lambda-posts-build-status-role'"
   }
 }
 
@@ -76,7 +99,7 @@ run "verify_images_iam_role" {
   }
 }
 
-# Test 4: Verify DynamoDB policy name for Posts role
+# Test 4: Verify DynamoDB policy names for Posts read/write roles
 run "verify_dynamodb_policy_name" {
   command = plan
 
@@ -85,8 +108,13 @@ run "verify_dynamodb_policy_name" {
   }
 
   assert {
-    condition     = aws_iam_role_policy.lambda_posts_dynamodb.name == "blog-lambda-posts-dynamodb-policy"
-    error_message = "DynamoDB policy name must be 'blog-lambda-posts-dynamodb-policy'"
+    condition     = aws_iam_role_policy.lambda_posts_read_dynamodb.name == "blog-lambda-posts-read-dynamodb-policy"
+    error_message = "DynamoDB read policy name must be 'blog-lambda-posts-read-dynamodb-policy'"
+  }
+
+  assert {
+    condition     = aws_iam_role_policy.lambda_posts_write_dynamodb.name == "blog-lambda-posts-write-dynamodb-policy"
+    error_message = "DynamoDB write policy name must be 'blog-lambda-posts-write-dynamodb-policy'"
   }
 }
 
@@ -118,7 +146,7 @@ run "verify_cognito_policy_name" {
   }
 }
 
-# Test 7: Verify S3 cascade policy name for Posts role
+# Test 7: Verify S3 cascade policy name for Posts write role
 run "verify_s3_cascade_policy_name" {
   command = plan
 
@@ -127,8 +155,8 @@ run "verify_s3_cascade_policy_name" {
   }
 
   assert {
-    condition     = aws_iam_role_policy.lambda_posts_s3_cascade.name == "blog-lambda-posts-s3-cascade-policy"
-    error_message = "S3 cascade policy name must be 'blog-lambda-posts-s3-cascade-policy'"
+    condition     = aws_iam_role_policy.lambda_posts_write_s3_cascade.name == "blog-lambda-posts-write-s3-cascade-policy"
+    error_message = "S3 cascade policy name must be 'blog-lambda-posts-write-s3-cascade-policy'"
   }
 }
 
@@ -141,8 +169,18 @@ run "verify_role_outputs" {
   }
 
   assert {
-    condition     = output.posts_role_name == "blog-lambda-posts-role"
-    error_message = "posts_role_name output must be correct"
+    condition     = output.posts_read_role_name == "blog-lambda-posts-read-role"
+    error_message = "posts_read_role_name output must be correct"
+  }
+
+  assert {
+    condition     = output.posts_write_role_name == "blog-lambda-posts-write-role"
+    error_message = "posts_write_role_name output must be correct"
+  }
+
+  assert {
+    condition     = output.posts_build_status_role_name == "blog-lambda-posts-build-status-role"
+    error_message = "posts_build_status_role_name output must be correct"
   }
 
   assert {
@@ -154,29 +192,100 @@ run "verify_role_outputs" {
     condition     = output.images_role_name == "blog-lambda-images-role"
     error_message = "images_role_name output must be correct"
   }
+
+  assert {
+    condition     = output.categories_read_role_name == "blog-lambda-categories-read-role"
+    error_message = "categories_read_role_name output must be correct"
+  }
+
+  assert {
+    condition     = output.categories_write_role_name == "blog-lambda-categories-write-role"
+    error_message = "categories_write_role_name output must be correct"
+  }
 }
 
-# Test 9: Verify all three domain-specific roles exist
-run "verify_three_domain_roles" {
+# Test 9: Verify all domain-specific roles exist and are distinct
+run "verify_domain_roles_distinct" {
   command = plan
 
   module {
     source = "./modules/lambda"
   }
 
-  # All three role names should be different
   assert {
-    condition     = aws_iam_role.lambda_posts.name != aws_iam_role.lambda_auth.name
-    error_message = "Posts and Auth roles must have different names"
+    condition = length(distinct([
+      aws_iam_role.lambda_posts_read.name,
+      aws_iam_role.lambda_posts_write.name,
+      aws_iam_role.lambda_posts_build_status.name,
+      aws_iam_role.lambda_auth.name,
+      aws_iam_role.lambda_images.name,
+      aws_iam_role.lambda_categories_read.name,
+      aws_iam_role.lambda_categories_write.name,
+    ])) == 7
+    error_message = "All seven domain/purpose-specific IAM roles must have distinct names"
+  }
+}
+
+# Test 10: Least privilege - read-only roles must not grant write actions
+run "verify_read_roles_are_read_only" {
+  command = plan
+
+  module {
+    source = "./modules/lambda"
   }
 
   assert {
-    condition     = aws_iam_role.lambda_posts.name != aws_iam_role.lambda_images.name
-    error_message = "Posts and Images roles must have different names"
+    condition = alltrue([
+      for action in jsondecode(aws_iam_role_policy.lambda_posts_read_dynamodb.policy).Statement[0].Action :
+      !contains(["dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:DeleteItem", "dynamodb:Scan"], action)
+    ])
+    error_message = "lambda_posts_read policy must not grant any DynamoDB write action or Scan"
   }
 
   assert {
-    condition     = aws_iam_role.lambda_auth.name != aws_iam_role.lambda_images.name
-    error_message = "Auth and Images roles must have different names"
+    condition     = jsondecode(aws_iam_role_policy.lambda_categories_read_dynamodb.policy).Statement[0].Action == ["dynamodb:Scan"]
+    error_message = "lambda_categories_read policy must grant only dynamodb:Scan (no write actions)"
+  }
+}
+
+# Test 11: Least privilege - build-status role can poll CodeBuild but never start a build
+run "verify_build_status_role_cannot_start_build" {
+  command = plan
+
+  module {
+    source = "./modules/lambda"
+  }
+
+  assert {
+    condition = !contains(
+      jsondecode(aws_iam_role_policy.lambda_posts_build_status_codebuild[0].policy).Statement[0].Action,
+      "codebuild:StartBuild"
+    )
+    error_message = "lambda_posts_build_status must never be granted codebuild:StartBuild"
+  }
+
+  assert {
+    condition = contains(
+      jsondecode(aws_iam_role_policy.lambda_posts_build_status_codebuild[0].policy).Statement[0].Action,
+      "codebuild:BatchGetBuilds"
+    )
+    error_message = "lambda_posts_build_status must be able to poll build results via codebuild:BatchGetBuilds"
+  }
+}
+
+# Test 12: Least privilege - write role retains codebuild:StartBuild (create/update/delete post)
+run "verify_write_role_has_start_build" {
+  command = plan
+
+  module {
+    source = "./modules/lambda"
+  }
+
+  assert {
+    condition = contains(
+      jsondecode(aws_iam_role_policy.lambda_posts_write_codebuild[0].policy).Statement[0].Action,
+      "codebuild:StartBuild"
+    )
+    error_message = "lambda_posts_write must be granted codebuild:StartBuild to trigger site rebuilds"
   }
 }

--- a/terraform/tests/module_interdependency.tftest.hcl
+++ b/terraform/tests/module_interdependency.tftest.hcl
@@ -212,10 +212,13 @@ run "lambda_outputs_for_monitoring" {
     error_message = "Lambda module must export all 18 function names"
   }
 
-  # Verify role name outputs match expected values
+  # Verify role name outputs match expected values.
+  # Issue #493 split the combined posts role into least-privilege
+  # read/write/build-status roles; posts_write_role_name is the closest
+  # successor to the old posts_role_name output.
   assert {
-    condition     = output.posts_role_name == "blog-lambda-posts-role"
-    error_message = "Lambda module must export posts_role_name correctly"
+    condition     = output.posts_write_role_name == "blog-lambda-posts-write-role"
+    error_message = "Lambda module must export posts_write_role_name correctly"
   }
 
   assert {
@@ -228,9 +231,9 @@ run "lambda_outputs_for_monitoring" {
     error_message = "Lambda module must export images_role_name correctly"
   }
 
-  # Verify execution_role_name legacy alias
+  # Verify execution_role_name legacy alias (now points at the write role)
   assert {
-    condition     = output.execution_role_name == "blog-lambda-posts-role"
+    condition     = output.execution_role_name == "blog-lambda-posts-write-role"
     error_message = "Lambda module must export execution_role_name (legacy alias)"
   }
 }


### PR DESCRIPTION
## 概要

Issue #493 の対応。`terraform/modules/lambda/iam.tf` の IAM ロールが `lambda_posts` / `lambda_categories` というドメイン単位の共有ロールになっており、認証不要の読み取り専用関数（`get_public_post`、`list_posts`、`get_post_by_slug`、`list_categories`）にも書き込み・削除権限が付与されていました。最小権限の原則に基づき、読み取り/書き込みでロールを分割しました。

`lambda_auth`・`lambda_images` は元々適切な権限だったため変更していません。

## 各 Lambda が実際に呼ぶ AWS API の調査結果

想像ではなく `go-functions/cmd/**/main.go` を直接読み、必要に応じて内部パッケージ (`internal/buildtrigger` 等) も確認して洗い出しました。

| Handler | Lambda 関数名 | DynamoDB API（テーブル） | S3 API（バケット） | CodeBuild API | Cognito API | 備考 |
|---|---|---|---|---|---|---|
| posts/create | blog-create-post-go | PutItem, Query（BlogPosts, SlugIndex 経由のスラッグ重複チェック） | — | StartBuild, ListBuildsForProject, BatchGetBuilds（公開時のみ） | — | |
| posts/get | blog-get-post-go | GetItem（BlogPosts） | — | — | — | 純粋な読み取り |
| posts/get_public | blog-get-public-post-go | GetItem（BlogPosts） | — | — | — | 純粋な読み取り |
| posts/list | blog-list-posts-go | Query（BlogPosts。認証済みの場合は件数取得用の Query も追加発行するが同一 API） | — | — | — | |
| posts/update | blog-update-post-go | GetItem, PutItem, Query（BlogPosts。スラッグ変更時のみ Query） | — | StartBuild, ListBuildsForProject, BatchGetBuilds（公開時のみ） | — | |
| posts/delete | blog-delete-post-go | GetItem, DeleteItem（BlogPosts） | DeleteObjects（画像がある場合のみ） | StartBuild, ListBuildsForProject, BatchGetBuilds（公開済み記事のみ） | — | 「削除」だが S3 とビルドトリガーも伴う |
| posts/build_status | blog-build-status-post-go | — | — | ListBuildsForProject, BatchGetBuilds（**StartBuild なし**） | — | DynamoDB・S3 に一切アクセスしない |
| posts/get_by_slug | blog-get-post-by-slug-go | Query（BlogPosts, SlugIndex） | — | — | — | GetItem ではなく Query |
| categories/list | blog-list-categories-go | **Scan**（Categoriesテーブル全件） | — | — | — | Scan のみ、書き込みなし |
| categories/create | blog-create-category-go | Scan（sortOrder未指定時のみ）, **TransactWriteItems**（Categories: カテゴリ作成 + SLUG#予約の2アイテム） | — | — | — | PutItem 単体ではなく TransactWriteItems |
| categories/update | blog-update-category-go | GetItem, Query（Categories, SlugIndex）, PutItem（非スラッグ変更時）, **TransactWriteItems（Categories と BlogPosts の両方にまたがる単一トランザクション）** | — | — | — | **最大の発見**: スラッグ変更時、該当カテゴリの全記事を Query（BlogPosts, CategoryIndex）した上で `category` フィールドを TransactWriteItems の Update で書き換える。単なる「カテゴリ更新」ではなく実質「記事一括更新」も行う |
| categories/delete | blog-delete-category-go | GetItem（Categories）, Query（BlogPosts, CategoryIndex - 使用中チェック、読み取りのみ）, TransactWriteItems（Categories のみ: カテゴリ + SLUG#予約の削除） | — | — | — | BlogPosts へは読み取りのみ、書き込みしない |
| categories/bulk_sort | blog-update-categories-sort-order-go | **BatchGetItem**（Categories, ID存在確認）, TransactWriteItems（Categories, sortOrder一括更新） | — | — | — | **発見**: 既存の結合ロールに `dynamodb:BatchGetItem` が付与されておらず、この関数は本番で権限不足の可能性があった（後述） |
| images/get_upload_url | blog-upload-url-go | — | PresignPutObject（実行時にS3 APIは呼ばないが、署名生成に `s3:PutObject` 権限が必要） | — | — | 変更対象外（images ロールのまま） |
| images/delete | blog-delete-image-go | — | DeleteObject | — | — | 変更対象外 |
| auth/login | blog-login-go | — | — | — | InitiateAuth | 変更対象外（既に最小権限） |
| auth/logout | blog-logout-go | — | — | — | GlobalSignOut | 変更対象外 |
| auth/refresh | blog-refresh-go | — | — | — | InitiateAuth | 変更対象外 |
| categories/seed | (未デプロイ) | — | — | — | — | `local.lambda_functions` に存在せず、Lambda としてデプロイされていない単体スクリプト |

### 調査で判明した意外な事実

- **`categories/update` が最大の驚き**: 見た目は「カテゴリ更新」だが、スラッグを変更すると該当カテゴリに属する全記事の `category` フィールドを、BlogPosts テーブルへの `Update`（TransactWriteItems 経由、100件ずつバッチ）で書き換える。Categories テーブルだけでなく BlogPosts テーブルへの書き込み権限が必須。
- **`categories/create` と `categories/delete` は `TransactWriteItems`** を使ってスラッグ予約アイテムをアトミックに作成/削除している。単純な PutItem/DeleteItem 権限だけでは足りないと誤解しがちだが、AWS の仕様上 `TransactWriteItems` の認可は個々の操作種別（PutItem/UpdateItem/DeleteItem）の権限で行われるため、`dynamodb:TransactWriteItems` という別アクションを明示的に付与する必要はない（[AWS公式ドキュメント](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis-iam.html)で確認済み）。
- **`update_categories_sort_order`（bulk_sort）が `dynamodb:BatchGetItem` を毎回呼んでいるのに、変更前の結合ロールにはその権限がなかった** — 潜在的な既存バグ。今回の見直しで `lambda_categories_write` に追加。
- **`images/get_upload_url` は実行時に S3 API を一切呼ばない**（`PresignPutObject` はローカルの署名処理のみ）が、生成した署名付き URL をブラウザが実際に使う際には実行ロールの `s3:PutObject` 権限で認可されるため、権限自体は必要。
- **`posts/build_status` は DynamoDB・S3 に一切アクセスせず、CodeBuild の `StartBuild` も呼ばない**（ビルド状況のポーリングのみ）。旧ロールでは posts ドメイン全体の書き込み権限（DynamoDB 書き込み + S3 削除 + CodeBuild StartBuild）を継承していたため、影響範囲が不必要に大きかった。

## 分割後のロール構成

| ロール | 対象関数 | 付与権限 |
|---|---|---|
| `lambda_posts_read` | get_post, get_public_post, list_posts, get_post_by_slug | dynamodb:GetItem, Query（BlogPosts） |
| `lambda_posts_write` | create_post, update_post, delete_post | dynamodb:GetItem/PutItem/DeleteItem/Query（BlogPosts）, s3:DeleteObject/DeleteObjects, codebuild:StartBuild/ListBuildsForProject/BatchGetBuilds |
| `lambda_posts_build_status` | build_status_post | codebuild:ListBuildsForProject/BatchGetBuilds のみ（StartBuild なし、DynamoDB/S3 なし） |
| `lambda_categories_read` | list_categories | dynamodb:Scan（Categories） |
| `lambda_categories_write` | create_category, update_category, delete_category, update_categories_sort_order | dynamodb:Scan/PutItem/GetItem/UpdateItem/DeleteItem/Query/BatchGetItem（Categories）, dynamodb:Query/UpdateItem（BlogPosts） |
| `lambda_auth` | login, logout, refresh | 変更なし（既に最小権限） |
| `lambda_images` | get_upload_url, delete_image | 変更なし（対象外） |

## 変更ファイル

- `terraform/modules/lambda/iam.tf` — ロール分割・権限の絞り込み
- `terraform/modules/lambda/main.tf` — 各 Lambda 関数のロール割り当てを変更
- `terraform/modules/lambda/outputs.tf` — ロール出力を分割後の名前にリネーム（`execution_role_arn`/`execution_role_name` レガシーエイリアスは write ロールを指すよう更新）
- `terraform/modules/lambda/README.md` — IAM ロール構成のドキュメント更新
- `terraform/modules/lambda/tests/lambda.tftest.hcl` — ロール名・信頼ポリシー・関数→ロール割り当て・ポリシー内容のテストを追加/更新
- `terraform/tests/lambda_iam.tftest.hcl` — 同様にルートレベルのテストを更新
- `terraform/tests/module_interdependency.tftest.hcl` — **指示された変更範囲外ですが、旧ロール名 `blog-lambda-posts-role` をハードコードした2箇所のアサーションが、今回の分割で意図的に削除したロール名を前提としており、直さない限りルートの `terraform test` が恒久的に赤くなるため、最小限の修正を行いました**（`posts_role_name` → `posts_write_role_name`、`execution_role_name` の期待値を write ロール名に更新）。この点はレビューで問題があればご指摘ください。

## 検証結果

- `cd terraform/environments/dev && terraform init -backend=false && terraform validate` — Success
- `cd terraform/environments/prd && terraform init -backend=false && terraform validate` — Success
- `terraform fmt -check -recursive terraform/`（リポジトリルートから） — 差分なし
- `cd terraform/modules/lambda && terraform init -backend=false && terraform test` — 42 passed, 0 failed
- `cd terraform && terraform test` — 22 passed, 0 failed（`lambda_iam.tftest.hcl` 12件 / `module_interdependency.tftest.hcl` 10件 / `project_structure.tftest.hcl`）
- `checkov -d terraform/modules/lambda --framework terraform` — 変更前後で失敗数は同数（126件、いずれも既存の VPC/DLQ/KMS暗号化/同時実行数上限/ログ保持期間に関するもので `terraform/.checkov.yaml` に理由付きでスキップ登録済み）。IAM関連の新規指摘なし
- `trivy config terraform/modules/lambda --severity HIGH,CRITICAL` — 0 misconfigurations

**`terraform plan` は実行していません**（AWS認証情報と実際のstateに触れるため、指示通り未実行）。plan の差分確認と dev 環境での post-deploy E2E はレビュー時に人間が実施してください。

## 注意事項（デプロイ前に確認いただきたい点）

- IAM ロール名が変わる（`blog-lambda-posts-role` → `blog-lambda-posts-read-role` 等）ため、`terraform plan` では対象ロールの **re-create**（旧ロール削除・新ロール作成）＋Lambda関数の `role` 更新が計画されるはずです。ダウンタイムは想定していませんが、必ず plan の差分を確認してください。
- `terraform apply` 後、実運用相当の操作（記事作成/更新/削除・公開、カテゴリ作成/更新/削除/並び替え、画像アップロード/削除）を dev 環境で一通り確認することを強く推奨します。特に `categories/update`（スラッグ変更を伴うカテゴリ名変更）と `posts/delete`（画像付き記事の削除）は最も複雑な権限パターンです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
