### PR TITLE
fix(deploy): CloudFront KVSのSigV4A署名エラーを修正

### DIFF
--- a/scripts/deploy/atomicDeploy.test.ts
+++ b/scripts/deploy/atomicDeploy.test.ts
@@ -10,6 +10,7 @@ import * as path from 'node:path';
 import {
   atomicDeploy,
   calculateDirectorySize,
+  createKeyValueStoreClient,
   DeployErrorCode,
   generateBuildId,
   getCacheControl,
@@ -185,6 +186,41 @@ describe('promoteRelease', () => {
       )
     ).resolves.toMatchObject({ promoted: true });
     expect(updateAttempts).toBe(2);
+  });
+});
+
+describe('CloudFront KVS client', () => {
+  test('signs KVS requests with the explicitly configured JS SigV4A signer', async () => {
+    const client = createKeyValueStoreClient();
+    let authorization: string | undefined;
+    const requestHandler = {
+      handle: vi.fn(async (request: { headers: Record<string, string> }) => {
+        authorization = request.headers.authorization;
+        return {
+          response: {
+            statusCode: 200,
+            headers: { 'content-type': 'application/json' },
+            body: new TextEncoder().encode('{}'),
+          },
+        };
+      }),
+    };
+
+    client.config.credentials = async () => ({
+      accessKeyId: 'AKIDEXAMPLE',
+      secretAccessKey: 'test-secret',
+    });
+    client.config.requestHandler =
+      requestHandler as unknown as typeof client.config.requestHandler;
+
+    await client.send(
+      new DescribeKeyValueStoreCommand({
+        KvsARN: 'arn:aws:cloudfront::123456789012:key-value-store/test',
+      })
+    );
+
+    expect(authorization).toMatch(/^AWS4-ECDSA-P256-SHA256 /);
+    expect(requestHandler.handle).toHaveBeenCalledOnce();
   });
 });
 

--- a/scripts/deploy/atomicDeploy.ts
+++ b/scripts/deploy/atomicDeploy.ts
@@ -16,9 +16,7 @@ import {
   GetKeyCommand,
   UpdateKeysCommand,
 } from '@aws-sdk/client-cloudfront-keyvaluestore';
-// The CloudFront KVS data-plane endpoint requires SigV4A. Register the
-// portable JavaScript signer explicitly (the client does not bundle one).
-import '@aws-sdk/signature-v4a';
+import { SignatureV4a } from '@aws-sdk/signature-v4a';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { lookup as mimeLookup } from 'mime-types';
@@ -51,6 +49,18 @@ export class DeployError extends Error {
 
 interface CommandClient {
   send(command: object): Promise<unknown>;
+}
+
+/**
+ * CloudFront KVS requires SigV4A. Pass the JavaScript signer directly instead
+ * of relying on the SDK's process-global registration container: package
+ * managers may install multiple @smithy/signature-v4 module instances.
+ */
+export function createKeyValueStoreClient(): CloudFrontKeyValueStoreClient {
+  return new CloudFrontKeyValueStoreClient({
+    region: 'us-east-1',
+    signerConstructor: SignatureV4a,
+  });
 }
 
 export interface AtomicDeployConfig {
@@ -372,9 +382,7 @@ export async function atomicDeploy(
     ({
       s3: new S3Client({ region: config.region }) as unknown as CommandClient,
       // CloudFront KVS is a global data-plane API exposed through us-east-1.
-      kvs: new CloudFrontKeyValueStoreClient({
-        region: 'us-east-1',
-      }) as unknown as CommandClient,
+      kvs: createKeyValueStoreClient() as unknown as CommandClient,
     } satisfies AtomicDeployConfig['clients']);
 
   try {

--- a/scripts/deploy/bun.lock
+++ b/scripts/deploy/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "@serverless-blog/deploy",
       "dependencies": {
-        "@aws-sdk/client-cloudfront": "^3.700.0",
-        "@aws-sdk/client-cloudfront-keyvaluestore": "^3.700.0",
-        "@aws-sdk/client-s3": "^3.700.0",
-        "@aws-sdk/signature-v4a": "^3.700.0",
+        "@aws-sdk/client-cloudfront": "3.971.0",
+        "@aws-sdk/client-cloudfront-keyvaluestore": "3.1101.0",
+        "@aws-sdk/client-s3": "3.971.0",
+        "@aws-sdk/signature-v4a": "3.1098.0",
         "commander": "^13.1.0",
         "mime-types": "^2.1.35",
       },

--- a/scripts/deploy/package.json
+++ b/scripts/deploy/package.json
@@ -13,10 +13,10 @@
     "test:coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@aws-sdk/client-cloudfront": "^3.700.0",
-    "@aws-sdk/client-cloudfront-keyvaluestore": "^3.700.0",
-    "@aws-sdk/client-s3": "^3.700.0",
-    "@aws-sdk/signature-v4a": "^3.700.0",
+    "@aws-sdk/client-cloudfront": "3.971.0",
+    "@aws-sdk/client-cloudfront-keyvaluestore": "3.1101.0",
+    "@aws-sdk/client-s3": "3.971.0",
+    "@aws-sdk/signature-v4a": "3.1098.0",
     "commander": "^13.1.0",
     "mime-types": "^2.1.35"
   },


### PR DESCRIPTION
## 概要

記事公開時のCodeBuildで、S3アップロード後のCloudFront KeyValueStoreポインタ更新がSigV4A署名実装を解決できず失敗する問題を修正します。

## 変更内容

- JavaScript版SigV4A署名器をKVSクライアントへ明示的に注入
- デプロイ用AWS SDKの直接依存バージョンを固定
- 疑似KVSリクエストがAWS4-ECDSA-P256-SHA256で署名される回帰テストを追加

## 検証

- bun run verify
- scripts/deploy: atomicDeploy.test.ts 24件成功
- bun install --frozen-lockfile 成功

## リスク

実AWS KVSへの疎通はPR内では行っていません。AWS SDKの実リクエスト生成・署名経路は疑似HTTPハンドラで検証済みです。