### PR TITLE
perf(go): 未認証の読み取りに no-store を返すのをやめる

### DIFF
--- a/go-functions/cmd/categories/list/main.go
+++ b/go-functions/cmd/categories/list/main.go
@@ -99,7 +99,7 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	}
 
 	// Return response (empty array if no categories)
-	return middleware.JSONResponse(200, response)
+	return middleware.PublicJSONResponse(200, response)
 }
 
 // processResults converts DynamoDB items to Category structs

--- a/go-functions/cmd/posts/get_by_slug/main.go
+++ b/go-functions/cmd/posts/get_by_slug/main.go
@@ -90,7 +90,7 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		return errorResponse(404, "post not found")
 	}
 
-	return middleware.JSONResponse(200, post)
+	return middleware.PublicJSONResponse(200, post)
 }
 
 // errorResponse creates an error response with CORS headers.

--- a/go-functions/cmd/posts/get_public/main.go
+++ b/go-functions/cmd/posts/get_public/main.go
@@ -81,7 +81,7 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		return errorResponse(404, "post not found")
 	}
 
-	return middleware.JSONResponse(200, post)
+	return middleware.PublicJSONResponse(200, post)
 }
 
 // errorResponse creates an error response with CORS headers

--- a/go-functions/cmd/posts/list/main.go
+++ b/go-functions/cmd/posts/list/main.go
@@ -168,9 +168,14 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 			return errorResponse(500, "failed to retrieve posts")
 		}
 		response.Count = &count
+
+		// This endpoint is mounted both publicly and under /admin. An
+		// authenticated response can contain drafts, so it must not be
+		// cacheable even though the public one is.
+		return middleware.JSONResponse(200, response)
 	}
 
-	return middleware.JSONResponse(200, response)
+	return middleware.PublicJSONResponse(200, response)
 }
 
 // parseLimit parses and validates the limit parameter

--- a/go-functions/cmd/posts/list/main_test.go
+++ b/go-functions/cmd/posts/list/main_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 
 	"serverless-blog/go-functions/internal/domain"
+	"serverless-blog/go-functions/internal/middleware"
 )
 
 // Test constants
