### PR TITLE
fix(ci): allow empty RSS in production smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1226,9 +1226,12 @@ jobs:
           echo ""
           echo "--- a real article page renders ---"
           RSS=$(curl -sS --max-time 30 "${SITE_URL}/rss.xml" || echo "")
+          # An empty feed is valid. Keep grep's expected no-match status from
+          # tripping GitHub Actions' implicit `bash -e` together with pipefail.
           ARTICLE_URL=$(echo "$RSS" \
             | grep -o '<link>[^<]*/posts/[^<]*</link>' \
-            | head -1 | sed -e 's|<link>||' -e 's|</link>||')
+            | head -1 | sed -e 's|<link>||' -e 's|</link>||' \
+            || true)
 
           if [ -z "$ARTICLE_URL" ]; then
             echo "⚠️ No article found in the RSS feed - skipping article check"


### PR DESCRIPTION
## Summary
- allow an empty production RSS feed to reach the documented article-check skip path
- prevent grep's expected no-match status from aborting the GitHub Actions shell under errexit and pipefail
- preserve failures for HTTP errors and required metadata checks

## Verification
- reproduced empty-feed and populated-feed cases with bash -euo pipefail
- bun run verify
- develop Deploy workflow passed
- Security Scan passed

## Context
The previous production deployment completed successfully, but its final smoke test was reported as failed because the production RSS feed contained no article entries.