@@ -2591,5 +2593,60 @@ func TestHandler_SearchNoResults(t *testing.T) {
 	// No results expected
 	if len(listResp.Items) != 0 {
 		t.Errorf("expected 0 items for non-matching search, got %d", len(listResp.Items))
+	}
+}
+
+// TestHandler_CacheControl covers the split introduced in #492: this endpoint
+// is mounted both publicly and under /admin, and an authenticated response can
+// contain drafts, so only the anonymous one may be cached.
+func TestHandler_CacheControl(t *testing.T) {
+	tests := []struct {
+		name       string
+		authorizer map[string]interface{}
+		want       string
+	}{
+		{
+			name:       "anonymous read is cacheable",
+			authorizer: nil,
+			want:       fmt.Sprintf("public, max-age=%d", middleware.PublicCacheMaxAgeSeconds),
+		},
+		{
+			name: "authenticated read is not cacheable",
+			authorizer: map[string]interface{}{
+				"claims": map[string]interface{}{"sub": "user-123"},
+			},
+			want: "no-store",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup := setupTest(t)
+			defer cleanup()
+
+			dynamoClientGetter = func() (DynamoDBClientInterface, error) {
+				return &MockDynamoDBClient{
+					QueryFunc: func(_ context.Context, _ *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+						return &dynamodb.QueryOutput{Items: nil, Count: 0}, nil
+					},
+				}, nil
+			}
+
+			resp, err := Handler(context.Background(), events.APIGatewayProxyRequest{
+				QueryStringParameters: map[string]string{},
+				RequestContext: events.APIGatewayProxyRequestContext{
+					Authorizer: tt.authorizer,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Handler returned unexpected error: %v", err)
+			}
+			if resp.StatusCode != 200 {
+				t.Fatalf("StatusCode = %d, want 200", resp.StatusCode)
+			}
+			if got := resp.Headers["Cache-Control"]; got != tt.want {
+				t.Errorf("Cache-Control = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/go-functions/internal/middleware/middleware.go
+++ b/go-functions/internal/middleware/middleware.go
@@ -3,10 +3,17 @@ package middleware
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/aws/aws-lambda-go/events"
 )
+
+// PublicCacheMaxAgeSeconds is how long a response to an anonymous read may be
+// reused. It is deliberately short: publishing a post triggers a site rebuild
+// and a CloudFront invalidation, and a minute of staleness on the API is well
+// inside the time that pipeline takes.
+const PublicCacheMaxAgeSeconds = 60
 
 // CORSHeaders returns standard CORS headers.
 // The Access-Control-Allow-Origin value is read from the ALLOWED_ORIGIN
@@ -25,6 +32,32 @@ func CORSHeaders() map[string]string {
 		"X-Frame-Options":              "DENY",
 		"Cache-Control":                "no-store",
 	}
+}
+
+// PublicCacheHeaders returns the standard headers with a short shared-cache
+// window instead of no-store.
+//
+// Only use this for responses that contain nothing but published content
+// served to an anonymous caller. no-store stays the default in CORSHeaders so
+// that anything not explicitly opted in — admin reads, drafts, tokens —
+// cannot be cached by omission.
+func PublicCacheHeaders() map[string]string {
+	headers := CORSHeaders()
+	headers["Cache-Control"] = fmt.Sprintf("public, max-age=%d", PublicCacheMaxAgeSeconds)
+	return headers
+}
+
+// PublicJSONResponse creates a JSON response that a shared cache may reuse for
+// PublicCacheMaxAgeSeconds. See PublicCacheHeaders for when this is allowed.
+func PublicJSONResponse(statusCode int, body interface{}) (events.APIGatewayProxyResponse, error) {
+	response, err := JSONResponse(statusCode, body)
+	if err != nil {
+		// Marshaling failed, so the body is an error payload: leave it uncached.
+		return response, err
+	}
+
+	response.Headers = PublicCacheHeaders()
+	return response, nil
 }
 
 // JSONResponse creates a JSON response with CORS headers.

--- a/go-functions/internal/middleware/middleware_test.go
+++ b/go-functions/internal/middleware/middleware_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"os"
 	"testing"
@@ -125,5 +126,60 @@ func TestErrorResponse(t *testing.T) {
 	}
 	if parsed["error"] != "bad request" {
 		t.Errorf("body error = %q, want 'bad request'", parsed["error"])
+	}
+}
+
+// TestCORSHeadersDefaultsToNoStore pins the default. Public caching is opt-in
+// (PublicJSONResponse); if this default ever flips, every endpoint that never
+// opted in — admin reads, drafts, token responses — silently becomes
+// cacheable.
+func TestCORSHeadersDefaultsToNoStore(t *testing.T) {
+	if got := CORSHeaders()["Cache-Control"]; got != "no-store" {
+		t.Errorf("CORSHeaders()[Cache-Control] = %q, want %q", got, "no-store")
+	}
+}
+
+func TestPublicCacheHeaders(t *testing.T) {
+	headers := PublicCacheHeaders()
+
+	want := fmt.Sprintf("public, max-age=%d", PublicCacheMaxAgeSeconds)
+	if got := headers["Cache-Control"]; got != want {
+		t.Errorf("Cache-Control = %q, want %q", got, want)
+	}
+
+	// The rest of the security headers must survive the override.
+	for _, key := range []string{"X-Content-Type-Options", "X-Frame-Options", "Content-Type"} {
+		if headers[key] == "" {
+			t.Errorf("PublicCacheHeaders() dropped %s", key)
+		}
+	}
+}
+
+func TestPublicJSONResponse(t *testing.T) {
+	resp, err := PublicJSONResponse(200, map[string]string{"hello": "world"})
+	if err != nil {
+		t.Fatalf("PublicJSONResponse() unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	want := fmt.Sprintf("public, max-age=%d", PublicCacheMaxAgeSeconds)
+	if got := resp.Headers["Cache-Control"]; got != want {
+		t.Errorf("Cache-Control = %q, want %q", got, want)
+	}
+	if resp.Body != `{"hello":"world"}` {
+		t.Errorf("Body = %q", resp.Body)
+	}
+}
+
+// A body that cannot be marshaled produces an error payload, which must not
+// be handed to a shared cache.
+func TestPublicJSONResponseDoesNotCacheMarshalFailure(t *testing.T) {
+	resp, err := PublicJSONResponse(200, make(chan int))
+	if err == nil {
+		t.Fatal("PublicJSONResponse() error = nil, want a marshaling error")
+	}
+	if got := resp.Headers["Cache-Control"]; got != "no-store" {
+		t.Errorf("Cache-Control = %q, want %q", got, "no-store")
 	}
 }


### PR DESCRIPTION
## 概要

`CORSHeaders()` がすべてのレスポンスに `Cache-Control: no-store` を付けていたため、認証不要の公開 GET すらいかなるキャッシュでも再利用できなかった。

Closes #492

## 設計上の判断: デフォルトは `no-store` のまま

**デフォルトを緩めるのではなく、公開エンドポイントがオプトインする形にしました。** `CORSHeaders()` が返す値は `no-store` のままです。

逆にすると、明示的にオプトアウトしていないもの — **管理系の読み取り、ドラフト、トークンのレスポンス** — が「書き忘れ」によってキャッシュ可能になります。安全側の初期値を動かさないほうが事故が起きません。

## `GET /posts` の扱い（重要）

このエンドポイントは**公開と `/admin` の両方にマウントされ**、認証時のレスポンスには**ドラフトが含まれます**。そのため認証済みリクエストには `no-store` を維持し、未認証時のみキャッシュ可能にしました。ここを一律に扱うとドラフトがキャッシュに載ります。

両分岐の回帰テストを追加済みです。

## 検証

| 対象 | 結果 |
|---|---|
| Go 全体テスト | green、**総カバレッジ 92.1%** |
| `make build` | 18関数 |
| `golangci-lint`（CI 同一 v2.11 + Go 1.25.12） | 0 issues |

追加した回帰テスト:
- `CORSHeaders()` のデフォルトが `no-store` であること（**このデフォルトが将来反転したら落ちる**）
- 公開ヘッダーが `max-age` を持ちつつ、他のセキュリティヘッダー（nosniff / DENY）を落としていないこと
- marshal 失敗時のエラーレスポンスはキャッシュ可能にしないこと
- `GET /posts` が未認証で cacheable、認証済みで `no-store` になること

## ⚠️ 効果の限界（正直に）

Issue の「CloudFront との整合を確認する」を実施した結果、**現時点でこの変更の実効果は限定的**です。

1. **CloudFront の `/api/*` は `CachingDisabled` ポリシー**（`terraform/modules/cdn/main.tf:626`）。つまり CloudFront は Cache-Control を無視してキャッシュしません
2. **公開サイトは完全な SSG**（`output: 'static'`）で、記事データはビルド時に取得されます。実行時に公開 API を叩く経路が事実上ありません

したがって現状の効果は「ブラウザ・中間キャッシュでの再利用が可能になる」程度です。

**CloudFront 側を変えることは本 PR では行いませんでした。** `/api/*` をキャッシュさせるには、キャッシュキーに `Authorization` を含める設計が必須で、**誤るとドラフトが匿名ユーザーに配信されます**。同じ PR でまとめて入れるにはリスクが高すぎると判断しました。

ただし本 PR は「HTTP セマンティクスとして正しい状態」にする変更であり、将来 CloudFront 側を見直す際の前提にもなります。CloudFront のキャッシュ有効化を進める場合は、別 Issue として切り出してください（必要なら私が起票します）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)