### PR TITLE
fix: 記事ステータス変更後のサイトビルドを確実に収束させる

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,7 +177,7 @@ jobs:
             echo "cache-hit=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          FUNCS="posts-create posts-get posts-get_public posts-get_by_slug posts-list posts-update posts-delete posts-build_status auth-login auth-logout auth-refresh images-get_upload_url images-delete categories-list categories-create categories-update categories-bulk_sort categories-delete"
+          FUNCS="posts-create posts-get posts-get_public posts-get_by_slug posts-list posts-update posts-delete posts-build_status posts-reconcile_build auth-login auth-logout auth-refresh images-get_upload_url images-delete categories-list categories-create categories-update categories-bulk_sort categories-delete"
           TOTAL=0
           for f in $FUNCS; do TOTAL=$((TOTAL + 1)); done
           COUNT=0
@@ -233,6 +233,8 @@ jobs:
             path: posts/delete
           - function: posts-build_status
             path: posts/build_status
+          - function: posts-reconcile_build
+            path: posts/reconcile_build
           - function: posts-get_by_slug
             path: posts/get_by_slug
           - function: auth-login

--- a/.kiro/specs/post-site-build-consistency/design.md
+++ b/.kiro/specs/post-site-build-consistency/design.md
@@ -1,0 +1,77 @@
+# 技術設計: 記事と公開サイトビルドの整合性
+
+## 概要
+
+BlogPostsテーブルに予約ID `__SITE_BUILD_STATE__` の制御項目を置き、記事変更と
+`desiredRevision` の加算をDynamoDB transactionで一体化する。CodeBuildは一度に
+1件だけ開始し、実行中の変更は `desiredRevision > activeRevision` として保持する。
+完了照合Lambdaは成功したrevisionを `deployedRevision` へ反映し、差分が残れば
+後続ビルドを開始する。
+
+```mermaid
+sequenceDiagram
+    participant A as Admin API
+    participant D as DynamoDB
+    participant C as CodeBuild
+    participant R as Reconciler
+    A->>D: 記事変更 + desiredRevision++ (transaction)
+    A->>D: starting lockを条件付き取得
+    A->>C: StartBuild(CONTENT_REVISION)
+    C-->>R: State Change event
+    R->>C: BatchGetBuilds(activeBuildId)
+    R->>D: deployedRevision更新
+    alt desiredRevision > deployedRevision
+      R->>C: trailing build開始
+    end
+```
+
+## 状態モデル
+
+| 属性 | 意味 |
+|---|---|
+| `desiredRevision` | 記事変更transactionで単調増加する要求revision |
+| `deployedRevision` | KVS昇格まで成功した最新revision |
+| `activeRevision` | 現在開始中または実行中のrevision |
+| `activeBuildId` | CodeBuild Build ID |
+| `startToken` | StartBuildの冪等トークン |
+| `status` | `queued`, `starting`, `in-progress`, `succeeded`, `failed` |
+| `requestedAt/startedAt/completedAt` | 状態遷移時刻 |
+| `lastError` | 直近失敗内容 |
+
+## API契約
+
+ビルド要求を伴う作成・更新レスポンスは従来の記事フィールドに次を追加する。
+
+```json
+{
+  "siteBuild": {
+    "targetRevision": 42,
+    "buildId": "optional",
+    "status": "queued"
+  }
+}
+```
+
+`GET /admin/posts/{id}/build-status?targetRevision=42` はDynamoDBの制御項目を読み、
+`deployedRevision >= targetRevision` の場合だけ `succeeded` を返す。記事IDは既存API
+互換性のため維持するが、相関キーには使用しない。
+
+## 明示保存と自動保存
+
+- `saveMode=manual`（省略時の既定）: category必須。公開サイトへ影響する場合はrevisionを作成する。
+- `saveMode=autosave`: publishStatusを無視し、作成時はdraft固定。空categoryを省略し、更新時は既存値を維持する。
+
+## 完了・補償経路
+
+- EventBridge CodeBuild State Changeを低遅延経路とする。
+- EventBridge targetはretry policyとSQS DLQを持つ。
+- EventBridge Schedulerが5分間隔で同じLambdaを起動する。
+- ReconcilerはDynamoDBのactiveBuildIdを正としてBatchGetBuildsし、イベント重複・順不同を無害化する。
+- `starting` が5分以上継続した場合は同じStartBuild idempotency tokenで再開する。
+
+## リスク
+
+1. 記事用単一テーブルへ制御項目を置くため、Scanを追加する場合は予約ID除外が必要となる。現行記事一覧はGSI Queryのため影響しない。
+2. 記事更新transaction成功後にStartBuildが失敗しても要求はqueued/failedとして残り、定期照合で再試行される。
+3. 状態表示はポーリング方式で最大5秒程度の遅延がある。
+4. S3/KVSの完全性はKVS atomic deploymentの成功をCodeBuild成功として扱う契約に依存する。

--- a/.kiro/specs/post-site-build-consistency/requirements.md
+++ b/.kiro/specs/post-site-build-consistency/requirements.md
@@ -1,0 +1,60 @@
+# 要件: 記事と公開サイトビルドの整合性
+
+## Requirement 1: 公開状態の収束
+
+**Objective:** 管理者として、記事の公開状態を変更した最終結果を公開サイトへ確実に反映したい。
+
+### Acceptance Criteria
+
+1. 新規公開、下書きから公開、公開から下書き、公開中記事の明示保存、公開記事削除はサイトビルド要求を作成すること。
+2. 下書きの明示保存、下書き記事削除、自動保存はサイトビルド要求を作成しないこと。
+3. 記事変更とビルド要求のrevision更新は同一DynamoDBトランザクションに含めること。
+4. 実行中ビルドがある場合も最新のdesired revisionを保持し、完了後の後続ビルドで回収すること。
+5. ビルド成功時だけdeployed revisionを進め、失敗時は直前の公開サイトを維持すること。
+
+## Requirement 2: 相関可能なビルド状態
+
+**Objective:** 管理者として、自分の保存操作に対応する公開反映状態を確認したい。
+
+### Acceptance Criteria
+
+1. ビルド要求を伴う保存レスポンスはtarget revisionと状態を返すこと。
+2. 状態APIはtarget revisionを受け取り、過去の成功ビルドを新しい要求の成功と判定しないこと。
+3. deployed revisionがtarget revision以上の場合だけ反映完了とすること。
+4. queued、in-progress、succeeded、failedを区別すること。
+5. 一覧再読み込み後も現在のサイトビルド状態を取得できること。
+
+## Requirement 3: 完了通知と補償
+
+**Objective:** 運用者として、CodeBuild完了イベントの欠落や重複があっても最終状態へ収束させたい。
+
+### Acceptance Criteria
+
+1. CodeBuild State ChangeのEventBridgeイベントで状態照合Lambdaを起動すること。
+2. EventBridge targetに再試行とDLQを設定すること。
+3. 定期スケジュールでも同じ照合Lambdaを起動すること。
+4. 完了イベントはBuild IDとactive revisionを条件に冪等処理すること。
+5. starting状態の中断を検出して再開できること。
+
+## Requirement 4: 明示保存後の一覧表示
+
+**Objective:** 管理者として、保存後に記事一覧へ戻り、公開反映状態を確認したい。
+
+### Acceptance Criteria
+
+1. 新規作成・編集の明示保存後は公開状態にかかわらず記事一覧へ遷移すること。
+2. 公開状態変更と公開記事削除でも同じビルド状態UIを表示すること。
+3. 状態は3〜5秒間隔でポーリングし、対象revisionの成功または失敗で停止すること。
+4. API取得失敗とビルド失敗を区別して表示すること。
+
+## Requirement 5: カテゴリ未設定の自動保存
+
+**Objective:** 管理者として、カテゴリを選ぶ前でも編集中の下書きを失わずに保存したい。
+
+### Acceptance Criteria
+
+1. 自動保存payloadはpublishStatusを変更せず、saveMode=autosaveを明示すること。
+2. 新規自動保存は常にdraftを作成すること。
+3. カテゴリ未設定の自動保存はcategory属性をDynamoDBへ保存しないこと。
+4. 既存公開記事の自動保存でカテゴリが未設定なら、永続化済みカテゴリを維持すること。
+5. 明示保存と公開記事ではカテゴリ必須を維持すること。

--- a/.kiro/specs/post-site-build-consistency/spec.json
+++ b/.kiro/specs/post-site-build-consistency/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "post-site-build-consistency",
+  "created_at": "2026-08-02T11:00:00+09:00",
+  "updated_at": "2026-08-02T11:00:00+09:00",
+  "language": "ja",
+  "phase": "implementation",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/post-site-build-consistency/tasks.md
+++ b/.kiro/specs/post-site-build-consistency/tasks.md
@@ -1,0 +1,11 @@
+# 実装タスク
+
+- [x] 1. サイトビルド状態モデルとDynamoDB transaction helperを実装する
+- [x] 2. create/update/deleteを公開影響判定と永続revisionへ接続する
+- [x] 3. CodeBuild開始ロック、冪等開始、trailing buildを実装する
+- [x] 4. EventBridge完了通知、DLQ、Scheduler照合をTerraformへ追加する
+- [x] 5. 状態APIをtarget revision相関へ変更する
+- [x] 6. saveMode契約とカテゴリ未設定autosaveを実装する
+- [x] 7. 明示保存後の一覧遷移と一覧ビルド状態表示を実装する
+- [x] 8. Go、Vitest、Terraform、E2Eの回帰テストを追加する
+- [x] 9. dev/prd Terraform validateと `bun run verify` を通す

--- a/frontend/admin/src/api/posts.ts
+++ b/frontend/admin/src/api/posts.ts
@@ -6,7 +6,7 @@ export interface Post {
   title: string;
   contentMarkdown: string;
   contentHtml: string;
-  category: string;
+  category?: string;
   tags: string[];
   publishStatus: 'draft' | 'published';
   createdAt: string;
@@ -14,17 +14,25 @@ export interface Post {
   slug?: string;
   excerpt?: string;
   coverImageUrl?: string;
+  siteBuild?: SiteBuildRequest;
+}
+
+export interface SiteBuildRequest {
+  targetRevision: number;
+  buildId?: string;
+  status: BuildStatusValue;
 }
 
 export interface CreatePostRequest {
   title: string;
   contentMarkdown: string;
-  category: string;
+  category?: string;
   tags?: string[];
   publishStatus: 'draft' | 'published';
   slug?: string;
   excerpt?: string;
   coverImageUrl?: string;
+  saveMode?: 'manual' | 'autosave';
 }
 
 export interface UpdatePostRequest {
@@ -36,6 +44,7 @@ export interface UpdatePostRequest {
   slug?: string;
   excerpt?: string;
   coverImageUrl?: string;
+  saveMode?: 'manual' | 'autosave';
 }
 
 /**
@@ -149,9 +158,14 @@ export const deletePost = async (id: string): Promise<void> => {
 };
 
 /**
- * CodeBuild ビルドステータスのレスポンス型 (PR5b)
+ * 公開サイトビルドのステータスレスポンス型
  */
-export type BuildStatusValue = 'idle' | 'in-progress' | 'succeeded' | 'failed';
+export type BuildStatusValue =
+  | 'idle'
+  | 'queued'
+  | 'in-progress'
+  | 'succeeded'
+  | 'failed';
 
 export interface BuildStatusResponse {
   buildId?: string;
@@ -159,17 +173,22 @@ export interface BuildStatusResponse {
   phase?: string;
   startTime?: string;
   endTime?: string;
+  targetRevision?: number;
+  desiredRevision?: number;
+  deployedRevision?: number;
 }
 
 /**
- * 公開後のビルドステータスを取得
- * 直近の CodeBuild 結果を返却し、admin UI のバッジ表示に利用される。
+ * 保存に対応する公開サイトビルドのステータスを取得する。
+ * targetRevision 指定時は、その保存が公開サイトへ反映済みかを返す。
  */
 export const fetchBuildStatus = async (
-  postId: string
+  postId: string,
+  targetRevision?: number
 ): Promise<BuildStatusResponse> => {
   const response = await apiClient.get<BuildStatusResponse>(
-    `/admin/posts/${postId}/build-status`
+    `/admin/posts/${postId}/build-status`,
+    { params: targetRevision ? { targetRevision } : undefined }
   );
   return response.data;
 };

--- a/frontend/admin/src/components/BuildStatusBadge.tsx
+++ b/frontend/admin/src/components/BuildStatusBadge.tsx
@@ -13,10 +13,13 @@ export interface BuildStatusBadgeProps {
   publicUrl?: string;
   /** テスト用ポーリング間隔上書き。 */
   intervalMs?: number;
+  /** 保存操作に対応するサイトcontent revision。 */
+  targetRevision?: number;
 }
 
 const STATUS_LABEL: Record<string, string> = {
   idle: '待機中',
+  queued: '反映待ち…',
   'in-progress': 'ビルド中…',
   succeeded: 'ビルド完了',
   failed: 'ビルド失敗',
@@ -24,6 +27,7 @@ const STATUS_LABEL: Record<string, string> = {
 
 const STATUS_CLASS: Record<string, string> = {
   idle: 'admin-badge-light',
+  queued: 'admin-badge-warning',
   'in-progress': 'admin-badge-dark',
   succeeded: 'admin-badge-success',
   failed: 'admin-badge-danger',
@@ -42,10 +46,12 @@ export const BuildStatusBadge: React.FC<BuildStatusBadgeProps> = ({
   enabled,
   publicUrl,
   intervalMs,
+  targetRevision,
 }) => {
   const { status, error } = useBuildStatus(postId, {
     enabled: enabled && Boolean(postId),
     intervalMs,
+    targetRevision,
   });
 
   if (!enabled || !postId) {

--- a/frontend/admin/src/components/PostEditor.test.tsx
+++ b/frontend/admin/src/components/PostEditor.test.tsx
@@ -1032,4 +1032,42 @@ describe('PostEditor', () => {
       expect(addButton).not.toBeDisabled();
     });
   });
+
+  it('カテゴリ未設定の自動保存は公開状態とcategoryを送信しない', async () => {
+    const onAutosave = vi.fn().mockResolvedValue(undefined);
+    const initialData: PostData = {
+      title: '公開中の記事',
+      contentMarkdown: '本文',
+      category: '',
+      tags: [],
+      publishStatus: 'published',
+    };
+
+    render(
+      <PostEditor
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+        onAutosave={onAutosave}
+        categories={mockCategories}
+        initialData={initialData}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/タイトル/i), {
+      target: { value: '公開中の記事（編集中）' },
+    });
+
+    await waitFor(() => expect(onAutosave).toHaveBeenCalled(), {
+      timeout: 2500,
+    });
+    const payload = onAutosave.mock.calls.at(-1)?.[0];
+    expect(payload).toEqual(
+      expect.objectContaining({
+        title: '公開中の記事（編集中）',
+        saveMode: 'autosave',
+      })
+    );
+    expect(payload).not.toHaveProperty('category');
+    expect(payload).not.toHaveProperty('publishStatus');
+  });
 });

--- a/frontend/admin/src/components/PostEditor.tsx
+++ b/frontend/admin/src/components/PostEditor.tsx
@@ -33,6 +33,11 @@ export interface PostData {
   coverImageUrl?: string;
 }
 
+export type AutosavePostData = Omit<PostData, 'category' | 'publishStatus'> & {
+  category?: string;
+  saveMode: 'autosave';
+};
+
 export interface PostEditorHandle {
   insertAtCursor: (text: string) => void;
   removeImageUrl: (imageUrl: string) => void;
@@ -66,7 +71,7 @@ interface PostEditorProps {
    * 1.5s デバウンス / window blur / visibility hidden で発火し、
    * 失敗時は throw する。新規作成時は親側で createPost + URL 置換を行う。
    */
-  onAutosave?: (data: PostData) => Promise<void>;
+  onAutosave?: (data: AutosavePostData) => Promise<void>;
 }
 
 export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
@@ -143,18 +148,18 @@ export const PostEditor = forwardRef<PostEditorHandle, PostEditorProps>(
 
     // 自動保存 (onAutosave が渡された時のみ有効)。
     // タイトル非空かつ本文非空の場合だけ保存対象にする (空 POST を防ぐ)。
-    const autosaveData: PostData = {
+    const autosaveData: AutosavePostData = {
       title,
       contentMarkdown,
-      category: meta.category,
       tags: meta.tags,
-      publishStatus: meta.publishStatus,
+      saveMode: 'autosave',
+      ...(meta.category ? { category: meta.category } : {}),
       slug: meta.slug || undefined,
       excerpt: meta.excerpt || undefined,
       coverImageUrl: meta.coverImageUrl || undefined,
     };
     const noopAutosave = useRef(async () => {}).current;
-    const autosave = useAutosave<PostData>({
+    const autosave = useAutosave<AutosavePostData>({
       data: autosaveData,
       save: onAutosave ?? noopAutosave,
       enabled: !!onAutosave,

--- a/frontend/admin/src/hooks/useBuildStatus.test.ts
+++ b/frontend/admin/src/hooks/useBuildStatus.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import type { BuildStatusResponse } from '../api/posts';
 
 vi.mock('../api/posts');
 const postsApi = await import('../api/posts');
@@ -62,6 +63,25 @@ describe('useBuildStatus', () => {
     expect(result.current.buildId).toBe('b-1');
     expect(result.current.phase).toBe('BUILD');
     expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes targetRevision so status is correlated with the save', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      status: 'queued',
+      targetRevision: 7,
+    });
+
+    const { result } = renderHook(() =>
+      useBuildStatus('post-1', {
+        enabled: true,
+        intervalMs: 1000,
+        targetRevision: 7,
+      })
+    );
+
+    await flush();
+    expect(result.current.status).toBe('queued');
+    expect(mockedFetch).toHaveBeenCalledWith('post-1', 7);
   });
 
   it('keeps polling on the configured interval until succeeded', async () => {
@@ -182,5 +202,38 @@ describe('useBuildStatus', () => {
       await vi.advanceTimersByTimeAsync(2000);
     });
     expect(mockedFetch).toHaveBeenCalledTimes(callsBefore);
+  });
+
+  it('ignores a stale response after the correlation target changes', async () => {
+    let resolveOldRequest: (value: BuildStatusResponse) => void = () =>
+      undefined;
+    mockedFetch
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOldRequest = resolve;
+          })
+      )
+      .mockResolvedValueOnce({ status: 'succeeded', targetRevision: 2 });
+
+    const { result, rerender } = renderHook(
+      ({ targetRevision }: { targetRevision: number }) =>
+        useBuildStatus('post-1', {
+          enabled: true,
+          intervalMs: 200,
+          targetRevision,
+        }),
+      { initialProps: { targetRevision: 1 } }
+    );
+
+    rerender({ targetRevision: 2 });
+    await flush();
+    expect(result.current.status).toBe('succeeded');
+
+    await act(async () => {
+      resolveOldRequest({ status: 'in-progress', targetRevision: 1 });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.status).toBe('succeeded');
   });
 });

--- a/frontend/admin/src/hooks/useBuildStatus.ts
+++ b/frontend/admin/src/hooks/useBuildStatus.ts
@@ -16,6 +16,8 @@ export interface UseBuildStatusOptions {
    * ポーリング間隔(ms)。テスト用に上書き可能。デフォルト 5000ms。
    */
   intervalMs?: number;
+  /** 保存レスポンスが返した相関対象revision。 */
+  targetRevision?: number;
 }
 
 export interface UseBuildStatusResult {
@@ -42,24 +44,19 @@ const DEFAULT_INTERVAL = 5_000;
  */
 export function useBuildStatus(
   postId: string | undefined,
-  { enabled, intervalMs = DEFAULT_INTERVAL }: UseBuildStatusOptions
+  {
+    enabled,
+    intervalMs = DEFAULT_INTERVAL,
+    targetRevision,
+  }: UseBuildStatusOptions
 ): UseBuildStatusResult {
   const [snapshot, setSnapshot] = useState<BuildStatusResponse>({
     status: 'idle',
   });
   const [error, setError] = useState<string | null>(null);
 
-  // mount 状態は state 更新の取りこぼし防止に使う。
-  const mountedRef = useRef(true);
   // ポーリングを止める判定に使う最新値。state ではタイマー内で stale になる。
   const stoppedRef = useRef(false);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     if (!enabled || !postId) {
@@ -72,14 +69,15 @@ export function useBuildStatus(
 
     let timer: ReturnType<typeof setTimeout> | null = null;
     let inFlight = false;
+    let cancelled = false;
     stoppedRef.current = false;
 
     const tick = async (): Promise<void> => {
       if (inFlight || stoppedRef.current) return;
       inFlight = true;
       try {
-        const result = await fetchBuildStatus(postId);
-        if (!mountedRef.current) return;
+        const result = await fetchBuildStatus(postId, targetRevision);
+        if (cancelled) return;
         setSnapshot(result);
         setError(null);
         if (result.status === 'succeeded' || result.status === 'failed') {
@@ -87,7 +85,7 @@ export function useBuildStatus(
           return;
         }
       } catch (err) {
-        if (!mountedRef.current) return;
+        if (cancelled) return;
         setError(
           err instanceof Error ? err.message : 'failed to fetch build status'
         );
@@ -95,7 +93,7 @@ export function useBuildStatus(
         inFlight = false;
       }
 
-      if (!stoppedRef.current && mountedRef.current) {
+      if (!stoppedRef.current && !cancelled) {
         timer = setTimeout(() => {
           void tick();
         }, intervalMs);
@@ -105,12 +103,13 @@ export function useBuildStatus(
     void tick();
 
     return () => {
+      cancelled = true;
       stoppedRef.current = true;
       if (timer !== null) {
         clearTimeout(timer);
       }
     };
-  }, [enabled, postId, intervalMs]);
+  }, [enabled, postId, intervalMs, targetRevision]);
 
   return {
     status: snapshot.status,

--- a/frontend/admin/src/pages/PostCreatePage.test.tsx
+++ b/frontend/admin/src/pages/PostCreatePage.test.tsx
@@ -203,7 +203,13 @@ describe('PostCreatePage', () => {
     await user.click(screen.getByRole('button', { name: /保存/i }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/posts');
+      expect(mockNavigate).toHaveBeenCalledWith('/posts', {
+        state: {
+          postId: 'test-id',
+          siteBuild: undefined,
+          message: '記事を保存しました',
+        },
+      });
     });
   });
 
@@ -500,7 +506,13 @@ describe('PostCreatePage', () => {
     await user.click(screen.getByRole('button', { name: /保存/i }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/posts');
+      expect(mockNavigate).toHaveBeenCalledWith('/posts', {
+        state: {
+          postId: 'test-id',
+          siteBuild: undefined,
+          message: '記事を保存しました',
+        },
+      });
     });
   });
 });

--- a/frontend/admin/src/pages/PostCreatePage.tsx
+++ b/frontend/admin/src/pages/PostCreatePage.tsx
@@ -3,20 +3,17 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import {
   PostEditor,
+  type AutosavePostData,
   type PostData,
   type PostEditorHandle,
 } from '../components/PostEditor';
 import { createPost, updatePost } from '../api/posts';
 import AdminLayout from '../components/AdminLayout';
-import { BuildStatusBadge } from '../components/BuildStatusBadge';
 import { useCategories } from '../hooks/useCategories';
 
 const PostCreatePage = () => {
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
-  // PR5b: When the new post is created with publishStatus='published', stay
-  // on the page and surface CodeBuild progress via BuildStatusBadge.
-  const [publishedPostId, setPublishedPostId] = useState<string | null>(null);
   const editorRef = useRef<PostEditorHandle>(null);
   // autosave で記事が初回作成された後の id。これ以降の保存は updatePost を使う。
   const [postId, setPostId] = useState<string | null>(null);
@@ -36,20 +33,32 @@ const PostCreatePage = () => {
       // それ以外の (autosave がまだ走っていない) 初回保存では createPost。
       let savedId: string;
       if (postId) {
-        await updatePost(postId, data);
+        const updated = await updatePost(postId, {
+          ...data,
+          saveMode: 'manual',
+        });
         savedId = postId;
+        navigate('/posts', {
+          state: {
+            postId: savedId,
+            siteBuild: updated?.siteBuild,
+            message: '記事を保存しました',
+          },
+        });
+        return;
       } else {
-        const created = await createPost(data);
+        const created = await createPost({ ...data, saveMode: 'manual' });
         savedId = created.id;
         setPostId(created.id);
-      }
-      // PR5b: publish ならページに留まり BuildStatusBadge を表示する。
-      // draft なら従来通り一覧へ遷移。
-      if (data.publishStatus === 'published') {
-        setPublishedPostId(savedId);
+        navigate('/posts', {
+          state: {
+            postId: savedId,
+            siteBuild: created?.siteBuild,
+            message: '記事を保存しました',
+          },
+        });
         return;
       }
-      navigate('/posts');
     } catch (err) {
       console.error('記事作成エラー:', err);
       // PR6: surface server-side slug conflict so the writer knows to change it.
@@ -71,7 +80,7 @@ const PostCreatePage = () => {
   // - 2 回目以降: updatePost(id, data)。
   // 失敗時は throw → useAutosave が status='error' に遷移させる。
   const handleAutosave = useCallback(
-    async (data: PostData) => {
+    async (data: AutosavePostData) => {
       if (postId) {
         await updatePost(postId, data);
         return;
@@ -99,11 +108,6 @@ const PostCreatePage = () => {
           {error}
         </div>
       )}
-
-      <BuildStatusBadge
-        postId={publishedPostId ?? undefined}
-        enabled={publishedPostId !== null}
-      />
 
       <div className="admin-card">
         <PostEditor

--- a/frontend/admin/src/pages/PostEditPage.test.tsx
+++ b/frontend/admin/src/pages/PostEditPage.test.tsx
@@ -223,6 +223,7 @@ describe('PostEditPage', () => {
           category: 'tech',
           tags: ['test-tag'],
           publishStatus: 'published',
+          saveMode: 'manual',
         });
       });
     });

--- a/frontend/admin/src/pages/PostEditPage.tsx
+++ b/frontend/admin/src/pages/PostEditPage.tsx
@@ -3,12 +3,12 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import {
   PostEditor,
+  type AutosavePostData,
   type PostData,
   type PostEditorHandle,
 } from '../components/PostEditor';
 import { getPost, updatePost } from '../api/posts';
 import AdminLayout from '../components/AdminLayout';
-import { BuildStatusBadge } from '../components/BuildStatusBadge';
 import { PostEditSkeleton } from '../components/skeleton';
 import { useCategories } from '../hooks/useCategories';
 
@@ -18,9 +18,6 @@ const PostEditPage = () => {
   const [initialData, setInitialData] = useState<PostData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // PR5b: After publish, stay on the page and show build progress instead of
-  // navigating away. Drafts continue to navigate to the list.
-  const [publishedPostId, setPublishedPostId] = useState<string | null>(null);
   const editorRef = useRef<PostEditorHandle>(null);
 
   // カテゴリを動的に取得
@@ -44,7 +41,7 @@ const PostEditPage = () => {
         setInitialData({
           title: post.title,
           contentMarkdown: post.contentMarkdown,
-          category: post.category,
+          category: post.category ?? '',
           tags: post.tags || [],
           publishStatus: post.publishStatus,
           slug: post.slug ?? '',
@@ -67,12 +64,14 @@ const PostEditPage = () => {
     // このhandleSaveは呼ばれない。したがって、冗長なIDチェックは不要。
     try {
       setError(null);
-      await updatePost(id!, data);
-      if (data.publishStatus === 'published') {
-        setPublishedPostId(id!);
-        return;
-      }
-      navigate('/posts');
+      const updated = await updatePost(id!, { ...data, saveMode: 'manual' });
+      navigate('/posts', {
+        state: {
+          postId: id!,
+          siteBuild: updated?.siteBuild,
+          message: '記事を保存しました',
+        },
+      });
     } catch (err) {
       console.error('記事更新エラー:', err);
       if (axios.isAxiosError(err) && err.response?.status === 409) {
@@ -88,7 +87,7 @@ const PostEditPage = () => {
 
   // 自動保存: 既存記事なので常に updatePost
   const handleAutosave = useCallback(
-    async (data: PostData) => {
+    async (data: AutosavePostData) => {
       if (!id) return;
       await updatePost(id, data);
     },
@@ -118,11 +117,6 @@ const PostEditPage = () => {
   return (
     <AdminLayout title="Edit Article" subtitle="記事を編集">
       {error && <div className="admin-alert admin-alert-error">{error}</div>}
-
-      <BuildStatusBadge
-        postId={publishedPostId ?? undefined}
-        enabled={publishedPostId !== null}
-      />
 
       <div className="admin-card">
         {initialData && (

--- a/frontend/admin/src/pages/PostListPage.test.tsx
+++ b/frontend/admin/src/pages/PostListPage.test.tsx
@@ -758,6 +758,7 @@ describe('PostListPage', () => {
           contentMarkdown: 'Content',
           category: 'tech',
           publishStatus: 'published',
+          saveMode: 'manual',
         });
         expect(screen.getByText(/記事を公開しました/i)).toBeInTheDocument();
       });
@@ -795,6 +796,7 @@ describe('PostListPage', () => {
           contentMarkdown: 'Content',
           category: 'tech',
           publishStatus: 'draft',
+          saveMode: 'manual',
         });
         expect(
           screen.getByText(/記事を下書きに変更しました/i)
@@ -874,7 +876,7 @@ describe('PostListPage', () => {
       await waitFor(() => {
         expect(screen.getByTestId('build-status-badge')).toBeInTheDocument();
       });
-      expect(mockFetchBuildStatus).toHaveBeenCalledWith('1');
+      expect(mockFetchBuildStatus).toHaveBeenCalledWith('1', undefined);
     });
 
     it('下書き記事を削除した場合はビルドステータスバッジを表示しない', async () => {
@@ -927,10 +929,10 @@ describe('PostListPage', () => {
       expect(
         screen.queryByTestId('build-status-badge')
       ).not.toBeInTheDocument();
-      expect(mockFetchBuildStatus).not.toHaveBeenCalled();
+      expect(mockFetchBuildStatus).not.toHaveBeenCalledWith('2', undefined);
     });
 
-    it('タブを切り替えるとビルドステータスバッジが消える', async () => {
+    it('タブを切り替えてもビルドステータスバッジを維持する', async () => {
       const publishedPost = {
         id: '1',
         title: 'Published Post',
@@ -970,9 +972,7 @@ describe('PostListPage', () => {
       fireEvent.click(screen.getByRole('button', { name: /下書き/i }));
 
       await waitFor(() => {
-        expect(
-          screen.queryByTestId('build-status-badge')
-        ).not.toBeInTheDocument();
+        expect(screen.getByTestId('build-status-badge')).toBeInTheDocument();
       });
     });
   });

--- a/frontend/admin/src/pages/PostListPage.tsx
+++ b/frontend/admin/src/pages/PostListPage.tsx
@@ -1,13 +1,19 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { getPosts, deletePost, updatePost } from '../api/posts';
-import type { Post } from '../api/posts';
+import {
+  getPosts,
+  deletePost,
+  updatePost,
+  fetchBuildStatus,
+} from '../api/posts';
+import type { Post, SiteBuildRequest } from '../api/posts';
 import ConfirmDialog from '../components/ConfirmDialog';
 import AdminLayout from '../components/AdminLayout';
 import { BuildStatusBadge } from '../components/BuildStatusBadge';
 import { PostListSkeleton } from '../components/skeleton';
 
 type TabType = 'published' | 'draft';
+type BuildTracking = { postId: string; siteBuild?: SiteBuildRequest };
 
 const PostListPage = () => {
   const location = useLocation();
@@ -23,9 +29,20 @@ const PostListPage = () => {
   const [showConfirmDialog, setShowConfirmDialog] = useState<boolean>(false);
   const [postToDelete, setPostToDelete] = useState<string | null>(null);
 
-  // 公開済み記事を削除した直後にビルドステータスを表示するための postId。
-  // 下書き削除時はサーバー側でビルドが起きないため null のまま。
-  const [deletedPostId, setDeletedPostId] = useState<string | null>(null);
+  const navigationState = location.state as {
+    postId?: string;
+    siteBuild?: SiteBuildRequest;
+    message?: string;
+  } | null;
+  const [buildTracking, setBuildTracking] = useState<BuildTracking | null>(
+    () =>
+      navigationState?.postId && navigationState.siteBuild
+        ? {
+            postId: navigationState.postId,
+            siteBuild: navigationState.siteBuild,
+          }
+        : null
+  );
 
   const loadPosts = async (publishStatus: TabType, token?: string) => {
     try {
@@ -50,11 +67,53 @@ const PostListPage = () => {
     loadPosts(activeTab);
   }, [activeTab, location.key]); // location.keyを追加してナビゲーション時に再読み込み
 
+  useEffect(() => {
+    let cancelled = false;
+    if (navigationState?.message) {
+      setSuccessMessage(navigationState.message);
+    }
+    if (navigationState?.postId && navigationState.siteBuild) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    void fetchBuildStatus('site')
+      .then((status) => {
+        if (
+          !cancelled &&
+          (status.status === 'queued' ||
+            status.status === 'in-progress' ||
+            status.status === 'failed')
+        ) {
+          setBuildTracking({
+            postId: 'site',
+            siteBuild: status.targetRevision
+              ? {
+                  targetRevision: status.targetRevision,
+                  buildId: status.buildId,
+                  status: status.status,
+                }
+              : undefined,
+          });
+        }
+      })
+      .catch(() => {
+        // Badge 側のポーリングで取得を再試行し、API エラーを表示する。
+        if (!cancelled) setBuildTracking({ postId: 'site' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    navigationState?.message,
+    navigationState?.postId,
+    navigationState?.siteBuild,
+  ]);
+
   const handleTabChange = (tab: TabType) => {
     setActiveTab(tab);
     setNextToken(undefined);
     setSearchQuery(''); // タブ切り替え時に検索クエリをリセット
-    setDeletedPostId(null); // タブ切り替え時に直前のビルドステータスバッジを消す
   };
 
   const handleNextPage = () => {
@@ -82,7 +141,7 @@ const PostListPage = () => {
       await deletePost(postToDelete);
       setSuccessMessage('記事を削除しました');
       if (wasPublished) {
-        setDeletedPostId(postToDelete);
+        setBuildTracking({ postId: postToDelete });
       }
       setShowConfirmDialog(false);
       setPostToDelete(null);
@@ -107,12 +166,17 @@ const PostListPage = () => {
       const newStatus: 'draft' | 'published' =
         post.publishStatus === 'published' ? 'draft' : 'published';
 
-      await updatePost(post.id, {
+      const updated = await updatePost(post.id, {
         title: post.title,
         contentMarkdown: post.contentMarkdown,
         category: post.category,
         publishStatus: newStatus,
+        saveMode: 'manual',
       });
+
+      if (updated?.siteBuild) {
+        setBuildTracking({ postId: post.id, siteBuild: updated.siteBuild });
+      }
 
       setSuccessMessage(
         `記事を${newStatus === 'published' ? '公開' : '下書きに変更'}しました`
@@ -179,8 +243,9 @@ const PostListPage = () => {
       )}
 
       <BuildStatusBadge
-        postId={deletedPostId ?? undefined}
-        enabled={deletedPostId !== null}
+        postId={buildTracking?.postId}
+        enabled={buildTracking !== null}
+        targetRevision={buildTracking?.siteBuild?.targetRevision}
       />
 
       {/* 検索バー */}

--- a/go-functions/Makefile
+++ b/go-functions/Makefile
@@ -30,6 +30,7 @@ FUNCTIONS := \
 	posts/update \
 	posts/delete \
 	posts/build_status \
+	posts/reconcile_build \
 	auth/login \
 	auth/logout \
 	auth/refresh \

--- a/go-functions/cmd/posts/build_status/main.go
+++ b/go-functions/cmd/posts/build_status/main.go
@@ -1,49 +1,43 @@
 // Package main provides the GetBuildStatus Lambda function for retrieving
-// the latest CodeBuild status of the Astro SSG site rebuild.
+// the revision-correlated status of the Astro SSG site rebuild.
 //
 // PR5b: Build status visibility for the publish flow. The admin UI polls
 // this endpoint after a publish to show "queued / in-progress / succeeded /
 // failed" so the editor knows when their post is live.
 //
 // Route: GET /admin/posts/{id}/build-status (Cognito authenticated)
-//
-// The handler returns the most recent build for the configured CodeBuild
-// project. Build-to-post correlation is intentionally coarse: we surface
-// "the latest build for the project" rather than tying a build to the
-// post id (CodeBuild coalesces rapid publishes; precise correlation is
-// out of scope for this PR).
 package main
 
 import (
 	"context"
 	"os"
+	"strconv"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/codebuild"
-	"github.com/aws/aws-sdk-go-v2/service/codebuild/types"
 
 	"serverless-blog/go-functions/internal/auth"
-	"serverless-blog/go-functions/internal/buildtrigger"
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
 	"serverless-blog/go-functions/internal/middleware"
+	"serverless-blog/go-functions/internal/sitebuild"
 )
 
-// codebuildClientGetter returns a CodeBuild client. Overridable in tests.
-var codebuildClientGetter = func() (buildtrigger.CodeBuildClientInterface, error) {
-	return clients.GetCodeBuild()
+var dynamoClientGetter = func() (sitebuild.DynamoDBClient, error) {
+	return clients.GetDynamoDB()
 }
 
 // BuildStatusResponse is the API response body. Fields use camelCase JSON
 // to match the rest of the admin API.
 type BuildStatusResponse struct {
-	BuildID   string  `json:"buildId"`
-	Status    string  `json:"status"`
-	Phase     string  `json:"phase,omitempty"`
-	StartTime *string `json:"startTime,omitempty"`
-	EndTime   *string `json:"endTime,omitempty"`
+	BuildID          string `json:"buildId,omitempty"`
+	Status           string `json:"status"`
+	Phase            string `json:"phase,omitempty"`
+	TargetRevision   int64  `json:"targetRevision,omitempty"`
+	DesiredRevision  int64  `json:"desiredRevision,omitempty"`
+	DeployedRevision int64  `json:"deployedRevision,omitempty"`
+	StartTime        string `json:"startTime,omitempty"`
+	EndTime          string `json:"endTime,omitempty"`
 }
 
 // Handler handles GET /admin/posts/{id}/build-status.
@@ -56,77 +50,41 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		return errorResponse(400, "post ID is required")
 	}
 
-	projectName := buildtrigger.SanitizeProjectName(os.Getenv("CODEBUILD_PROJECT_NAME"))
-	if projectName == "" {
+	tableName := os.Getenv("TABLE_NAME")
+	if tableName == "" {
 		return errorResponse(500, "server configuration error")
 	}
 
-	client, err := codebuildClientGetter()
+	client, err := dynamoClientGetter()
 	if err != nil {
 		return errorResponse(500, "server error")
 	}
-
-	listOutput, err := client.ListBuildsForProject(ctx, &codebuild.ListBuildsForProjectInput{
-		ProjectName: aws.String(projectName),
-		SortOrder:   types.SortOrderTypeDescending,
-	})
-	if err != nil {
-		return errorResponse(500, "failed to list builds")
-	}
-
-	if len(listOutput.Ids) == 0 {
-		return middleware.JSONResponse(200, BuildStatusResponse{Status: "idle"})
-	}
-
-	getOutput, err := client.BatchGetBuilds(ctx, &codebuild.BatchGetBuildsInput{
-		Ids: []string{listOutput.Ids[0]},
-	})
+	coordinator := sitebuild.NewCoordinator(client, nil, tableName, "")
+	state, err := coordinator.GetState(ctx)
 	if err != nil {
 		return errorResponse(500, "failed to get build status")
 	}
 
-	if len(getOutput.Builds) == 0 {
-		return middleware.JSONResponse(200, BuildStatusResponse{Status: "idle"})
+	targetRevision := state.DesiredRevision
+	if raw := request.QueryStringParameters["targetRevision"]; raw != "" {
+		targetRevision, err = strconv.ParseInt(raw, 10, 64)
+		if err != nil || targetRevision <= 0 {
+			return errorResponse(400, "targetRevision must be a positive integer")
+		}
 	}
-
-	build := getOutput.Builds[0]
+	requestState := sitebuild.RequestForState(state, targetRevision)
 	resp := BuildStatusResponse{
-		Status: mapBuildStatus(build.BuildStatus),
-		Phase:  aws.ToString(build.CurrentPhase),
+		BuildID: requestState.BuildID, Status: requestState.Status,
+		TargetRevision: requestState.TargetRevision, DesiredRevision: state.DesiredRevision,
+		DeployedRevision: state.DeployedRevision, StartTime: state.StartedAt, EndTime: state.CompletedAt,
 	}
-	if build.Id != nil {
-		resp.BuildID = *build.Id
+	switch requestState.Status {
+	case sitebuild.StatusInProgress:
+		resp.Phase = "BUILD"
+	case sitebuild.StatusQueued:
+		resp.Phase = "QUEUED"
 	}
-	if build.StartTime != nil {
-		ts := build.StartTime.UTC().Format("2006-01-02T15:04:05Z07:00")
-		resp.StartTime = &ts
-	}
-	if build.EndTime != nil {
-		ts := build.EndTime.UTC().Format("2006-01-02T15:04:05Z07:00")
-		resp.EndTime = &ts
-	}
-
 	return middleware.JSONResponse(200, resp)
-}
-
-// mapBuildStatus maps a CodeBuild StatusType into one of the four UI states
-// (idle / in-progress / succeeded / failed). CodeBuild does not surface a
-// distinct "queued" state via this API, so the badge treats "in-progress"
-// as covering both queued and running.
-func mapBuildStatus(status types.StatusType) string {
-	switch status {
-	case types.StatusTypeInProgress:
-		return "in-progress"
-	case types.StatusTypeSucceeded:
-		return "succeeded"
-	case types.StatusTypeFailed,
-		types.StatusTypeFault,
-		types.StatusTypeTimedOut,
-		types.StatusTypeStopped:
-		return "failed"
-	default:
-		return "idle"
-	}
 }
 
 func errorResponse(statusCode int, message string) (events.APIGatewayProxyResponse, error) {

--- a/go-functions/cmd/posts/build_status/main_test.go
+++ b/go-functions/cmd/posts/build_status/main_test.go
@@ -5,447 +5,126 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/codebuild"
-	"github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 
-	"serverless-blog/go-functions/internal/buildtrigger"
-	"serverless-blog/go-functions/internal/domain"
+	"serverless-blog/go-functions/internal/sitebuild"
 )
 
-const (
-	testPostID      = "post-123"
-	testUserID      = "user-456"
-	testProjectName = "blog-astro-build-dev"
-)
-
-// mockCodeBuild satisfies buildtrigger.CodeBuildClientInterface.
-// StartBuild is unused by the build_status handler but is required by the
-// interface, so we provide a simple stub.
-type mockCodeBuild struct {
-	listFunc  func(ctx context.Context, params *codebuild.ListBuildsForProjectInput, optFns ...func(*codebuild.Options)) (*codebuild.ListBuildsForProjectOutput, error)
-	batchFunc func(ctx context.Context, params *codebuild.BatchGetBuildsInput, optFns ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error)
+type mockDynamo struct {
+	state sitebuild.State
+	err   error
 }
 
-func (m *mockCodeBuild) StartBuild(_ context.Context, _ *codebuild.StartBuildInput, _ ...func(*codebuild.Options)) (*codebuild.StartBuildOutput, error) {
-	return nil, errors.New("StartBuild not expected in build_status tests")
-}
-
-func (m *mockCodeBuild) ListBuildsForProject(ctx context.Context, params *codebuild.ListBuildsForProjectInput, optFns ...func(*codebuild.Options)) (*codebuild.ListBuildsForProjectOutput, error) {
-	if m.listFunc == nil {
-		return nil, errors.New("listFunc not set")
+func (m *mockDynamo) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	if m.err != nil {
+		return nil, m.err
 	}
-	return m.listFunc(ctx, params, optFns...)
-}
-
-func (m *mockCodeBuild) BatchGetBuilds(ctx context.Context, params *codebuild.BatchGetBuildsInput, optFns ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error) {
-	if m.batchFunc == nil {
-		return nil, errors.New("batchFunc not set")
+	if m.state.ID == "" {
+		return &dynamodb.GetItemOutput{}, nil
 	}
-	return m.batchFunc(ctx, params, optFns...)
+	item, err := attributevalue.MarshalMap(m.state)
+	return &dynamodb.GetItemOutput{Item: item}, err
 }
 
-func setupTest(t *testing.T) func() {
-	t.Helper()
-	t.Setenv("CODEBUILD_PROJECT_NAME", testProjectName)
-	original := codebuildClientGetter
-	return func() {
-		codebuildClientGetter = original
-	}
+func (m *mockDynamo) UpdateItem(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	return &dynamodb.UpdateItemOutput{}, nil
 }
 
-func authedRequest(postID string) events.APIGatewayProxyRequest {
+func request(target string) events.APIGatewayProxyRequest {
 	return events.APIGatewayProxyRequest{
-		PathParameters: map[string]string{"id": postID},
-		RequestContext: events.APIGatewayProxyRequestContext{
-			Authorizer: map[string]interface{}{
-				"claims": map[string]interface{}{
-					"sub": testUserID,
-				},
-			},
-		},
+		PathParameters:        map[string]string{"id": "post-1"},
+		QueryStringParameters: map[string]string{"targetRevision": target},
+		RequestContext: events.APIGatewayProxyRequestContext{Authorizer: map[string]interface{}{
+			"claims": map[string]interface{}{"sub": "user-1"},
+		}},
 	}
 }
 
-// --- success paths ---
-
-func TestHandler_ReturnsLatestInProgressBuild(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
-
-	start := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
-	mock := &mockCodeBuild{
-		listFunc: func(_ context.Context, params *codebuild.ListBuildsForProjectInput, _ ...func(*codebuild.Options)) (*codebuild.ListBuildsForProjectOutput, error) {
-			if aws.ToString(params.ProjectName) != testProjectName {
-				t.Errorf("expected project %q, got %q", testProjectName, aws.ToString(params.ProjectName))
-			}
-			if params.SortOrder != types.SortOrderTypeDescending {
-				t.Errorf("expected descending sort order, got %v", params.SortOrder)
-			}
-			return &codebuild.ListBuildsForProjectOutput{
-				Ids: []string{"build-newest", "build-older"},
-			}, nil
-		},
-		batchFunc: func(_ context.Context, params *codebuild.BatchGetBuildsInput, _ ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error) {
-			if len(params.Ids) != 1 || params.Ids[0] != "build-newest" {
-				t.Errorf("expected only newest build id requested, got %v", params.Ids)
-			}
-			return &codebuild.BatchGetBuildsOutput{
-				Builds: []types.Build{
-					{
-						Id:           aws.String("build-newest"),
-						BuildStatus:  types.StatusTypeInProgress,
-						CurrentPhase: aws.String("BUILD"),
-						StartTime:    &start,
-					},
-				},
-			}, nil
-		},
-	}
-	codebuildClientGetter = func() (buildtrigger.CodeBuildClientInterface, error) {
-		return mock, nil
-	}
-
-	resp, err := Handler(context.Background(), authedRequest(testPostID))
-	if err != nil {
-		t.Fatalf("Handler returned unexpected error: %v", err)
-	}
-	if resp.StatusCode != 200 {
-		t.Fatalf("expected 200, got %d (body=%s)", resp.StatusCode, resp.Body)
-	}
-
-	var body BuildStatusResponse
-	if err := json.Unmarshal([]byte(resp.Body), &body); err != nil {
-		t.Fatalf("failed to unmarshal: %v", err)
-	}
-	if body.BuildID != "build-newest" {
-		t.Errorf("expected buildId build-newest, got %q", body.BuildID)
-	}
-	if body.Status != "in-progress" {
-		t.Errorf("expected status in-progress, got %q", body.Status)
-	}
-	if body.Phase != "BUILD" {
-		t.Errorf("expected phase BUILD, got %q", body.Phase)
-	}
-	if body.StartTime == nil || *body.StartTime != "2026-05-01T10:00:00Z" {
-		t.Errorf("expected startTime 2026-05-01T10:00:00Z, got %v", body.StartTime)
-	}
-	if body.EndTime != nil {
-		t.Errorf("expected endTime nil for in-progress build, got %v", *body.EndTime)
-	}
+func setup(t *testing.T, state sitebuild.State) {
+	t.Helper()
+	t.Setenv("TABLE_NAME", "posts")
+	original := dynamoClientGetter
+	dynamoClientGetter = func() (sitebuild.DynamoDBClient, error) { return &mockDynamo{state: state}, nil }
+	t.Cleanup(func() { dynamoClientGetter = original })
 }
 
-func TestHandler_ReturnsIdleWhenNoBuilds(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
-
-	mock := &mockCodeBuild{
-		listFunc: func(_ context.Context, _ *codebuild.ListBuildsForProjectInput, _ ...func(*codebuild.Options)) (*codebuild.ListBuildsForProjectOutput, error) {
-			return &codebuild.ListBuildsForProjectOutput{Ids: []string{}}, nil
-		},
-	}
-	codebuildClientGetter = func() (buildtrigger.CodeBuildClientInterface, error) {
-		return mock, nil
-	}
-
-	resp, err := Handler(context.Background(), authedRequest(testPostID))
-	if err != nil {
-		t.Fatalf("Handler returned unexpected error: %v", err)
-	}
-	if resp.StatusCode != 200 {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-
-	var body BuildStatusResponse
-	if err := json.Unmarshal([]byte(resp.Body), &body); err != nil {
-		t.Fatalf("failed to unmarshal: %v", err)
-	}
-	if body.Status != "idle" {
-		t.Errorf("expected status idle, got %q", body.Status)
-	}
-}
-
-func TestHandler_ReturnsIdleWhenBatchGetEmpty(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
-
-	mock := &mockCodeBuild{
-		listFunc: func(_ context.Context, _ *codebuild.ListBuildsForProjectInput, _ ...func(*codebuild.Options)) (*codebuild.ListBuildsForProjectOutput, error) {
-			return &codebuild.ListBuildsForProjectOutput{Ids: []string{"build-x"}}, nil
-		},
-		batchFunc: func(_ context.Context, _ *codebuild.BatchGetBuildsInput, _ ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error) {
-			return &codebuild.BatchGetBuildsOutput{Builds: nil}, nil
-		},
-	}
-	codebuildClientGetter = func() (buildtrigger.CodeBuildClientInterface, error) {
-		return mock, nil
-	}
-
-	resp, err := Handler(context.Background(), authedRequest(testPostID))
-	if err != nil {
-		t.Fatalf("Handler returned unexpected error: %v", err)
-	}
-	if resp.StatusCode != 200 {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-	var body BuildStatusResponse
-	_ = json.Unmarshal([]byte(resp.Body), &body)
-	if body.Status != "idle" {
-		t.Errorf("expected status idle, got %q", body.Status)
-	}
-}
-
-func TestHandler_StatusMapping(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    types.StatusType
-		expected string
-	}{
-		{"in_progress -> in-progress", types.StatusTypeInProgress, "in-progress"},
-		{"succeeded -> succeeded", types.StatusTypeSucceeded, "succeeded"},
-		{"failed -> failed", types.StatusTypeFailed, "failed"},
-		{"fault -> failed", types.StatusTypeFault, "failed"},
-		{"timed_out -> failed", types.StatusTypeTimedOut, "failed"},
-		{"stopped -> failed", types.StatusTypeStopped, "failed"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cleanup := setupTest(t)
-			defer cleanup()
-
-			end := time.Date(2026, 5, 1, 10, 5, 0, 0, time.UTC)
-			mock := &mockCodeBuild{
-				listFunc: func(_ context.Context, _ *codebuild.ListBuildsForProjectInput, _ ...func(*codebuild.Options)) (*codebuild.ListBuildsForProjectOutput, error) {
-					return &codebuild.ListBuildsForProjectOutput{Ids: []string{"b-1"}}, nil
-				},
-				batchFunc: func(_ context.Context, _ *codebuild.BatchGetBuildsInput, _ ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error) {
-					return &codebuild.BatchGetBuildsOutput{
-						Builds: []types.Build{
-							{
-								Id:          aws.String("b-1"),
-								BuildStatus: tt.input,
-								EndTime:     &end,
-							},
-						},
-					}, nil
-				},
-			}
-			codebuildClientGetter = func() (buildtrigger.CodeBuildClientInterface, error) {
-				return mock, nil
-			}
-
-			resp, err := Handler(context.Background(), authedRequest(testPostID))
-			if err != nil || resp.StatusCode != 200 {
-				t.Fatalf("Handler failed: err=%v status=%d", err, resp.StatusCode)
-			}
-			var body BuildStatusResponse
-			if err := json.Unmarshal([]byte(resp.Body), &body); err != nil {
-				t.Fatalf("unmarshal: %v", err)
-			}
-			if body.Status != tt.expected {
-				t.Errorf("expected status %q, got %q", tt.expected, body.Status)
-			}
-			if body.EndTime == nil || *body.EndTime != "2026-05-01T10:05:00Z" {
-				t.Errorf("expected endTime, got %v", body.EndTime)
-			}
-		})
-	}
-}
-
-// --- error paths ---
-
-func TestHandler_Unauthorized(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
-
-	resp, err := Handler(context.Background(), events.APIGatewayProxyRequest{
-		PathParameters: map[string]string{"id": testPostID},
+func TestHandlerCorrelatesTargetRevision(t *testing.T) {
+	setup(t, sitebuild.State{
+		ID: sitebuild.StateItemID, DesiredRevision: 5, DeployedRevision: 3,
+		ActiveRevision: 4, ActiveBuildID: "build-4", Status: sitebuild.StatusInProgress,
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.StatusCode != 401 {
-		t.Errorf("expected 401, got %d", resp.StatusCode)
-	}
-}
-
-func TestHandler_MissingPostID(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
-
-	req := authedRequest("")
-	resp, err := Handler(context.Background(), req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.StatusCode != 400 {
-		t.Errorf("expected 400, got %d", resp.StatusCode)
-	}
-	var body domain.ErrorResponse
-	_ = json.Unmarshal([]byte(resp.Body), &body)
-	if body.Message != "post ID is required" {
-		t.Errorf("expected post ID is required, got %q", body.Message)
-	}
-}
-
-func TestHandler_MissingProjectName(t *testing.T) {
-	t.Setenv("CODEBUILD_PROJECT_NAME", "")
-	resp, err := Handler(context.Background(), authedRequest(testPostID))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.StatusCode != 500 {
-		t.Errorf("expected 500, got %d", resp.StatusCode)
-	}
-	var body domain.ErrorResponse
-	_ = json.Unmarshal([]byte(resp.Body), &body)
-	if body.Message != "server configuration error" {
-		t.Errorf("expected server configuration error, got %q", body.Message)
-	}
-}
-
-// SanitizeProjectName rejects names containing CR/LF or other control
-// characters. The handler must treat that as a server configuration error
-// — the same path as a missing env var.
-func TestHandler_RejectsInvalidProjectName(t *testing.T) {
-	t.Setenv("CODEBUILD_PROJECT_NAME", "bad name with spaces")
-	resp, err := Handler(context.Background(), authedRequest(testPostID))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.StatusCode != 500 {
-		t.Errorf("expected 500, got %d", resp.StatusCode)
-	}
-}
-
-func TestHandler_ClientInitError(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
-
-	codebuildClientGetter = func() (buildtrigger.CodeBuildClientInterface, error) {
-		return nil, errors.New("init failed")
-	}
-
-	resp, err := Handler(context.Background(), authedRequest(testPostID))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.StatusCode != 500 {
-		t.Errorf("expected 500, got %d", resp.StatusCode)
-	}
-}
-
-func TestHandler_ListBuildsError(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
-
-	mock := &mockCodeBuild{
-		listFunc: func(_ context.Context, _ *codebuild.ListBuildsForProjectInput, _ ...func(*codebuild.Options)) (*codebuild.ListBuildsForProjectOutput, error) {
-			return nil, errors.New("AccessDenied")
-		},
-	}
-	codebuildClientGetter = func() (buildtrigger.CodeBuildClientInterface, error) {
-		return mock, nil
-	}
-
-	resp, err := Handler(context.Background(), authedRequest(testPostID))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.StatusCode != 500 {
-		t.Errorf("expected 500, got %d", resp.StatusCode)
-	}
-	var body domain.ErrorResponse
-	_ = json.Unmarshal([]byte(resp.Body), &body)
-	if body.Message != "failed to list builds" {
-		t.Errorf("expected failed to list builds, got %q", body.Message)
-	}
-}
-
-func TestHandler_BatchGetBuildsError(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
-
-	mock := &mockCodeBuild{
-		listFunc: func(_ context.Context, _ *codebuild.ListBuildsForProjectInput, _ ...func(*codebuild.Options)) (*codebuild.ListBuildsForProjectOutput, error) {
-			return &codebuild.ListBuildsForProjectOutput{Ids: []string{"b-1"}}, nil
-		},
-		batchFunc: func(_ context.Context, _ *codebuild.BatchGetBuildsInput, _ ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error) {
-			return nil, errors.New("ThrottlingException")
-		},
-	}
-	codebuildClientGetter = func() (buildtrigger.CodeBuildClientInterface, error) {
-		return mock, nil
-	}
-
-	resp, err := Handler(context.Background(), authedRequest(testPostID))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.StatusCode != 500 {
-		t.Errorf("expected 500, got %d", resp.StatusCode)
-	}
-}
-
-// --- auth edge cases ---
-
-func TestHandler_AuthEdgeCases(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
 
 	tests := []struct {
-		name       string
-		authorizer map[string]interface{}
+		target string
+		status string
 	}{
-		{"nil authorizer", nil},
-		{"empty authorizer", map[string]interface{}{}},
-		{"nil claims", map[string]interface{}{"claims": nil}},
-		{"claims not a map", map[string]interface{}{"claims": "not-a-map"}},
-		{"no sub", map[string]interface{}{"claims": map[string]interface{}{"email": "x@y"}}},
-		{"sub not string", map[string]interface{}{"claims": map[string]interface{}{"sub": 123}}},
-		{"empty sub", map[string]interface{}{"claims": map[string]interface{}{"sub": ""}}},
+		{"3", sitebuild.StatusSucceeded},
+		{"4", sitebuild.StatusInProgress},
+		{"5", sitebuild.StatusQueued},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := events.APIGatewayProxyRequest{
-				PathParameters: map[string]string{"id": testPostID},
-				RequestContext: events.APIGatewayProxyRequestContext{Authorizer: tt.authorizer},
-			}
-			resp, err := Handler(context.Background(), req)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if resp.StatusCode != 401 {
-				t.Errorf("expected 401, got %d", resp.StatusCode)
-			}
-		})
+		resp, err := Handler(context.Background(), request(tt.target))
+		if err != nil || resp.StatusCode != 200 {
+			t.Fatalf("target %s: status=%d err=%v", tt.target, resp.StatusCode, err)
+		}
+		var body BuildStatusResponse
+		if err := json.Unmarshal([]byte(resp.Body), &body); err != nil {
+			t.Fatal(err)
+		}
+		if body.Status != tt.status || body.TargetRevision == 0 {
+			t.Errorf("target %s: got status=%s revision=%d", tt.target, body.Status, body.TargetRevision)
+		}
 	}
 }
 
-// --- response structure ---
+func TestHandlerUsesLatestDesiredRevisionWhenTargetOmitted(t *testing.T) {
+	setup(t, sitebuild.State{ID: sitebuild.StateItemID, DesiredRevision: 7, DeployedRevision: 7, Status: sitebuild.StatusSucceeded})
+	req := request("")
+	resp, _ := Handler(context.Background(), req)
+	var body BuildStatusResponse
+	_ = json.Unmarshal([]byte(resp.Body), &body)
+	if body.Status != sitebuild.StatusSucceeded || body.TargetRevision != 7 {
+		t.Fatalf("unexpected body: %+v", body)
+	}
+}
 
-func TestHandler_CORSHeaders(t *testing.T) {
-	cleanup := setupTest(t)
-	defer cleanup()
-
-	mock := &mockCodeBuild{
-		listFunc: func(_ context.Context, _ *codebuild.ListBuildsForProjectInput, _ ...func(*codebuild.Options)) (*codebuild.ListBuildsForProjectOutput, error) {
-			return &codebuild.ListBuildsForProjectOutput{Ids: []string{}}, nil
-		},
-	}
-	codebuildClientGetter = func() (buildtrigger.CodeBuildClientInterface, error) {
-		return mock, nil
-	}
-
-	resp, _ := Handler(context.Background(), authedRequest(testPostID))
-	if resp.Headers["Access-Control-Allow-Origin"] == "" {
-		t.Errorf("expected CORS header to be set")
-	}
-	if resp.Headers["Content-Type"] != "application/json" {
-		t.Errorf("expected Content-Type application/json, got %q", resp.Headers["Content-Type"])
-	}
+func TestHandlerValidationAndErrors(t *testing.T) {
+	t.Run("unauthorized", func(t *testing.T) {
+		setup(t, sitebuild.State{})
+		resp, _ := Handler(context.Background(), events.APIGatewayProxyRequest{PathParameters: map[string]string{"id": "post-1"}})
+		if resp.StatusCode != 401 {
+			t.Fatalf("got %d", resp.StatusCode)
+		}
+	})
+	t.Run("missing post id", func(t *testing.T) {
+		setup(t, sitebuild.State{})
+		req := request("")
+		req.PathParameters = nil
+		resp, _ := Handler(context.Background(), req)
+		if resp.StatusCode != 400 {
+			t.Fatalf("got %d", resp.StatusCode)
+		}
+	})
+	t.Run("invalid revision", func(t *testing.T) {
+		setup(t, sitebuild.State{})
+		resp, _ := Handler(context.Background(), request("old"))
+		if resp.StatusCode != 400 {
+			t.Fatalf("got %d", resp.StatusCode)
+		}
+	})
+	t.Run("dynamodb error", func(t *testing.T) {
+		t.Setenv("TABLE_NAME", "posts")
+		original := dynamoClientGetter
+		dynamoClientGetter = func() (sitebuild.DynamoDBClient, error) {
+			return &mockDynamo{err: errors.New("unavailable")}, nil
+		}
+		t.Cleanup(func() { dynamoClientGetter = original })
+		resp, _ := Handler(context.Background(), request("1"))
+		if resp.StatusCode != 500 {
+			t.Fatalf("got %d", resp.StatusCode)
+		}
+	})
 }

--- a/go-functions/cmd/posts/create/main.go
+++ b/go-functions/cmd/posts/create/main.go
@@ -30,12 +30,21 @@ import (
 	"serverless-blog/go-functions/internal/domain"
 	"serverless-blog/go-functions/internal/markdown"
 	"serverless-blog/go-functions/internal/middleware"
+	"serverless-blog/go-functions/internal/sitebuild"
 )
 
 // DynamoDBClientInterface defines the interface for DynamoDB operations (for testing)
 type DynamoDBClientInterface interface {
 	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+	TransactWriteItems(ctx context.Context, params *dynamodb.TransactWriteItemsInput, optFns ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error)
 	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+type postMutationResponse struct {
+	domain.BlogPost
+	SiteBuild *sitebuild.Request `json:"siteBuild,omitempty"`
 }
 
 // slugIndexName returns the SlugIndex GSI name (overridable via env for tests).
@@ -80,6 +89,9 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	var req domain.CreatePostRequest
 	if err := json.Unmarshal([]byte(request.Body), &req); err != nil {
 		return errorResponse(400, "invalid request body")
+	}
+	if req.SaveMode == domain.SaveModeAutosave {
+		req.PublishStatus = nil
 	}
 
 	// Validate required fields
@@ -164,25 +176,26 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		return errorResponse(500, "failed to marshal post")
 	}
 
-	// Save to DynamoDB
-	putInput := &dynamodb.PutItemInput{
-		TableName: &tableName,
-		Item:      av,
-	}
-
-	_, err = dynamoClient.PutItem(ctx, putInput)
-	if err != nil {
-		return errorResponse(500, "failed to create post")
-	}
-
-	// Trigger CodeBuild if post is created as published
-	// Requirement 10.1: Trigger site rebuild when post is published
+	var siteBuildRequest *sitebuild.Request
 	if publishStatus == domain.PublishStatusPublished {
-		triggerSiteBuild(ctx)
+		_, err = dynamoClient.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{TransactItems: []types.TransactWriteItem{
+			{Put: &types.Put{TableName: &tableName, Item: av}},
+			sitebuild.RequestUpdate(tableName, time.Now()),
+		}})
+		if err != nil {
+			return errorResponse(500, "failed to create post")
+		}
+		request := triggerSiteBuild(ctx, dynamoClient, tableName)
+		siteBuildRequest = &request
+	} else {
+		_, err = dynamoClient.PutItem(ctx, &dynamodb.PutItemInput{TableName: &tableName, Item: av})
+		if err != nil {
+			return errorResponse(500, "failed to create post")
+		}
 	}
 
 	// Return created post with 201 status
-	return middleware.JSONResponse(201, post)
+	return middleware.JSONResponse(201, postMutationResponse{BlogPost: post, SiteBuild: siteBuildRequest})
 }
 
 // errorResponse creates an error response with CORS headers
@@ -192,28 +205,32 @@ func errorResponse(statusCode int, message string) (events.APIGatewayProxyRespon
 
 // triggerSiteBuild triggers the Astro SSG build via CodeBuild
 // Requirement 10.1: Trigger CodeBuild when post is published
-func triggerSiteBuild(ctx context.Context) {
+func triggerSiteBuild(ctx context.Context, dynamoClient DynamoDBClientInterface, tableName string) sitebuild.Request {
 	projectName := buildtrigger.SanitizeProjectName(os.Getenv("CODEBUILD_PROJECT_NAME"))
 	if projectName == "" {
 		slog.Warn("CODEBUILD_PROJECT_NAME not set or invalid, skipping build trigger")
-		return
+		return sitebuild.CurrentRequest(ctx, dynamoClient, tableName)
 	}
 
 	client, err := codebuildClientGetter()
 	if err != nil {
 		slog.Error("failed to get CodeBuild client", "error", err)
-		return
+		return sitebuild.CurrentRequest(ctx, dynamoClient, tableName)
 	}
 
-	trigger := buildtrigger.NewBuildTrigger(client, projectName)
-	if err := trigger.TriggerBuild(ctx); err != nil {
-		//nolint:gosec // G706: projectName already passed buildtrigger.SanitizeProjectName regex validation, so no log-injection vector
+	coordinator := sitebuild.NewCoordinator(dynamoClient, client, tableName, projectName)
+	request, err := coordinator.StartPending(ctx)
+	if err != nil {
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
-		return
+		state, stateErr := coordinator.GetState(ctx)
+		if stateErr == nil {
+			return sitebuild.RequestForState(state, state.DesiredRevision)
+		}
+		return sitebuild.Request{Status: sitebuild.StatusFailed}
 	}
 
-	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
+	return request
 }
 
 // checkSlugExists returns true if any BlogPost item already owns the given slug.

--- a/go-functions/cmd/posts/create/main.go
+++ b/go-functions/cmd/posts/create/main.go
@@ -221,6 +221,7 @@ func triggerSiteBuild(ctx context.Context, dynamoClient DynamoDBClientInterface,
 	coordinator := sitebuild.NewCoordinator(dynamoClient, client, tableName, projectName)
 	request, err := coordinator.StartPending(ctx)
 	if err != nil {
+		//nolint:gosec // G706: projectName is allow-list validated by SanitizeProjectName; CR/LF and control characters are rejected.
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		state, stateErr := coordinator.GetState(ctx)
 		if stateErr == nil {
@@ -229,6 +230,7 @@ func triggerSiteBuild(ctx context.Context, dynamoClient DynamoDBClientInterface,
 		return sitebuild.Request{Status: sitebuild.StatusFailed}
 	}
 
+	//nolint:gosec // G706: projectName is allow-list validated by SanitizeProjectName; CR/LF and control characters are rejected.
 	slog.Info("site build triggered successfully", "project", projectName)
 	return request
 }

--- a/go-functions/cmd/posts/create/main_test.go
+++ b/go-functions/cmd/posts/create/main_test.go
@@ -27,6 +27,24 @@ type MockDynamoDBClient struct {
 	QueryFunc   func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
 }
 
+func (m *MockDynamoDBClient) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (m *MockDynamoDBClient) UpdateItem(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func (m *MockDynamoDBClient) TransactWriteItems(ctx context.Context, params *dynamodb.TransactWriteItemsInput, _ ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error) {
+	if len(params.TransactItems) > 0 && params.TransactItems[0].Put != nil && m.PutItemFunc != nil {
+		_, err := m.PutItemFunc(ctx, &dynamodb.PutItemInput{TableName: params.TransactItems[0].Put.TableName, Item: params.TransactItems[0].Put.Item})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &dynamodb.TransactWriteItemsOutput{}, nil
+}
+
 func (m *MockDynamoDBClient) PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
 	if m.PutItemFunc != nil {
 		return m.PutItemFunc(ctx, params, optFns...)
@@ -84,6 +102,38 @@ func setupTest(t *testing.T) func() {
 		markdownConverter = originalMarkdownConverter
 		uuidGenerator = originalUUIDGenerator
 		codebuildClientGetter = originalCodeBuildGetter
+	}
+}
+
+func TestHandler_AutosaveWithoutCategoryCreatesDraftAndOmitsCategory(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	var savedItem map[string]types.AttributeValue
+	mockClient := &MockDynamoDBClient{PutItemFunc: func(_ context.Context, params *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+		savedItem = params.Item
+		return &dynamodb.PutItemOutput{}, nil
+	}}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	markdownConverter = func(string) (string, error) { return "<p>body</p>", nil }
+	uuidGenerator = func() string { return "autosave-post" }
+
+	request := events.APIGatewayProxyRequest{
+		Body: `{"title":"Autosave","contentMarkdown":"body","publishStatus":"published","saveMode":"autosave"}`,
+		RequestContext: events.APIGatewayProxyRequestContext{Authorizer: map[string]interface{}{
+			"claims": map[string]interface{}{"sub": testAuthorID},
+		}},
+	}
+	response, err := Handler(context.Background(), request)
+	if err != nil || response.StatusCode != 201 {
+		t.Fatalf("expected 201 response, got status=%d err=%v body=%s", response.StatusCode, err, response.Body)
+	}
+	if _, ok := savedItem["category"]; ok {
+		t.Fatal("category must be omitted from a categoryless autosave item")
+	}
+	status, ok := savedItem["publishStatus"].(*types.AttributeValueMemberS)
+	if !ok || status.Value != domain.PublishStatusDraft {
+		t.Fatalf("autosave must create a draft, got %#v", savedItem["publishStatus"])
 	}
 }
 
@@ -1789,7 +1839,7 @@ func TestTriggerSiteBuild_MissingProjectName(t *testing.T) {
 	t.Setenv("CODEBUILD_PROJECT_NAME", "")
 
 	// triggerSiteBuild should not panic and should return silently
-	triggerSiteBuild(context.Background())
+	triggerSiteBuild(context.Background(), &MockDynamoDBClient{}, testTableName)
 	// No error expected - just a warning log
 }
 
@@ -1807,7 +1857,7 @@ func TestTriggerSiteBuild_CodeBuildClientInitError(t *testing.T) {
 	}
 
 	// triggerSiteBuild should not panic and should handle error gracefully
-	triggerSiteBuild(context.Background())
+	triggerSiteBuild(context.Background(), &MockDynamoDBClient{}, testTableName)
 	// No error expected - just an error log
 }
 

--- a/go-functions/cmd/posts/delete/main.go
+++ b/go-functions/cmd/posts/delete/main.go
@@ -227,10 +227,12 @@ func triggerSiteBuild(ctx context.Context, dynamoClient DynamoDBClientInterface,
 
 	coordinator := sitebuild.NewCoordinator(dynamoClient, client, tableName, projectName)
 	if _, err := coordinator.StartPending(ctx); err != nil {
+		//nolint:gosec // G706: projectName is allow-list validated by SanitizeProjectName; CR/LF and control characters are rejected.
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		return
 	}
 
+	//nolint:gosec // G706: projectName is allow-list validated by SanitizeProjectName; CR/LF and control characters are rejected.
 	slog.Info("site build triggered successfully", "project", projectName)
 }
 

--- a/go-functions/cmd/posts/delete/main.go
+++ b/go-functions/cmd/posts/delete/main.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -32,12 +33,15 @@ import (
 	"serverless-blog/go-functions/internal/clients"
 	"serverless-blog/go-functions/internal/domain"
 	"serverless-blog/go-functions/internal/middleware"
+	"serverless-blog/go-functions/internal/sitebuild"
 )
 
 // DynamoDBClientInterface defines the interface for DynamoDB operations (for testing)
 type DynamoDBClientInterface interface {
 	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
 	DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+	TransactWriteItems(ctx context.Context, params *dynamodb.TransactWriteItemsInput, optFns ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error)
 }
 
 // S3ClientInterface defines the interface for S3 operations (for testing)
@@ -121,23 +125,26 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		return *errResp, nil
 	}
 
-	// Delete post from DynamoDB
-	deleteInput := &dynamodb.DeleteItemInput{
-		TableName: &tableName,
-		Key: map[string]types.AttributeValue{
-			"id": &types.AttributeValueMemberS{Value: postID},
-		},
+	isPublished := existingPost.PublishStatus == domain.PublishStatusPublished
+	if isPublished {
+		_, err = dynamoClient.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{TransactItems: []types.TransactWriteItem{
+			{Delete: &types.Delete{TableName: &tableName, Key: map[string]types.AttributeValue{"id": &types.AttributeValueMemberS{Value: postID}}}},
+			sitebuild.RequestUpdate(tableName, time.Now()),
+		}})
+	} else {
+		_, err = dynamoClient.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+			TableName: &tableName,
+			Key:       map[string]types.AttributeValue{"id": &types.AttributeValueMemberS{Value: postID}},
+		})
 	}
-
-	_, err = dynamoClient.DeleteItem(ctx, deleteInput)
 	if err != nil {
 		return errorResponse(500, "failed to delete post")
 	}
 
 	// Trigger site rebuild if the deleted post was published
 	// Requirement 10.11: Only trigger build for published posts
-	if existingPost.PublishStatus == domain.PublishStatusPublished {
-		triggerSiteBuild(ctx)
+	if isPublished {
+		triggerSiteBuild(ctx, dynamoClient, tableName)
 	}
 
 	// Return 204 No Content
@@ -205,7 +212,7 @@ func deletePostImages(ctx context.Context, post domain.BlogPost) *events.APIGate
 
 // triggerSiteBuild triggers the Astro SSG build via CodeBuild
 // Requirement 10.11: Trigger CodeBuild when a published post is deleted
-func triggerSiteBuild(ctx context.Context) {
+func triggerSiteBuild(ctx context.Context, dynamoClient DynamoDBClientInterface, tableName string) {
 	projectName := buildtrigger.SanitizeProjectName(os.Getenv("CODEBUILD_PROJECT_NAME"))
 	if projectName == "" {
 		slog.Warn("CODEBUILD_PROJECT_NAME not set or invalid, skipping build trigger")
@@ -218,14 +225,12 @@ func triggerSiteBuild(ctx context.Context) {
 		return
 	}
 
-	trigger := buildtrigger.NewBuildTrigger(client, projectName)
-	if err := trigger.TriggerBuild(ctx); err != nil {
-		//nolint:gosec // G706: projectName already passed buildtrigger.SanitizeProjectName regex validation, so no log-injection vector
+	coordinator := sitebuild.NewCoordinator(dynamoClient, client, tableName, projectName)
+	if _, err := coordinator.StartPending(ctx); err != nil {
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		return
 	}
 
-	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
 }
 

--- a/go-functions/cmd/posts/delete/main_test.go
+++ b/go-functions/cmd/posts/delete/main_test.go
@@ -41,6 +41,20 @@ type MockDynamoDBClient struct {
 	DeleteItemFunc func(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
 }
 
+func (m *MockDynamoDBClient) UpdateItem(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func (m *MockDynamoDBClient) TransactWriteItems(ctx context.Context, params *dynamodb.TransactWriteItemsInput, _ ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error) {
+	if len(params.TransactItems) > 0 && params.TransactItems[0].Delete != nil && m.DeleteItemFunc != nil {
+		_, err := m.DeleteItemFunc(ctx, &dynamodb.DeleteItemInput{TableName: params.TransactItems[0].Delete.TableName, Key: params.TransactItems[0].Delete.Key})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &dynamodb.TransactWriteItemsOutput{}, nil
+}
+
 func (m *MockDynamoDBClient) GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
 	if m.GetItemFunc != nil {
 		return m.GetItemFunc(ctx, params, optFns...)
@@ -1174,7 +1188,7 @@ func TestTriggerSiteBuild_MissingProjectName(t *testing.T) {
 	t.Setenv("CODEBUILD_PROJECT_NAME", "")
 
 	// triggerSiteBuild should not panic and should return silently
-	triggerSiteBuild(context.Background())
+	triggerSiteBuild(context.Background(), &MockDynamoDBClient{}, testTableName)
 }
 
 // TestTriggerSiteBuild_ClientError tests that triggerSiteBuild handles client errors gracefully
@@ -1191,5 +1205,5 @@ func TestTriggerSiteBuild_ClientError(t *testing.T) {
 	}
 
 	// triggerSiteBuild should not panic and should handle error gracefully
-	triggerSiteBuild(context.Background())
+	triggerSiteBuild(context.Background(), &MockDynamoDBClient{}, testTableName)
 }

--- a/go-functions/cmd/posts/reconcile_build/main.go
+++ b/go-functions/cmd/posts/reconcile_build/main.go
@@ -1,0 +1,52 @@
+// Package main reconciles durable site-build state with CodeBuild.
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"serverless-blog/go-functions/internal/buildtrigger"
+	"serverless-blog/go-functions/internal/clients"
+	"serverless-blog/go-functions/internal/sitebuild"
+)
+
+var dynamoClientGetter = func() (sitebuild.DynamoDBClient, error) { return clients.GetDynamoDB() }
+var codebuildClientGetter = func() (sitebuild.CodeBuildClient, error) { return clients.GetCodeBuild() }
+
+// Handler accepts both CodeBuild State Change events and scheduled events.
+// The event payload is intentionally not trusted for state transitions; the
+// active Build ID persisted in DynamoDB is reconciled through BatchGetBuilds.
+func Handler(ctx context.Context) error {
+	tableName := os.Getenv("TABLE_NAME")
+	projectName := buildtrigger.SanitizeProjectName(os.Getenv("CODEBUILD_PROJECT_NAME"))
+	if tableName == "" || projectName == "" {
+		return errors.New("site build reconciler is not configured")
+	}
+	dynamoClient, err := dynamoClientGetter()
+	if err != nil {
+		return err
+	}
+	codebuildClient, err := codebuildClientGetter()
+	if err != nil {
+		return err
+	}
+	state, err := sitebuild.NewCoordinator(dynamoClient, codebuildClient, tableName, projectName).Reconcile(ctx)
+	if err != nil {
+		return err
+	}
+	slog.Info("site build state reconciled",
+		"desiredRevision", state.DesiredRevision,
+		"deployedRevision", state.DeployedRevision,
+		"activeRevision", state.ActiveRevision,
+		"status", state.Status,
+	)
+	return nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/go-functions/cmd/posts/reconcile_build/main_test.go
+++ b/go-functions/cmd/posts/reconcile_build/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+
+	"serverless-blog/go-functions/internal/sitebuild"
+)
+
+type idleDynamoDB struct{}
+
+func (idleDynamoDB) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (idleDynamoDB) UpdateItem(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+type idleCodeBuild struct{}
+
+func (idleCodeBuild) StartBuild(_ context.Context, _ *codebuild.StartBuildInput, _ ...func(*codebuild.Options)) (*codebuild.StartBuildOutput, error) {
+	return &codebuild.StartBuildOutput{}, nil
+}
+
+func (idleCodeBuild) BatchGetBuilds(_ context.Context, _ *codebuild.BatchGetBuildsInput, _ ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error) {
+	return &codebuild.BatchGetBuildsOutput{}, nil
+}
+
+func preserveClientGetters(t *testing.T) {
+	t.Helper()
+	originalDynamo := dynamoClientGetter
+	originalCodeBuild := codebuildClientGetter
+	t.Cleanup(func() {
+		dynamoClientGetter = originalDynamo
+		codebuildClientGetter = originalCodeBuild
+	})
+}
+
+func TestHandlerRejectsMissingConfiguration(t *testing.T) {
+	preserveClientGetters(t)
+	t.Setenv("TABLE_NAME", "")
+	t.Setenv("CODEBUILD_PROJECT_NAME", "")
+	if err := Handler(context.Background()); err == nil {
+		t.Fatal("expected configuration error")
+	}
+}
+
+func TestHandlerReturnsClientInitializationError(t *testing.T) {
+	preserveClientGetters(t)
+	t.Setenv("TABLE_NAME", "posts")
+	t.Setenv("CODEBUILD_PROJECT_NAME", "site-project")
+	want := errors.New("dynamodb unavailable")
+	dynamoClientGetter = func() (sitebuild.DynamoDBClient, error) { return nil, want }
+	if err := Handler(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("expected DynamoDB error, got %v", err)
+	}
+}
+
+func TestHandlerSucceedsWhenNoBuildIsPending(t *testing.T) {
+	preserveClientGetters(t)
+	t.Setenv("TABLE_NAME", "posts")
+	t.Setenv("CODEBUILD_PROJECT_NAME", "site-project")
+	dynamoClientGetter = func() (sitebuild.DynamoDBClient, error) { return idleDynamoDB{}, nil }
+	codebuildClientGetter = func() (sitebuild.CodeBuildClient, error) { return idleCodeBuild{}, nil }
+	if err := Handler(context.Background()); err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+}

--- a/go-functions/cmd/posts/update/main.go
+++ b/go-functions/cmd/posts/update/main.go
@@ -33,15 +33,21 @@ import (
 	"serverless-blog/go-functions/internal/domain"
 	"serverless-blog/go-functions/internal/markdown"
 	"serverless-blog/go-functions/internal/middleware"
+	"serverless-blog/go-functions/internal/sitebuild"
 )
 
 // DynamoDBClientInterface defines the interface for DynamoDB operations (for testing)
-//
-//nolint:dupl // mirror of test mock; categories/update follows the same pattern.
 type DynamoDBClientInterface interface {
 	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
 	PutItem(ctx context.Context, params *dynamodb.PutItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+	TransactWriteItems(ctx context.Context, params *dynamodb.TransactWriteItemsInput, optFns ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error)
 	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+type postMutationResponse struct {
+	domain.BlogPost
+	SiteBuild *sitebuild.Request `json:"siteBuild,omitempty"`
 }
 
 // slugIndexName returns the SlugIndex GSI name (overridable via env for tests).
@@ -66,7 +72,7 @@ var codebuildClientGetter = clients.GetCodeBuild
 // This can be overridden in tests
 var markdownConverter = markdown.ConvertToHTML
 
-// Handler handles PUT /posts/:id requests
+// Handler handles PUT /posts/:id requests.
 func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Validate and parse request
 	postID, req, userID, errResp := validateAndParseRequest(request)
@@ -90,6 +96,7 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	if existingPost.AuthorID != userID {
 		return errorResponse(403, "forbidden: you can only update your own posts")
 	}
+	normalizeAutosaveRequest(req)
 
 	// Validate update fields
 	if validateErr := validateUpdateRequest(req); validateErr != nil {
@@ -118,20 +125,29 @@ func Handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		return *errResp, nil
 	}
 
-	// Save to DynamoDB
-	if errResp := savePost(ctx, dynamoClient, tableName, updatedPost); errResp != nil {
+	requiresBuild := shouldTriggerBuild(existingPost, req)
+	if errResp := savePost(ctx, dynamoClient, tableName, updatedPost, requiresBuild); errResp != nil {
 		return *errResp, nil
 	}
 
-	// Trigger CodeBuild if publishStatus changed to "published"
-	// Requirement 10.1: Trigger CodeBuild for site rebuild when post is published
-	// Requirement 10.10: Handle CodeBuild API errors gracefully without affecting post update response
-	if shouldTriggerBuild(existingPost, req) {
-		triggerSiteBuild(ctx)
+	var siteBuildRequest *sitebuild.Request
+	if requiresBuild {
+		request := triggerSiteBuild(ctx, dynamoClient, tableName)
+		siteBuildRequest = &request
 	}
 
 	// Return updated post with 200 status
-	return middleware.JSONResponse(200, updatedPost)
+	return middleware.JSONResponse(200, postMutationResponse{BlogPost: *updatedPost, SiteBuild: siteBuildRequest})
+}
+
+func normalizeAutosaveRequest(req *domain.UpdatePostRequest) {
+	if req.SaveMode != domain.SaveModeAutosave {
+		return
+	}
+	req.PublishStatus = nil
+	if req.Category != nil && strings.TrimSpace(*req.Category) == "" {
+		req.Category = nil
+	}
 }
 
 // validateAndParseRequest validates authentication and parses the request body
@@ -254,56 +270,66 @@ func shouldSetPublishedAt(existingPost *domain.BlogPost, req *domain.UpdatePostR
 // shouldTriggerBuild checks if a site rebuild should be triggered
 // Requirement 10.1: Trigger CodeBuild when post is published
 // Note: existingPost parameter kept for future use (e.g., checking transition from draft)
-func shouldTriggerBuild(_ *domain.BlogPost, req *domain.UpdatePostRequest) bool {
-	// Only trigger if publishStatus is being set to "published"
+func shouldTriggerBuild(existingPost *domain.BlogPost, req *domain.UpdatePostRequest) bool {
+	if req.SaveMode == domain.SaveModeAutosave {
+		return false
+	}
+	if existingPost.PublishStatus == domain.PublishStatusPublished {
+		return true
+	}
 	return req.PublishStatus != nil && *req.PublishStatus == domain.PublishStatusPublished
 }
 
 // triggerSiteBuild triggers the Astro SSG build via CodeBuild
 // Requirement 10.1, 10.2, 10.10: Trigger CodeBuild, handle errors gracefully
-func triggerSiteBuild(ctx context.Context) {
+func triggerSiteBuild(ctx context.Context, dynamoClient DynamoDBClientInterface, tableName string) sitebuild.Request {
 	// Get CodeBuild project name from environment, sanitized at the trust boundary
 	projectName := buildtrigger.SanitizeProjectName(os.Getenv("CODEBUILD_PROJECT_NAME"))
 	if projectName == "" {
 		slog.Warn("CODEBUILD_PROJECT_NAME not set or invalid, skipping build trigger")
-		return
+		return sitebuild.CurrentRequest(ctx, dynamoClient, tableName)
 	}
 
 	// Get CodeBuild client
 	client, err := codebuildClientGetter()
 	if err != nil {
 		slog.Error("failed to get CodeBuild client", "error", err)
-		return
+		return sitebuild.CurrentRequest(ctx, dynamoClient, tableName)
 	}
 
 	// Create and use build trigger
-	trigger := buildtrigger.NewBuildTrigger(client, projectName)
-
-	if err := trigger.TriggerBuild(ctx); err != nil {
+	coordinator := sitebuild.NewCoordinator(dynamoClient, client, tableName, projectName)
+	request, err := coordinator.StartPending(ctx)
+	if err != nil {
 		// Requirement 10.10: Handle CodeBuild API errors gracefully
-		//nolint:gosec // G706: projectName already passed buildtrigger.SanitizeProjectName regex validation, so no log-injection vector
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
-		return
+		state, stateErr := coordinator.GetState(ctx)
+		if stateErr == nil {
+			return sitebuild.RequestForState(state, state.DesiredRevision)
+		}
+		return sitebuild.Request{Status: sitebuild.StatusFailed}
 	}
 
-	//nolint:gosec // G706: see above — projectName is regex-validated.
 	slog.Info("site build triggered successfully", "project", projectName)
+	return request
 }
 
 // savePost saves the updated post to DynamoDB
-func savePost(ctx context.Context, client DynamoDBClientInterface, tableName string, post *domain.BlogPost) *events.APIGatewayProxyResponse {
+func savePost(ctx context.Context, client DynamoDBClientInterface, tableName string, post *domain.BlogPost, requestBuild bool) *events.APIGatewayProxyResponse {
 	av, err := attributevalue.MarshalMap(post)
 	if err != nil {
 		resp, _ := errorResponse(500, "failed to marshal post")
 		return &resp
 	}
 
-	putInput := &dynamodb.PutItemInput{
-		TableName: &tableName,
-		Item:      av,
+	if requestBuild {
+		_, err = client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{TransactItems: []types.TransactWriteItem{
+			{Put: &types.Put{TableName: &tableName, Item: av}},
+			sitebuild.RequestUpdate(tableName, time.Now()),
+		}})
+	} else {
+		_, err = client.PutItem(ctx, &dynamodb.PutItemInput{TableName: &tableName, Item: av})
 	}
-
-	_, err = client.PutItem(ctx, putInput)
 	if err != nil {
 		resp, _ := errorResponse(500, "failed to update post")
 		return &resp

--- a/go-functions/cmd/posts/update/main.go
+++ b/go-functions/cmd/posts/update/main.go
@@ -302,6 +302,7 @@ func triggerSiteBuild(ctx context.Context, dynamoClient DynamoDBClientInterface,
 	request, err := coordinator.StartPending(ctx)
 	if err != nil {
 		// Requirement 10.10: Handle CodeBuild API errors gracefully
+		//nolint:gosec // G706: projectName is allow-list validated by SanitizeProjectName; CR/LF and control characters are rejected.
 		slog.Error("failed to trigger site build", "error", err, "project", projectName)
 		state, stateErr := coordinator.GetState(ctx)
 		if stateErr == nil {
@@ -310,6 +311,7 @@ func triggerSiteBuild(ctx context.Context, dynamoClient DynamoDBClientInterface,
 		return sitebuild.Request{Status: sitebuild.StatusFailed}
 	}
 
+	//nolint:gosec // G706: projectName is allow-list validated by SanitizeProjectName; CR/LF and control characters are rejected.
 	slog.Info("site build triggered successfully", "project", projectName)
 	return request
 }

--- a/go-functions/cmd/posts/update/main_test.go
+++ b/go-functions/cmd/posts/update/main_test.go
@@ -39,6 +39,20 @@ type MockDynamoDBClient struct {
 	QueryFunc   func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
 }
 
+func (m *MockDynamoDBClient) UpdateItem(_ context.Context, _ *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func (m *MockDynamoDBClient) TransactWriteItems(ctx context.Context, params *dynamodb.TransactWriteItemsInput, _ ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error) {
+	if len(params.TransactItems) > 0 && params.TransactItems[0].Put != nil && m.PutItemFunc != nil {
+		_, err := m.PutItemFunc(ctx, &dynamodb.PutItemInput{TableName: params.TransactItems[0].Put.TableName, Item: params.TransactItems[0].Put.Item})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &dynamodb.TransactWriteItemsOutput{}, nil
+}
+
 func (m *MockDynamoDBClient) GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
 	if m.GetItemFunc != nil {
 		return m.GetItemFunc(ctx, params, optFns...)
@@ -123,6 +137,49 @@ func createTestPost() domain.BlogPost {
 		UpdatedAt:       testUpdatedAt,
 		PublishedAt:     nil,
 		ImageURLs:       []string{},
+	}
+}
+
+func TestHandler_AutosavePreservesPublishedStatusAndCategory(t *testing.T) {
+	cleanup := setupTest(t)
+	defer cleanup()
+
+	existingPost := createTestPost()
+	existingPost.PublishStatus = domain.PublishStatusPublished
+	existingPost.Category = "technology"
+	item, err := attributevalue.MarshalMap(existingPost)
+	if err != nil {
+		t.Fatalf("marshal existing post: %v", err)
+	}
+	var saved domain.BlogPost
+	mockClient := &MockDynamoDBClient{
+		GetItemFunc: func(context.Context, *dynamodb.GetItemInput, ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+			return &dynamodb.GetItemOutput{Item: item}, nil
+		},
+		PutItemFunc: func(_ context.Context, params *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+			if err := attributevalue.UnmarshalMap(params.Item, &saved); err != nil {
+				t.Fatalf("unmarshal saved post: %v", err)
+			}
+			return &dynamodb.PutItemOutput{}, nil
+		},
+	}
+	dynamoClientGetter = func() (DynamoDBClientInterface, error) { return mockClient, nil }
+	buildClientCalled := false
+	codebuildClientGetter = func() (*codebuild.Client, error) {
+		buildClientCalled = true
+		return nil, errors.New("must not be called")
+	}
+
+	request := createAuthenticatedRequest(testPostID, `{"title":"Autosaved","category":"","publishStatus":"draft","saveMode":"autosave"}`)
+	response, handlerErr := Handler(context.Background(), request)
+	if handlerErr != nil || response.StatusCode != 200 {
+		t.Fatalf("expected 200 response, got status=%d err=%v body=%s", response.StatusCode, handlerErr, response.Body)
+	}
+	if saved.Category != "technology" || saved.PublishStatus != domain.PublishStatusPublished {
+		t.Fatalf("autosave changed protected fields: category=%q status=%q", saved.Category, saved.PublishStatus)
+	}
+	if buildClientCalled {
+		t.Fatal("autosave must not trigger CodeBuild")
 	}
 }
 
@@ -1361,7 +1418,7 @@ func TestShouldTriggerBuild_NoPublishStatusChange(t *testing.T) {
 	}
 }
 
-// TestShouldTriggerBuild_PublishStatusToDraft tests that build is NOT triggered when status changes to draft
+// TestShouldTriggerBuild_PublishStatusToDraft tests that unpublishing removes the article from the static site.
 func TestShouldTriggerBuild_PublishStatusToDraft(t *testing.T) {
 	existingPost := createTestPost()
 	existingPost.PublishStatus = domain.PublishStatusPublished
@@ -1372,8 +1429,8 @@ func TestShouldTriggerBuild_PublishStatusToDraft(t *testing.T) {
 	}
 
 	result := shouldTriggerBuild(&existingPost, req)
-	if result {
-		t.Error("expected shouldTriggerBuild to return false when status changes to draft")
+	if !result {
+		t.Error("expected shouldTriggerBuild to return true when status changes to draft")
 	}
 }
 
@@ -1416,7 +1473,7 @@ func TestTriggerSiteBuild_MissingProjectName(t *testing.T) {
 	t.Setenv("CODEBUILD_PROJECT_NAME", "")
 
 	// triggerSiteBuild should not panic and should return silently
-	triggerSiteBuild(context.Background())
+	triggerSiteBuild(context.Background(), &MockDynamoDBClient{}, testTableName)
 	// No error expected - just a warning log
 }
 
@@ -1434,7 +1491,7 @@ func TestTriggerSiteBuild_CodeBuildClientInitError(t *testing.T) {
 	}
 
 	// triggerSiteBuild should not panic and should handle error gracefully
-	triggerSiteBuild(context.Background())
+	triggerSiteBuild(context.Background(), &MockDynamoDBClient{}, testTableName)
 	// No error expected - just an error log
 }
 
@@ -1668,7 +1725,7 @@ func TestShouldTriggerBuild_AllScenarios(t *testing.T) {
 			name:            "published to draft",
 			existingStatus:  domain.PublishStatusPublished,
 			requestStatus:   strPtr(domain.PublishStatusDraft),
-			expectedTrigger: false,
+			expectedTrigger: true,
 		},
 		{
 			name:            "draft to draft",
@@ -1686,7 +1743,7 @@ func TestShouldTriggerBuild_AllScenarios(t *testing.T) {
 			name:            "update other fields only (published post)",
 			existingStatus:  domain.PublishStatusPublished,
 			requestStatus:   nil,
-			expectedTrigger: false,
+			expectedTrigger: true,
 		},
 	}
 
@@ -1705,6 +1762,15 @@ func TestShouldTriggerBuild_AllScenarios(t *testing.T) {
 					tt.expectedTrigger, tt.name, result)
 			}
 		})
+	}
+}
+
+func TestShouldTriggerBuild_AutosavePublishedPost(t *testing.T) {
+	existingPost := createTestPost()
+	existingPost.PublishStatus = domain.PublishStatusPublished
+	req := &domain.UpdatePostRequest{Title: strPtr("Autosaved"), SaveMode: domain.SaveModeAutosave}
+	if shouldTriggerBuild(&existingPost, req) {
+		t.Fatal("autosave must not trigger a public site build")
 	}
 }
 

--- a/go-functions/internal/domain/types.go
+++ b/go-functions/internal/domain/types.go
@@ -20,6 +20,8 @@ import (
 const (
 	PublishStatusDraft     = "draft"
 	PublishStatusPublished = "published"
+	SaveModeManual         = "manual"
+	SaveModeAutosave       = "autosave"
 )
 
 // Validation limits for post and category fields.
@@ -137,7 +139,7 @@ type BlogPost struct {
 	Title           string   `json:"title" dynamodbav:"title"`
 	ContentMarkdown string   `json:"contentMarkdown" dynamodbav:"contentMarkdown"`
 	ContentHTML     string   `json:"contentHtml" dynamodbav:"contentHtml"`
-	Category        string   `json:"category" dynamodbav:"category"`
+	Category        string   `json:"category" dynamodbav:"category,omitempty"`
 	Tags            []string `json:"tags" dynamodbav:"tags"`
 	PublishStatus   string   `json:"publishStatus" dynamodbav:"publishStatus"`
 	AuthorID        string   `json:"authorId" dynamodbav:"authorId"`
@@ -161,6 +163,7 @@ type CreatePostRequest struct {
 	Slug            *string  `json:"slug,omitempty"`
 	Excerpt         *string  `json:"excerpt,omitempty"`
 	CoverImageURL   *string  `json:"coverImageUrl,omitempty"`
+	SaveMode        string   `json:"saveMode,omitempty"`
 }
 
 // Validate validates the CreatePostRequest.
@@ -177,8 +180,14 @@ func (r *CreatePostRequest) Validate() error {
 	if err := validateRuneLength(r.ContentMarkdown, "contentMarkdown", PostContentMarkdownMaxLength); err != nil {
 		return err
 	}
-	if r.Category == "" {
+	if r.Category == "" && r.SaveMode != SaveModeAutosave {
 		return errors.New("category is required")
+	}
+	if err := validateSaveMode(r.SaveMode); err != nil {
+		return err
+	}
+	if r.SaveMode == SaveModeAutosave && r.PublishStatus != nil && *r.PublishStatus == PublishStatusPublished {
+		return errors.New("autosave cannot publish a post")
 	}
 	if err := validateOptionalExcerpt(r.Excerpt); err != nil {
 		return err
@@ -203,6 +212,7 @@ type UpdatePostRequest struct {
 	Slug            *string  `json:"slug,omitempty"`
 	Excerpt         *string  `json:"excerpt,omitempty"`
 	CoverImageURL   *string  `json:"coverImageUrl,omitempty"`
+	SaveMode        string   `json:"saveMode,omitempty"`
 }
 
 // Validate validates the UpdatePostRequest.
@@ -216,8 +226,11 @@ func (r *UpdatePostRequest) Validate() error {
 	if err := validateOptionalNonEmpty(r.ContentMarkdown, "contentMarkdown", PostContentMarkdownMaxLength); err != nil {
 		return err
 	}
-	if r.Category != nil && *r.Category == "" {
+	if r.Category != nil && *r.Category == "" && r.SaveMode != SaveModeAutosave {
 		return errors.New("category cannot be empty when provided")
+	}
+	if err := validateSaveMode(r.SaveMode); err != nil {
+		return err
 	}
 	if err := validateOptionalExcerpt(r.Excerpt); err != nil {
 		return err
@@ -229,6 +242,13 @@ func (r *UpdatePostRequest) Validate() error {
 		return err
 	}
 	return validateOptionalCoverImageURL(r.CoverImageURL)
+}
+
+func validateSaveMode(mode string) error {
+	if mode != "" && mode != SaveModeManual && mode != SaveModeAutosave {
+		return errors.New("saveMode must be 'manual' or 'autosave'")
+	}
+	return nil
 }
 
 // validateOptionalNonEmpty validates a partial-update pointer field that,

--- a/go-functions/internal/domain/types_test.go
+++ b/go-functions/internal/domain/types_test.go
@@ -177,6 +177,25 @@ func TestCreatePostRequestValidation(t *testing.T) {
 			errMsg:  "category",
 		},
 		{
+			name: "autosave accepts missing category",
+			request: CreatePostRequest{
+				Title:           "Test Title",
+				ContentMarkdown: "# Hello",
+				SaveMode:        SaveModeAutosave,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid save mode",
+			request: CreatePostRequest{
+				Title:           "Test Title",
+				ContentMarkdown: "# Hello",
+				Category:        "technology",
+				SaveMode:        "background",
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid request with slug",
 			request: CreatePostRequest{
 				Title:           "Test Title",
@@ -479,6 +498,16 @@ func TestUpdatePostRequestValidation(t *testing.T) {
 		{
 			name:    "empty category rejected",
 			request: UpdatePostRequest{Category: strPtr("")},
+			wantErr: true,
+		},
+		{
+			name:    "autosave accepts empty category",
+			request: UpdatePostRequest{Category: strPtr(""), SaveMode: SaveModeAutosave},
+			wantErr: false,
+		},
+		{
+			name:    "invalid save mode rejected",
+			request: UpdatePostRequest{SaveMode: "background"},
 			wantErr: true,
 		},
 		{

--- a/go-functions/internal/sitebuild/sitebuild.go
+++ b/go-functions/internal/sitebuild/sitebuild.go
@@ -1,0 +1,372 @@
+// Package sitebuild coordinates durable public-site build requests.
+package sitebuild
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	codebuildtypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+const (
+	// StateItemID is reserved for the singleton site-build coordinator item.
+	StateItemID = "__SITE_BUILD_STATE__"
+	// StatusQueued means the target revision is waiting for a build slot.
+	StatusQueued = "queued"
+	// StatusStarting means a caller owns the conditional StartBuild lock.
+	StatusStarting = "starting"
+	// StatusInProgress means CodeBuild accepted the active revision.
+	StatusInProgress = "in-progress"
+	// StatusSucceeded means the active revision was deployed successfully.
+	StatusSucceeded = "succeeded"
+	// StatusFailed means the active revision failed to deploy.
+	StatusFailed = "failed"
+	// StatusIdle means no site-build request has been created yet.
+	StatusIdle = "idle"
+
+	defaultStartingTimeout = 5 * time.Minute
+)
+
+// State is persisted in the BlogPosts table. It intentionally omits all GSI
+// keys, so it never appears in article queries.
+type State struct {
+	ID               string `dynamodbav:"id"`
+	DesiredRevision  int64  `dynamodbav:"desiredRevision"`
+	DeployedRevision int64  `dynamodbav:"deployedRevision"`
+	ActiveRevision   int64  `dynamodbav:"activeRevision,omitempty"`
+	ActiveBuildID    string `dynamodbav:"activeBuildId,omitempty"`
+	StartToken       string `dynamodbav:"startToken,omitempty"`
+	Status           string `dynamodbav:"status"`
+	RequestedAt      string `dynamodbav:"requestedAt,omitempty"`
+	StartedAt        string `dynamodbav:"startedAt,omitempty"`
+	CompletedAt      string `dynamodbav:"completedAt,omitempty"`
+	LastError        string `dynamodbav:"lastError,omitempty"`
+}
+
+// Request is returned to the admin UI and correlates one save with deployment.
+type Request struct {
+	TargetRevision int64  `json:"targetRevision"`
+	BuildID        string `json:"buildId,omitempty"`
+	Status         string `json:"status"`
+}
+
+// DynamoDBClient is the subset needed by the coordinator.
+type DynamoDBClient interface {
+	GetItem(context.Context, *dynamodb.GetItemInput, ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+	UpdateItem(context.Context, *dynamodb.UpdateItemInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+}
+
+// CodeBuildClient is the subset needed to start and reconcile builds.
+type CodeBuildClient interface {
+	StartBuild(context.Context, *codebuild.StartBuildInput, ...func(*codebuild.Options)) (*codebuild.StartBuildOutput, error)
+	BatchGetBuilds(context.Context, *codebuild.BatchGetBuildsInput, ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error)
+}
+
+// Coordinator serializes builds while retaining the latest desired revision.
+type Coordinator struct {
+	dynamo          DynamoDBClient
+	codebuild       CodeBuildClient
+	tableName       string
+	projectName     string
+	now             func() time.Time
+	startingTimeout time.Duration
+}
+
+// NewCoordinator creates a durable site-build coordinator.
+func NewCoordinator(dynamoClient DynamoDBClient, codebuildClient CodeBuildClient, tableName, projectName string) *Coordinator {
+	return &Coordinator{
+		dynamo: dynamoClient, codebuild: codebuildClient, tableName: tableName,
+		projectName: projectName, now: time.Now, startingTimeout: defaultStartingTimeout,
+	}
+}
+
+// CurrentRequest returns the durable request visible to the admin API even
+// when the synchronous CodeBuild client or project configuration is
+// temporarily unavailable. The scheduled reconciler can start it later.
+func CurrentRequest(ctx context.Context, dynamoClient DynamoDBClient, tableName string) Request {
+	state, err := NewCoordinator(dynamoClient, nil, tableName, "").GetState(ctx)
+	if err != nil {
+		return Request{Status: StatusFailed}
+	}
+	return RequestForState(state, state.DesiredRevision)
+}
+
+// RequestUpdate returns the transaction item that atomically advances the
+// desired site revision alongside an article mutation.
+func RequestUpdate(tableName string, requestedAt time.Time) dynamodbtypes.TransactWriteItem {
+	return dynamodbtypes.TransactWriteItem{Update: &dynamodbtypes.Update{
+		TableName: aws.String(tableName),
+		Key: map[string]dynamodbtypes.AttributeValue{
+			"id": &dynamodbtypes.AttributeValueMemberS{Value: StateItemID},
+		},
+		UpdateExpression:         aws.String("ADD desiredRevision :one SET #status = if_not_exists(#status, :queued), requestedAt = :requestedAt, deployedRevision = if_not_exists(deployedRevision, :zero)"),
+		ExpressionAttributeNames: map[string]string{"#status": "status"},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":one":         &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+			":zero":        &dynamodbtypes.AttributeValueMemberN{Value: "0"},
+			":queued":      &dynamodbtypes.AttributeValueMemberS{Value: StatusQueued},
+			":requestedAt": &dynamodbtypes.AttributeValueMemberS{Value: requestedAt.UTC().Format(time.RFC3339Nano)},
+		},
+	}}
+}
+
+// GetState reads the singleton coordinator item with a strongly consistent read.
+func (c *Coordinator) GetState(ctx context.Context) (State, error) {
+	out, err := c.dynamo.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:      aws.String(c.tableName),
+		Key:            map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: StateItemID}},
+		ConsistentRead: aws.Bool(true),
+	})
+	if err != nil {
+		return State{}, err
+	}
+	if len(out.Item) == 0 {
+		return State{ID: StateItemID, Status: StatusIdle}, nil
+	}
+	var state State
+	if err := attributevalue.UnmarshalMap(out.Item, &state); err != nil {
+		return State{}, err
+	}
+	return state, nil
+}
+
+// StartPending starts the newest desired revision when no build owns the slot.
+//
+//nolint:gocyclo // Conditional lock acquisition and stale-start recovery form one explicit state machine.
+func (c *Coordinator) StartPending(ctx context.Context) (Request, error) {
+	state, err := c.GetState(ctx)
+	if err != nil {
+		return Request{}, err
+	}
+	request := RequestForState(state, state.DesiredRevision)
+	if state.DesiredRevision <= state.DeployedRevision || state.ActiveBuildID != "" {
+		return request, nil
+	}
+
+	if state.Status == StatusStarting && !isStartingStale(state, c.now(), c.startingTimeout) {
+		return request, nil
+	}
+
+	targetRevision := state.DesiredRevision
+	revision := targetRevision
+	token := fmt.Sprintf("site-revision-%d", revision)
+	now := c.now().UTC()
+	staleBefore := now.Add(-c.startingTimeout).Format(time.RFC3339Nano)
+	condition := "desiredRevision = :revision AND attribute_not_exists(activeBuildId) AND (#status <> :starting OR attribute_not_exists(startedAt) OR startedAt < :staleBefore)"
+	// A previous StartBuild may have succeeded while the Lambda stopped before
+	// persisting its Build ID. Recover that exact request first with the same
+	// idempotency token; a newer desired revision remains queued behind it.
+	if state.Status == StatusStarting && isStartingStale(state, now, c.startingTimeout) && state.ActiveRevision > 0 && state.StartToken != "" {
+		revision = state.ActiveRevision
+		token = state.StartToken
+		condition = "desiredRevision >= :revision AND attribute_not_exists(activeBuildId) AND #status = :starting AND activeRevision = :revision AND startToken = :token AND (attribute_not_exists(startedAt) OR startedAt < :staleBefore)"
+	}
+	acquired, err := c.dynamo.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:                aws.String(c.tableName),
+		Key:                      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: StateItemID}},
+		UpdateExpression:         aws.String("SET #status = :starting, activeRevision = :revision, startToken = :token, startedAt = :now REMOVE activeBuildId, lastError"),
+		ConditionExpression:      aws.String(condition),
+		ExpressionAttributeNames: map[string]string{"#status": "status"},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":starting":    &dynamodbtypes.AttributeValueMemberS{Value: StatusStarting},
+			":revision":    &dynamodbtypes.AttributeValueMemberN{Value: strconv.FormatInt(revision, 10)},
+			":token":       &dynamodbtypes.AttributeValueMemberS{Value: token},
+			":now":         &dynamodbtypes.AttributeValueMemberS{Value: now.Format(time.RFC3339Nano)},
+			":staleBefore": &dynamodbtypes.AttributeValueMemberS{Value: staleBefore},
+		},
+		ReturnValues: dynamodbtypes.ReturnValueAllNew,
+	})
+	if err != nil {
+		var conditional *dynamodbtypes.ConditionalCheckFailedException
+		if errors.As(err, &conditional) {
+			latest, getErr := c.GetState(ctx)
+			return RequestForState(latest, targetRevision), getErr
+		}
+		return Request{}, err
+	}
+	_ = acquired
+
+	buildOut, err := c.codebuild.StartBuild(ctx, &codebuild.StartBuildInput{
+		ProjectName:      aws.String(c.projectName),
+		IdempotencyToken: aws.String(token),
+		EnvironmentVariablesOverride: []codebuildtypes.EnvironmentVariable{{
+			Name: aws.String("CONTENT_REVISION"), Value: aws.String(strconv.FormatInt(revision, 10)), Type: codebuildtypes.EnvironmentVariableTypePlaintext,
+		}},
+	})
+	if err != nil {
+		if markErr := c.markStartFailed(ctx, revision, err); markErr != nil {
+			return Request{TargetRevision: revision, Status: StatusFailed}, errors.Join(err, markErr)
+		}
+		return Request{TargetRevision: revision, Status: StatusFailed}, err
+	}
+	buildID := ""
+	if buildOut.Build != nil {
+		buildID = aws.ToString(buildOut.Build.Id)
+	}
+	if buildID == "" {
+		err = errors.New("CodeBuild StartBuild returned no build ID")
+		if markErr := c.markStartFailed(ctx, revision, err); markErr != nil {
+			return Request{TargetRevision: revision, Status: StatusFailed}, errors.Join(err, markErr)
+		}
+		return Request{TargetRevision: revision, Status: StatusFailed}, err
+	}
+
+	_, err = c.dynamo.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:                aws.String(c.tableName),
+		Key:                      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: StateItemID}},
+		UpdateExpression:         aws.String("SET #status = :inProgress, activeBuildId = :buildId"),
+		ConditionExpression:      aws.String("activeRevision = :revision AND startToken = :token"),
+		ExpressionAttributeNames: map[string]string{"#status": "status"},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":inProgress": &dynamodbtypes.AttributeValueMemberS{Value: StatusInProgress},
+			":buildId":    &dynamodbtypes.AttributeValueMemberS{Value: buildID},
+			":revision":   &dynamodbtypes.AttributeValueMemberN{Value: strconv.FormatInt(revision, 10)},
+			":token":      &dynamodbtypes.AttributeValueMemberS{Value: token},
+		},
+	})
+	if err != nil {
+		return Request{}, err
+	}
+	if revision < targetRevision {
+		return Request{TargetRevision: targetRevision, Status: StatusQueued}, nil
+	}
+	return Request{TargetRevision: targetRevision, BuildID: buildID, Status: StatusInProgress}, nil
+}
+
+func (c *Coordinator) markStartFailed(ctx context.Context, revision int64, startErr error) error {
+	_, err := c.dynamo.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:                aws.String(c.tableName),
+		Key:                      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: StateItemID}},
+		UpdateExpression:         aws.String("SET #status = :failed, lastError = :error REMOVE activeBuildId, startToken, startedAt"),
+		ConditionExpression:      aws.String("activeRevision = :revision"),
+		ExpressionAttributeNames: map[string]string{"#status": "status"},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":failed":   &dynamodbtypes.AttributeValueMemberS{Value: StatusFailed},
+			":error":    &dynamodbtypes.AttributeValueMemberS{Value: startErr.Error()},
+			":revision": &dynamodbtypes.AttributeValueMemberN{Value: strconv.FormatInt(revision, 10)},
+		},
+	})
+	return err
+}
+
+// Reconcile updates durable state from the active CodeBuild and starts a
+// trailing build when newer content was requested during that build.
+func (c *Coordinator) Reconcile(ctx context.Context) (State, error) {
+	state, err := c.GetState(ctx)
+	if err != nil {
+		return State{}, err
+	}
+	if state.ActiveBuildID == "" {
+		if state.DesiredRevision > state.DeployedRevision {
+			if _, startErr := c.StartPending(ctx); startErr != nil {
+				return State{}, startErr
+			}
+			return c.GetState(ctx)
+		}
+		return state, nil
+	}
+
+	out, err := c.codebuild.BatchGetBuilds(ctx, &codebuild.BatchGetBuildsInput{Ids: []string{state.ActiveBuildID}})
+	if err != nil {
+		return State{}, err
+	}
+	if len(out.Builds) == 0 {
+		return state, nil
+	}
+	build := out.Builds[0]
+	if build.BuildStatus == codebuildtypes.StatusTypeInProgress {
+		return state, nil
+	}
+
+	now := c.now().UTC().Format(time.RFC3339Nano)
+	if build.BuildStatus == codebuildtypes.StatusTypeSucceeded {
+		_, err = c.dynamo.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName:                aws.String(c.tableName),
+			Key:                      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: StateItemID}},
+			UpdateExpression:         aws.String("SET deployedRevision = :revision, #status = :status, completedAt = :now REMOVE activeBuildId, startToken, startedAt, lastError"),
+			ConditionExpression:      aws.String("activeBuildId = :buildId AND activeRevision = :revision"),
+			ExpressionAttributeNames: map[string]string{"#status": "status"},
+			ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+				":revision": &dynamodbtypes.AttributeValueMemberN{Value: strconv.FormatInt(state.ActiveRevision, 10)},
+				":status":   &dynamodbtypes.AttributeValueMemberS{Value: StatusSucceeded},
+				":now":      &dynamodbtypes.AttributeValueMemberS{Value: now},
+				":buildId":  &dynamodbtypes.AttributeValueMemberS{Value: state.ActiveBuildID},
+			},
+		})
+		if err != nil {
+			return State{}, err
+		}
+		// Re-read desiredRevision inside StartPending. A post mutation can race
+		// with the completion update after the initial state read; relying on
+		// the stale snapshot here could strand that mutation until the scheduler.
+		if _, startErr := c.StartPending(ctx); startErr != nil {
+			return State{}, startErr
+		}
+		return c.GetState(ctx)
+	}
+
+	_, err = c.dynamo.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:                aws.String(c.tableName),
+		Key:                      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: StateItemID}},
+		UpdateExpression:         aws.String("SET #status = :failed, completedAt = :now, lastError = :error REMOVE activeBuildId, startToken, startedAt"),
+		ConditionExpression:      aws.String("activeBuildId = :buildId"),
+		ExpressionAttributeNames: map[string]string{"#status": "status"},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":failed":  &dynamodbtypes.AttributeValueMemberS{Value: StatusFailed},
+			":now":     &dynamodbtypes.AttributeValueMemberS{Value: now},
+			":error":   &dynamodbtypes.AttributeValueMemberS{Value: string(build.BuildStatus)},
+			":buildId": &dynamodbtypes.AttributeValueMemberS{Value: state.ActiveBuildID},
+		},
+	})
+	if err != nil {
+		return State{}, err
+	}
+	latest, err := c.GetState(ctx)
+	if err != nil {
+		return State{}, err
+	}
+	if latest.DesiredRevision > state.ActiveRevision {
+		if _, err := c.StartPending(ctx); err != nil {
+			return State{}, err
+		}
+	}
+	return c.GetState(ctx)
+}
+
+// RequestForState derives the status of one target revision from durable state.
+func RequestForState(state State, targetRevision int64) Request {
+	if targetRevision == 0 {
+		targetRevision = state.DesiredRevision
+	}
+	status := StatusQueued
+	buildID := ""
+	switch {
+	case targetRevision == 0:
+		status = StatusIdle
+	case state.DeployedRevision >= targetRevision:
+		status = StatusSucceeded
+	case state.Status == StatusFailed && state.ActiveRevision >= targetRevision:
+		status = StatusFailed
+	case state.ActiveBuildID != "" && state.ActiveRevision >= targetRevision:
+		status = StatusInProgress
+	case state.Status == StatusStarting && state.ActiveRevision >= targetRevision:
+		status = StatusQueued
+	}
+	if status == StatusInProgress && state.ActiveRevision >= targetRevision {
+		buildID = state.ActiveBuildID
+	}
+	return Request{TargetRevision: targetRevision, BuildID: buildID, Status: status}
+}
+
+func isStartingStale(state State, now time.Time, timeout time.Duration) bool {
+	started, err := time.Parse(time.RFC3339Nano, state.StartedAt)
+	return err != nil || now.Sub(started) >= timeout
+}

--- a/go-functions/internal/sitebuild/sitebuild_test.go
+++ b/go-functions/internal/sitebuild/sitebuild_test.go
@@ -1,0 +1,224 @@
+package sitebuild
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	codebuildtypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type mockDynamoDB struct {
+	states  []State
+	getCall int
+	updates []*dynamodb.UpdateItemInput
+}
+
+func (m *mockDynamoDB) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	if m.getCall >= len(m.states) {
+		return nil, errors.New("unexpected GetItem call")
+	}
+	item, err := attributevalue.MarshalMap(m.states[m.getCall])
+	m.getCall++
+	if err != nil {
+		return nil, err
+	}
+	return &dynamodb.GetItemOutput{Item: item}, nil
+}
+
+func (m *mockDynamoDB) UpdateItem(_ context.Context, input *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	m.updates = append(m.updates, input)
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+type mockCodeBuild struct {
+	startInputs []*codebuild.StartBuildInput
+	startOutput *codebuild.StartBuildOutput
+	startErr    error
+	batchOutput *codebuild.BatchGetBuildsOutput
+}
+
+func (m *mockCodeBuild) StartBuild(_ context.Context, input *codebuild.StartBuildInput, _ ...func(*codebuild.Options)) (*codebuild.StartBuildOutput, error) {
+	m.startInputs = append(m.startInputs, input)
+	if m.startErr != nil {
+		return nil, m.startErr
+	}
+	return m.startOutput, nil
+}
+
+func (m *mockCodeBuild) BatchGetBuilds(_ context.Context, _ *codebuild.BatchGetBuildsInput, _ ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error) {
+	return m.batchOutput, nil
+}
+
+func TestRequestUpdateAtomicallyIncrementsDesiredRevision(t *testing.T) {
+	item := RequestUpdate("posts", time.Date(2026, 8, 2, 1, 2, 3, 0, time.UTC))
+	if item.Update == nil || aws.ToString(item.Update.TableName) != "posts" {
+		t.Fatal("expected a transaction update for the posts table")
+	}
+	expression := aws.ToString(item.Update.UpdateExpression)
+	if !strings.Contains(expression, "ADD desiredRevision :one") {
+		t.Fatalf("desiredRevision must be incremented atomically: %s", expression)
+	}
+	if !strings.Contains(expression, "#status = if_not_exists(#status, :queued)") {
+		t.Fatalf("an active starting/in-progress status must be preserved: %s", expression)
+	}
+	if got := item.Update.ExpressionAttributeValues[":queued"].(*dynamodbtypes.AttributeValueMemberS); got.Value != StatusQueued {
+		t.Fatalf("expected queued state, got %q", got.Value)
+	}
+}
+
+func TestStartPendingStartsDesiredRevisionWithIdempotencyToken(t *testing.T) {
+	dynamoClient := &mockDynamoDB{states: []State{{
+		ID: StateItemID, DesiredRevision: 2, DeployedRevision: 1, Status: StatusQueued,
+	}}}
+	codebuildClient := &mockCodeBuild{startOutput: &codebuild.StartBuildOutput{
+		Build: &codebuildtypes.Build{Id: aws.String("project:build-2")},
+	}}
+	coordinator := NewCoordinator(dynamoClient, codebuildClient, "posts", "site-project")
+	coordinator.now = func() time.Time { return time.Date(2026, 8, 2, 2, 0, 0, 0, time.UTC) }
+
+	request, err := coordinator.StartPending(context.Background())
+	if err != nil {
+		t.Fatalf("StartPending returned error: %v", err)
+	}
+	if request.TargetRevision != 2 || request.BuildID != "project:build-2" || request.Status != StatusInProgress {
+		t.Fatalf("unexpected request: %+v", request)
+	}
+	if len(codebuildClient.startInputs) != 1 {
+		t.Fatalf("expected one StartBuild call, got %d", len(codebuildClient.startInputs))
+	}
+	input := codebuildClient.startInputs[0]
+	if aws.ToString(input.IdempotencyToken) != "site-revision-2" {
+		t.Fatalf("unexpected idempotency token: %q", aws.ToString(input.IdempotencyToken))
+	}
+	if len(input.EnvironmentVariablesOverride) != 1 || aws.ToString(input.EnvironmentVariablesOverride[0].Value) != "2" {
+		t.Fatalf("CONTENT_REVISION override is missing: %+v", input.EnvironmentVariablesOverride)
+	}
+	if len(dynamoClient.updates) != 2 {
+		t.Fatalf("expected lock and build-id updates, got %d", len(dynamoClient.updates))
+	}
+}
+
+func TestCurrentRequestPreservesTargetWhenSynchronousStartIsUnavailable(t *testing.T) {
+	dynamoClient := &mockDynamoDB{states: []State{{
+		ID: StateItemID, DesiredRevision: 8, DeployedRevision: 7, Status: StatusQueued,
+	}}}
+	request := CurrentRequest(context.Background(), dynamoClient, "posts")
+	if request.TargetRevision != 8 || request.Status != StatusQueued {
+		t.Fatalf("unexpected durable request: %+v", request)
+	}
+}
+
+func TestStartPendingQueuesNewestRevisionWhileBuildIsActive(t *testing.T) {
+	dynamoClient := &mockDynamoDB{states: []State{{
+		ID: StateItemID, DesiredRevision: 3, DeployedRevision: 1,
+		ActiveRevision: 2, ActiveBuildID: "project:build-2", Status: StatusQueued,
+	}}}
+	codebuildClient := &mockCodeBuild{}
+
+	request, err := NewCoordinator(dynamoClient, codebuildClient, "posts", "site-project").StartPending(context.Background())
+	if err != nil {
+		t.Fatalf("StartPending returned error: %v", err)
+	}
+	if request.TargetRevision != 3 || request.Status != StatusQueued || request.BuildID != "" {
+		t.Fatalf("new revision must remain queued behind the active build: %+v", request)
+	}
+	if len(codebuildClient.startInputs) != 0 {
+		t.Fatal("must not start a concurrent site build")
+	}
+}
+
+func TestStartPendingRecoversStaleStartBeforeNewerDesiredRevision(t *testing.T) {
+	now := time.Date(2026, 8, 2, 3, 0, 0, 0, time.UTC)
+	dynamoClient := &mockDynamoDB{states: []State{{
+		ID: StateItemID, DesiredRevision: 3, DeployedRevision: 1,
+		ActiveRevision: 2, StartToken: "site-revision-2", Status: StatusStarting,
+		StartedAt: now.Add(-10 * time.Minute).Format(time.RFC3339Nano),
+	}}}
+	codebuildClient := &mockCodeBuild{startOutput: &codebuild.StartBuildOutput{
+		Build: &codebuildtypes.Build{Id: aws.String("project:build-2")},
+	}}
+	coordinator := NewCoordinator(dynamoClient, codebuildClient, "posts", "site-project")
+	coordinator.now = func() time.Time { return now }
+
+	request, err := coordinator.StartPending(context.Background())
+	if err != nil {
+		t.Fatalf("StartPending returned error: %v", err)
+	}
+	if request.TargetRevision != 3 || request.Status != StatusQueued || request.BuildID != "" {
+		t.Fatalf("newer revision must remain queued during stale-start recovery: %+v", request)
+	}
+	if len(codebuildClient.startInputs) != 1 {
+		t.Fatalf("expected one recovery StartBuild call, got %d", len(codebuildClient.startInputs))
+	}
+	input := codebuildClient.startInputs[0]
+	if aws.ToString(input.IdempotencyToken) != "site-revision-2" || aws.ToString(input.EnvironmentVariablesOverride[0].Value) != "2" {
+		t.Fatalf("must recover the exact active revision: %+v", input)
+	}
+	if condition := aws.ToString(dynamoClient.updates[0].ConditionExpression); !strings.Contains(condition, "startToken = :token") {
+		t.Fatalf("recovery lock must retain the original token: %s", condition)
+	}
+}
+
+func TestReconcileSuccessfulBuildStartsTrailingRevision(t *testing.T) {
+	initial := State{
+		ID: StateItemID, DesiredRevision: 3, DeployedRevision: 1,
+		ActiveRevision: 2, ActiveBuildID: "project:build-2", Status: StatusInProgress,
+	}
+	afterCompletion := State{ID: StateItemID, DesiredRevision: 3, DeployedRevision: 2, ActiveRevision: 2, Status: StatusQueued}
+	final := State{
+		ID: StateItemID, DesiredRevision: 3, DeployedRevision: 2,
+		ActiveRevision: 3, ActiveBuildID: "project:build-3", Status: StatusInProgress,
+	}
+	dynamoClient := &mockDynamoDB{states: []State{initial, afterCompletion, final}}
+	codebuildClient := &mockCodeBuild{
+		batchOutput: &codebuild.BatchGetBuildsOutput{Builds: []codebuildtypes.Build{{BuildStatus: codebuildtypes.StatusTypeSucceeded}}},
+		startOutput: &codebuild.StartBuildOutput{Build: &codebuildtypes.Build{Id: aws.String("project:build-3")}},
+	}
+
+	state, err := NewCoordinator(dynamoClient, codebuildClient, "posts", "site-project").Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if state.DeployedRevision != 2 || state.ActiveRevision != 3 || state.ActiveBuildID != "project:build-3" {
+		t.Fatalf("trailing revision was not started: %+v", state)
+	}
+	if len(codebuildClient.startInputs) != 1 || aws.ToString(codebuildClient.startInputs[0].IdempotencyToken) != "site-revision-3" {
+		t.Fatalf("expected a trailing build for revision 3: %+v", codebuildClient.startInputs)
+	}
+	if len(dynamoClient.updates) != 3 {
+		t.Fatalf("expected completion, lock, and build-id updates, got %d", len(dynamoClient.updates))
+	}
+}
+
+func TestRequestForStateCorrelatesTargetRevision(t *testing.T) {
+	state := State{
+		DesiredRevision: 5, DeployedRevision: 3, ActiveRevision: 4,
+		ActiveBuildID: "project:build-4", Status: StatusInProgress,
+	}
+	tests := []struct {
+		name   string
+		target int64
+		status string
+		build  string
+	}{
+		{name: "deployed", target: 3, status: StatusSucceeded},
+		{name: "active", target: 4, status: StatusInProgress, build: "project:build-4"},
+		{name: "newer queued", target: 5, status: StatusQueued},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := RequestForState(state, tt.target)
+			if request.Status != tt.status || request.BuildID != tt.build {
+				t.Fatalf("unexpected correlated request: %+v", request)
+			}
+		})
+	}
+}

--- a/go-functions/internal/sitebuild/sitebuild_test.go
+++ b/go-functions/internal/sitebuild/sitebuild_test.go
@@ -16,12 +16,21 @@ import (
 )
 
 type mockDynamoDB struct {
-	states  []State
-	getCall int
-	updates []*dynamodb.UpdateItemInput
+	states       []State
+	getCall      int
+	getErr       error
+	emptyGet     bool
+	updates      []*dynamodb.UpdateItemInput
+	updateErrors []error
 }
 
 func (m *mockDynamoDB) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if m.emptyGet {
+		return &dynamodb.GetItemOutput{}, nil
+	}
 	if m.getCall >= len(m.states) {
 		return nil, errors.New("unexpected GetItem call")
 	}
@@ -34,7 +43,11 @@ func (m *mockDynamoDB) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ..
 }
 
 func (m *mockDynamoDB) UpdateItem(_ context.Context, input *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	call := len(m.updates)
 	m.updates = append(m.updates, input)
+	if call < len(m.updateErrors) && m.updateErrors[call] != nil {
+		return nil, m.updateErrors[call]
+	}
 	return &dynamodb.UpdateItemOutput{}, nil
 }
 
@@ -43,6 +56,7 @@ type mockCodeBuild struct {
 	startOutput *codebuild.StartBuildOutput
 	startErr    error
 	batchOutput *codebuild.BatchGetBuildsOutput
+	batchErr    error
 }
 
 func (m *mockCodeBuild) StartBuild(_ context.Context, input *codebuild.StartBuildInput, _ ...func(*codebuild.Options)) (*codebuild.StartBuildOutput, error) {
@@ -54,6 +68,9 @@ func (m *mockCodeBuild) StartBuild(_ context.Context, input *codebuild.StartBuil
 }
 
 func (m *mockCodeBuild) BatchGetBuilds(_ context.Context, _ *codebuild.BatchGetBuildsInput, _ ...func(*codebuild.Options)) (*codebuild.BatchGetBuildsOutput, error) {
+	if m.batchErr != nil {
+		return nil, m.batchErr
+	}
 	return m.batchOutput, nil
 }
 
@@ -116,6 +133,23 @@ func TestCurrentRequestPreservesTargetWhenSynchronousStartIsUnavailable(t *testi
 	}
 }
 
+func TestCurrentRequestReturnsFailedWhenStateCannotBeRead(t *testing.T) {
+	request := CurrentRequest(context.Background(), &mockDynamoDB{getErr: errors.New("read failed")}, "posts")
+	if request.Status != StatusFailed {
+		t.Fatalf("state read failure must be visible to the caller: %+v", request)
+	}
+}
+
+func TestGetStateReturnsIdleWhenCoordinatorDoesNotExist(t *testing.T) {
+	state, err := NewCoordinator(&mockDynamoDB{emptyGet: true}, nil, "posts", "").GetState(context.Background())
+	if err != nil {
+		t.Fatalf("GetState returned error: %v", err)
+	}
+	if state.ID != StateItemID || state.Status != StatusIdle {
+		t.Fatalf("unexpected empty state: %+v", state)
+	}
+}
+
 func TestStartPendingQueuesNewestRevisionWhileBuildIsActive(t *testing.T) {
 	dynamoClient := &mockDynamoDB{states: []State{{
 		ID: StateItemID, DesiredRevision: 3, DeployedRevision: 1,
@@ -167,6 +201,44 @@ func TestStartPendingRecoversStaleStartBeforeNewerDesiredRevision(t *testing.T) 
 	}
 }
 
+func TestStartPendingReturnsConditionalLockWinner(t *testing.T) {
+	conditional := &dynamodbtypes.ConditionalCheckFailedException{Message: aws.String("lost lock")}
+	dynamoClient := &mockDynamoDB{
+		states: []State{
+			{ID: StateItemID, DesiredRevision: 2, DeployedRevision: 1, Status: StatusQueued},
+			{ID: StateItemID, DesiredRevision: 2, DeployedRevision: 1, ActiveRevision: 2, ActiveBuildID: "project:build-2", Status: StatusInProgress},
+		},
+		updateErrors: []error{conditional},
+	}
+
+	request, err := NewCoordinator(dynamoClient, &mockCodeBuild{}, "posts", "site-project").StartPending(context.Background())
+	if err != nil {
+		t.Fatalf("conditional lock loss should return the winning request: %v", err)
+	}
+	if request.Status != StatusInProgress || request.BuildID != "project:build-2" {
+		t.Fatalf("unexpected winning request: %+v", request)
+	}
+}
+
+func TestStartPendingMarksCodeBuildStartFailure(t *testing.T) {
+	dynamoClient := &mockDynamoDB{states: []State{{
+		ID: StateItemID, DesiredRevision: 2, DeployedRevision: 1, Status: StatusQueued,
+	}}}
+	codebuildClient := &mockCodeBuild{startErr: errors.New("CodeBuild unavailable")}
+
+	request, err := NewCoordinator(dynamoClient, codebuildClient, "posts", "site-project").StartPending(context.Background())
+	if err == nil || request.Status != StatusFailed || request.TargetRevision != 2 {
+		t.Fatalf("expected correlated start failure, request=%+v err=%v", request, err)
+	}
+	if len(dynamoClient.updates) != 2 {
+		t.Fatalf("expected lock and failure updates, got %d", len(dynamoClient.updates))
+	}
+	failureUpdate := dynamoClient.updates[1]
+	if got := failureUpdate.ExpressionAttributeValues[":error"].(*dynamodbtypes.AttributeValueMemberS).Value; got != "CodeBuild unavailable" {
+		t.Fatalf("unexpected persisted failure: %q", got)
+	}
+}
+
 func TestReconcileSuccessfulBuildStartsTrailingRevision(t *testing.T) {
 	initial := State{
 		ID: StateItemID, DesiredRevision: 3, DeployedRevision: 1,
@@ -198,6 +270,73 @@ func TestReconcileSuccessfulBuildStartsTrailingRevision(t *testing.T) {
 	}
 }
 
+func TestReconcileFailedBuildStartsTrailingRevision(t *testing.T) {
+	initial := State{
+		ID: StateItemID, DesiredRevision: 3, DeployedRevision: 1,
+		ActiveRevision: 2, ActiveBuildID: "project:build-2", Status: StatusInProgress,
+	}
+	afterFailure := State{
+		ID: StateItemID, DesiredRevision: 3, DeployedRevision: 1,
+		ActiveRevision: 2, Status: StatusFailed, LastError: string(codebuildtypes.StatusTypeFailed),
+	}
+	final := State{
+		ID: StateItemID, DesiredRevision: 3, DeployedRevision: 1,
+		ActiveRevision: 3, ActiveBuildID: "project:build-3", Status: StatusInProgress,
+	}
+	dynamoClient := &mockDynamoDB{states: []State{initial, afterFailure, afterFailure, final}}
+	codebuildClient := &mockCodeBuild{
+		batchOutput: &codebuild.BatchGetBuildsOutput{Builds: []codebuildtypes.Build{{BuildStatus: codebuildtypes.StatusTypeFailed}}},
+		startOutput: &codebuild.StartBuildOutput{Build: &codebuildtypes.Build{Id: aws.String("project:build-3")}},
+	}
+
+	state, err := NewCoordinator(dynamoClient, codebuildClient, "posts", "site-project").Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if state.ActiveRevision != 3 || state.ActiveBuildID != "project:build-3" || state.Status != StatusInProgress {
+		t.Fatalf("failed build did not start trailing revision: %+v", state)
+	}
+	if len(dynamoClient.updates) != 3 {
+		t.Fatalf("expected failure, lock, and build-id updates, got %d", len(dynamoClient.updates))
+	}
+}
+
+func TestReconcileLeavesInProgressBuildUnchanged(t *testing.T) {
+	initial := State{
+		ID: StateItemID, DesiredRevision: 2, DeployedRevision: 1,
+		ActiveRevision: 2, ActiveBuildID: "project:build-2", Status: StatusInProgress,
+	}
+	dynamoClient := &mockDynamoDB{states: []State{initial}}
+	codebuildClient := &mockCodeBuild{batchOutput: &codebuild.BatchGetBuildsOutput{
+		Builds: []codebuildtypes.Build{{BuildStatus: codebuildtypes.StatusTypeInProgress}},
+	}}
+
+	state, err := NewCoordinator(dynamoClient, codebuildClient, "posts", "site-project").Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if state.ActiveBuildID != initial.ActiveBuildID || len(dynamoClient.updates) != 0 {
+		t.Fatalf("in-progress build must remain unchanged: %+v", state)
+	}
+}
+
+func TestReconcileReturnsCodeBuildStatusError(t *testing.T) {
+	initial := State{
+		ID: StateItemID, DesiredRevision: 2, DeployedRevision: 1,
+		ActiveRevision: 2, ActiveBuildID: "project:build-2", Status: StatusInProgress,
+	}
+	dynamoClient := &mockDynamoDB{states: []State{initial}}
+	codebuildClient := &mockCodeBuild{batchErr: errors.New("CodeBuild status unavailable")}
+
+	_, err := NewCoordinator(dynamoClient, codebuildClient, "posts", "site-project").Reconcile(context.Background())
+	if err == nil || err.Error() != "CodeBuild status unavailable" {
+		t.Fatalf("expected CodeBuild status error, got %v", err)
+	}
+	if len(dynamoClient.updates) != 0 {
+		t.Fatal("status lookup failure must not mutate durable state")
+	}
+}
+
 func TestRequestForStateCorrelatesTargetRevision(t *testing.T) {
 	state := State{
 		DesiredRevision: 5, DeployedRevision: 3, ActiveRevision: 4,
@@ -212,12 +351,33 @@ func TestRequestForStateCorrelatesTargetRevision(t *testing.T) {
 		{name: "deployed", target: 3, status: StatusSucceeded},
 		{name: "active", target: 4, status: StatusInProgress, build: "project:build-4"},
 		{name: "newer queued", target: 5, status: StatusQueued},
+		{name: "default target", target: 0, status: StatusQueued},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			request := RequestForState(state, tt.target)
 			if request.Status != tt.status || request.BuildID != tt.build {
 				t.Fatalf("unexpected correlated request: %+v", request)
+			}
+		})
+	}
+}
+
+func TestRequestForStateCoversIdleFailedAndStartingStates(t *testing.T) {
+	tests := []struct {
+		name   string
+		state  State
+		target int64
+		status string
+	}{
+		{name: "idle", state: State{Status: StatusIdle}, status: StatusIdle},
+		{name: "failed", state: State{DesiredRevision: 2, ActiveRevision: 2, Status: StatusFailed}, target: 2, status: StatusFailed},
+		{name: "starting", state: State{DesiredRevision: 2, ActiveRevision: 2, Status: StatusStarting}, target: 2, status: StatusQueued},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RequestForState(tt.state, tt.target); got.Status != tt.status {
+				t.Fatalf("unexpected request: %+v", got)
 			}
 		})
 	}

--- a/terraform/modules/lambda/iam.tf
+++ b/terraform/modules/lambda/iam.tf
@@ -11,9 +11,8 @@
 #   - lambda_posts_read         - GetItem/Query only (public + admin reads)
 #   - lambda_posts_write        - GetItem/PutItem/DeleteItem/Query + S3 delete
 #                                 cascade + CodeBuild trigger (create/update/delete)
-#   - lambda_posts_build_status - CodeBuild List/BatchGet only (polls build
-#                                 status; never starts a build, never touches
-#                                 DynamoDB or S3)
+#   - lambda_posts_build_status - GetItem only (reads durable build state;
+#                                 never starts a build or writes state)
 # - Auth domain: Cognito access only (unchanged - already least privilege)
 # - Images domain: S3 access only (unchanged - out of scope for #493)
 # - Categories domain:
@@ -95,9 +94,9 @@ resource "aws_iam_role_policy" "lambda_posts_read_dynamodb" {
 #   update_post -> dynamodb GetItem, PutItem, Query (slug change check)
 #   delete_post -> dynamodb GetItem, DeleteItem; s3 DeleteObjects (image
 #                  cascade, only when the post has ImageURLs)
-# None of the three call dynamodb UpdateItem or Scan directly, so those
-# actions are intentionally omitted.
-# All three conditionally trigger a site rebuild via CodeBuild.
+# Public-site-impacting mutations use TransactWriteItems with an Update on the
+# singleton build-state item. IAM authorizes the transaction through the
+# underlying Put/Delete/Update actions.
 # ======================
 
 resource "aws_iam_role" "lambda_posts_write" {
@@ -131,6 +130,7 @@ resource "aws_iam_role_policy" "lambda_posts_write_dynamodb" {
         Action = [
           "dynamodb:GetItem",
           "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
           "dynamodb:DeleteItem",
           "dynamodb:Query"
         ]
@@ -166,7 +166,6 @@ resource "aws_iam_role_policy" "lambda_posts_write_s3_cascade" {
 
 # CodeBuild access for triggering site rebuilds
 # Requirement 10.4: Lambda execution role with codebuild:StartBuild permission
-# Requirement 10.3: ListBuildsForProject and BatchGetBuilds for idempotency handling
 resource "aws_iam_role_policy" "lambda_posts_write_codebuild" {
   count = var.codebuild_project_arn != "" ? 1 : 0
   name  = "blog-lambda-posts-write-codebuild-policy"
@@ -179,9 +178,7 @@ resource "aws_iam_role_policy" "lambda_posts_write_codebuild" {
         Sid    = "CodeBuildTrigger"
         Effect = "Allow"
         Action = [
-          "codebuild:StartBuild",
-          "codebuild:ListBuildsForProject",
-          "codebuild:BatchGetBuilds"
+          "codebuild:StartBuild"
         ]
         Resource = var.codebuild_project_arn
       }
@@ -193,12 +190,7 @@ resource "aws_iam_role_policy" "lambda_posts_write_codebuild" {
 # Posts Domain - Build Status Role
 # Used by: build_status_post only.
 #
-# Confirmed this handler never calls dynamodb or s3 (it only polls
-# CodeBuild), and never calls codebuild:StartBuild - it only reads the
-# status of builds someone else started. Giving it the full write role
-# would hand a read-only "poll build status" endpoint the ability to
-# start arbitrary builds and mutate posts/images, which is exactly the
-# over-provisioning issue #493 exists to fix.
+# This handler reads only the singleton build-state item from DynamoDB.
 # ======================
 
 resource "aws_iam_role" "lambda_posts_build_status" {
@@ -218,22 +210,78 @@ resource "aws_iam_role_policy_attachment" "lambda_posts_build_status_xray" {
   policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 }
 
-resource "aws_iam_role_policy" "lambda_posts_build_status_codebuild" {
-  count = var.codebuild_project_arn != "" ? 1 : 0
-  name  = "blog-lambda-posts-build-status-codebuild-policy"
-  role  = aws_iam_role.lambda_posts_build_status.id
+resource "aws_iam_role_policy" "lambda_posts_build_status_dynamodb" {
+  name = "blog-lambda-posts-build-status-dynamodb-policy"
+  role = aws_iam_role.lambda_posts_build_status.id
 
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "CodeBuildStatusPoll"
-        Effect = "Allow"
-        Action = [
-          "codebuild:ListBuildsForProject",
-          "codebuild:BatchGetBuilds"
-        ]
+        Sid      = "DynamoDBBuildStateRead"
+        Effect   = "Allow"
+        Action   = ["dynamodb:GetItem"]
+        Resource = var.table_arn
+      }
+    ]
+  })
+}
+
+# ======================
+# Posts Domain - Build Reconciler Role
+# EventBridge/Scheduler invokes this Lambda. It may update only the singleton
+# coordinator item and start/poll only the configured CodeBuild project.
+# ======================
+
+resource "aws_iam_role" "lambda_posts_build_reconciler" {
+  name               = "blog-lambda-posts-build-reconciler-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_posts_build_reconciler_basic_execution" {
+  role       = aws_iam_role.lambda_posts_build_reconciler.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_posts_build_reconciler_xray" {
+  count      = var.enable_xray ? 1 : 0
+  role       = aws_iam_role.lambda_posts_build_reconciler.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+resource "aws_iam_role_policy" "lambda_posts_build_reconciler_dynamodb" {
+  name = "blog-lambda-posts-build-reconciler-dynamodb-policy"
+  role = aws_iam_role.lambda_posts_build_reconciler.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "DynamoDBBuildStateReconcile"
+      Effect   = "Allow"
+      Action   = ["dynamodb:GetItem", "dynamodb:UpdateItem"]
+      Resource = var.table_arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_posts_build_reconciler_codebuild" {
+  count = var.codebuild_project_arn != "" ? 1 : 0
+  name  = "blog-lambda-posts-build-reconciler-codebuild-policy"
+  role  = aws_iam_role.lambda_posts_build_reconciler.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "CodeBuildStart"
+        Effect   = "Allow"
+        Action   = ["codebuild:StartBuild"]
         Resource = var.codebuild_project_arn
+      },
+      {
+        Sid      = "CodeBuildReadBuild"
+        Effect   = "Allow"
+        Action   = ["codebuild:BatchGetBuilds"]
+        Resource = "${replace(var.codebuild_project_arn, ":project/", ":build/")}:*"
       }
     ]
   })

--- a/terraform/modules/lambda/import.tf
+++ b/terraform/modules/lambda/import.tf
@@ -225,7 +225,7 @@
 # +---------------------------+------------------------------------------------+
 #
 # After import, verify:
-# - All 11 Lambda functions are properly imported
+# - All API and background Lambda functions are properly imported
 # - Runtime is provided.al2023
 # - Architecture is arm64
 # - Memory size is 128 MB

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -1,7 +1,7 @@
 # Lambda Module - Go Lambda Functions
 # Requirements: 4.1 - Go Lambda functions module implementation
 #
-# This module defines 11 Go Lambda functions:
+# This module defines the Go Lambda functions used by the API and background jobs.
 # - Posts domain: createPost, getPost, getPublicPost, listPosts, updatePost, deletePost
 # - Auth domain: login, logout, refresh
 # - Images domain: getUploadUrl, deleteImage
@@ -69,8 +69,13 @@ locals {
     }
     build_status_post = {
       name        = "blog-build-status-post-go"
-      description = "Get latest CodeBuild status for the Astro SSG site rebuild (Go)"
+      description = "Get revision-correlated status for the Astro SSG site rebuild (Go)"
       binary_name = "posts-build_status"
+    }
+    reconcile_build_post = {
+      name        = "blog-reconcile-build-post-go"
+      description = "Reconcile durable site build requests with CodeBuild (Go)"
+      binary_name = "posts-reconcile_build"
     }
     get_post_by_slug = {
       name        = "blog-get-post-by-slug-go"
@@ -190,6 +195,12 @@ resource "aws_cloudwatch_log_group" "build_status_post" {
   tags              = local.common_tags
 }
 
+resource "aws_cloudwatch_log_group" "reconcile_build_post" {
+  name              = "/aws/lambda/${local.lambda_functions.reconcile_build_post.name}"
+  retention_in_days = local.log_retention_days
+  tags              = local.common_tags
+}
+
 resource "aws_cloudwatch_log_group" "get_post_by_slug" {
   name              = "/aws/lambda/${local.lambda_functions.get_post_by_slug.name}"
   retention_in_days = local.log_retention_days
@@ -279,6 +290,13 @@ data "archive_file" "build_status_post" {
   type             = "zip"
   source_file      = "${var.go_binary_path}/${local.lambda_functions.build_status_post.binary_name}/bootstrap"
   output_path      = "${path.module}/.terraform/tmp/${local.lambda_functions.build_status_post.binary_name}.zip"
+  output_file_mode = "0644"
+}
+
+data "archive_file" "reconcile_build_post" {
+  type             = "zip"
+  source_file      = "${var.go_binary_path}/${local.lambda_functions.reconcile_build_post.binary_name}/bootstrap"
+  output_path      = "${path.module}/.terraform/tmp/${local.lambda_functions.reconcile_build_post.binary_name}.zip"
   output_file_mode = "0644"
 }
 
@@ -522,9 +540,7 @@ resource "aws_lambda_function" "build_status_post" {
   timeout       = 30
 
   environment {
-    variables = merge(local.common_environment, {
-      CODEBUILD_PROJECT_NAME = var.codebuild_project_name
-    })
+    variables = local.common_environment
   }
 
   tracing_config {
@@ -534,6 +550,36 @@ resource "aws_lambda_function" "build_status_post" {
   depends_on = [aws_cloudwatch_log_group.build_status_post]
 
   tags = local.common_tags
+}
+
+# EventBridge/Scheduler target that closes completed builds and starts a
+# trailing build when desiredRevision advanced during the active build.
+resource "aws_lambda_function" "reconcile_build_post" {
+  function_name = local.lambda_functions.reconcile_build_post.name
+  description   = local.lambda_functions.reconcile_build_post.description
+  role          = aws_iam_role.lambda_posts_build_reconciler.arn
+
+  filename         = data.archive_file.reconcile_build_post.output_path
+  source_code_hash = data.archive_file.reconcile_build_post.output_base64sha256
+
+  runtime       = "provided.al2023"
+  architectures = ["arm64"]
+  handler       = "bootstrap"
+  memory_size   = 128
+  timeout       = 30
+
+  environment {
+    variables = merge(local.common_environment, {
+      CODEBUILD_PROJECT_NAME = var.codebuild_project_name
+    })
+  }
+
+  tracing_config {
+    mode = local.tracing_mode
+  }
+
+  depends_on = [aws_cloudwatch_log_group.reconcile_build_post]
+  tags       = local.common_tags
 }
 
 # GET /posts/by-slug/{slug} - Public post fetch by friendly slug (PR7).
@@ -953,4 +999,3 @@ resource "aws_lambda_function" "delete_category" {
 
   tags = local.common_tags
 }
-

--- a/terraform/modules/lambda/outputs.tf
+++ b/terraform/modules/lambda/outputs.tf
@@ -14,6 +14,7 @@ output "function_arns" {
     update_post                  = aws_lambda_function.update_post.arn
     delete_post                  = aws_lambda_function.delete_post.arn
     build_status_post            = aws_lambda_function.build_status_post.arn
+    reconcile_build_post         = aws_lambda_function.reconcile_build_post.arn
     get_post_by_slug             = aws_lambda_function.get_post_by_slug.arn
     login                        = aws_lambda_function.login.arn
     logout                       = aws_lambda_function.logout.arn
@@ -42,6 +43,7 @@ output "function_invoke_arns" {
     update_post                  = aws_lambda_function.update_post.invoke_arn
     delete_post                  = aws_lambda_function.delete_post.invoke_arn
     build_status_post            = aws_lambda_function.build_status_post.invoke_arn
+    reconcile_build_post         = aws_lambda_function.reconcile_build_post.invoke_arn
     get_post_by_slug             = aws_lambda_function.get_post_by_slug.invoke_arn
     login                        = aws_lambda_function.login.invoke_arn
     logout                       = aws_lambda_function.logout.invoke_arn
@@ -70,6 +72,7 @@ output "function_names" {
     aws_lambda_function.update_post.function_name,
     aws_lambda_function.delete_post.function_name,
     aws_lambda_function.build_status_post.function_name,
+    aws_lambda_function.reconcile_build_post.function_name,
     aws_lambda_function.get_post_by_slug.function_name,
     aws_lambda_function.login.function_name,
     aws_lambda_function.logout.function_name,
@@ -118,6 +121,16 @@ output "posts_build_status_role_arn" {
 output "posts_build_status_role_name" {
   value       = aws_iam_role.lambda_posts_build_status.name
   description = "Posts domain build-status Lambda execution role name"
+}
+
+output "posts_build_reconciler_role_arn" {
+  value       = aws_iam_role.lambda_posts_build_reconciler.arn
+  description = "Posts domain build-reconciler Lambda execution role ARN"
+}
+
+output "posts_build_reconciler_role_name" {
+  value       = aws_iam_role.lambda_posts_build_reconciler.name
+  description = "Posts domain build-reconciler Lambda execution role name"
 }
 
 # Auth Domain Role
@@ -399,4 +412,3 @@ output "delete_category_invoke_arn" {
   value       = aws_lambda_function.delete_category.invoke_arn
   description = "Delete Category Lambda function invoke ARN for API Gateway integration"
 }
-

--- a/terraform/modules/lambda/sitebuild_events.tf
+++ b/terraform/modules/lambda/sitebuild_events.tf
@@ -100,6 +100,7 @@ resource "aws_iam_role_policy" "sitebuild_reconcile_scheduler" {
 }
 
 resource "aws_scheduler_schedule" "sitebuild_reconcile" {
+  #checkov:skip=CKV_AWS_297:No TargetInput payload is configured; a CMK only double-encrypts target payloads, while AWS-owned keys already protect all schedule metadata.
   count               = var.codebuild_project_arn != "" ? 1 : 0
   name                = "${var.codebuild_project_name}-reconcile"
   schedule_expression = "rate(5 minutes)"

--- a/terraform/modules/lambda/sitebuild_events.tf
+++ b/terraform/modules/lambda/sitebuild_events.tf
@@ -1,0 +1,120 @@
+# Durable site-build completion notification and periodic reconciliation.
+
+resource "aws_sqs_queue" "sitebuild_reconcile_dlq" {
+  count                     = var.codebuild_project_arn != "" ? 1 : 0
+  name                      = "${var.codebuild_project_name}-reconcile-dlq"
+  message_retention_seconds = 1209600
+  sqs_managed_sse_enabled   = true
+  tags                      = local.common_tags
+}
+
+resource "aws_cloudwatch_event_rule" "codebuild_state_change" {
+  count       = var.codebuild_project_arn != "" ? 1 : 0
+  name        = "${var.codebuild_project_name}-state"
+  description = "Reconcile durable site-build state after CodeBuild state changes"
+  event_pattern = jsonencode({
+    source        = ["aws.codebuild"]
+    "detail-type" = ["CodeBuild Build State Change"]
+    detail = {
+      "project-name" = [var.codebuild_project_name]
+    }
+  })
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_event_target" "sitebuild_reconciler" {
+  count     = var.codebuild_project_arn != "" ? 1 : 0
+  rule      = aws_cloudwatch_event_rule.codebuild_state_change[0].name
+  target_id = "sitebuild-reconciler"
+  arn       = aws_lambda_function.reconcile_build_post.arn
+
+  dead_letter_config {
+    arn = aws_sqs_queue.sitebuild_reconcile_dlq[0].arn
+  }
+
+  retry_policy {
+    maximum_event_age_in_seconds = 3600
+    maximum_retry_attempts       = 6
+  }
+}
+
+data "aws_iam_policy_document" "sitebuild_reconcile_dlq" {
+  count = var.codebuild_project_arn != "" ? 1 : 0
+  statement {
+    effect    = "Allow"
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.sitebuild_reconcile_dlq[0].arn]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudwatch_event_rule.codebuild_state_change[0].arn]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "sitebuild_reconcile_dlq" {
+  count     = var.codebuild_project_arn != "" ? 1 : 0
+  queue_url = aws_sqs_queue.sitebuild_reconcile_dlq[0].id
+  policy    = data.aws_iam_policy_document.sitebuild_reconcile_dlq[0].json
+}
+
+resource "aws_lambda_permission" "sitebuild_reconcile_eventbridge" {
+  count         = var.codebuild_project_arn != "" ? 1 : 0
+  statement_id  = "AllowCodeBuildEvents"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.reconcile_build_post.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.codebuild_state_change[0].arn
+}
+
+resource "aws_iam_role" "sitebuild_reconcile_scheduler" {
+  count = var.codebuild_project_arn != "" ? 1 : 0
+  name  = "${var.codebuild_project_name}-scheduler"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "scheduler.amazonaws.com" }
+    }]
+  })
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy" "sitebuild_reconcile_scheduler" {
+  count = var.codebuild_project_arn != "" ? 1 : 0
+  name  = "invoke-sitebuild-reconciler"
+  role  = aws_iam_role.sitebuild_reconcile_scheduler[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["lambda:InvokeFunction"]
+      Resource = aws_lambda_function.reconcile_build_post.arn
+    }]
+  })
+}
+
+resource "aws_scheduler_schedule" "sitebuild_reconcile" {
+  count               = var.codebuild_project_arn != "" ? 1 : 0
+  name                = "${var.codebuild_project_name}-reconcile"
+  schedule_expression = "rate(5 minutes)"
+  state               = "ENABLED"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = aws_lambda_function.reconcile_build_post.arn
+    role_arn = aws_iam_role.sitebuild_reconcile_scheduler[0].arn
+    retry_policy {
+      maximum_event_age_in_seconds = 300
+      maximum_retry_attempts       = 2
+    }
+  }
+}

--- a/terraform/modules/lambda/tests/lambda.tftest.hcl
+++ b/terraform/modules/lambda/tests/lambda.tftest.hcl
@@ -2,7 +2,7 @@
 # Requirements: 4.1 - Go Lambda functions module implementation
 #
 # Test coverage:
-# - 11 Lambda functions with correct configurations
+# - API and background Lambda functions with correct configurations
 # - ARM64 architecture and provided.al2023 runtime
 # - Memory and timeout settings
 # - Environment variables
@@ -40,6 +40,13 @@ mock_provider "aws" {
     target = aws_iam_role.lambda_posts_build_status
     values = {
       arn = "arn:aws:iam::123456789012:role/blog-lambda-posts-build-status-role"
+    }
+  }
+
+  override_resource {
+    target = aws_iam_role.lambda_posts_build_reconciler
+    values = {
+      arn = "arn:aws:iam::123456789012:role/blog-lambda-posts-build-reconciler-role"
     }
   }
 
@@ -477,6 +484,15 @@ run "lambda_posts_build_status_role_created" {
   }
 }
 
+run "lambda_posts_build_reconciler_role_created" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role.lambda_posts_build_reconciler.name == "blog-lambda-posts-build-reconciler-role"
+    error_message = "Lambda posts build-reconciler role should be created with correct name"
+  }
+}
+
 run "lambda_auth_role_created" {
   command = plan
 
@@ -586,6 +602,15 @@ run "build_status_function_uses_build_status_role" {
   assert {
     condition     = aws_lambda_function.build_status_post.role == aws_iam_role.lambda_posts_build_status.arn
     error_message = "build_status_post must use the dedicated build-status role, not the write role"
+  }
+}
+
+run "build_reconciler_function_uses_reconciler_role" {
+  command = apply
+
+  assert {
+    condition     = aws_lambda_function.reconcile_build_post.role == aws_iam_role.lambda_posts_build_reconciler.arn
+    error_message = "reconcile_build_post must use the dedicated build-reconciler role"
   }
 }
 
@@ -717,10 +742,10 @@ run "cloudwatch_log_groups_retention_dev" {
 }
 
 # ======================
-# All 11 Functions Exist Tests
+# Core Function Existence Tests
 # ======================
 
-run "all_11_lambda_functions_exist" {
+run "core_lambda_functions_exist" {
   command = plan
 
   # Posts domain (6 functions)
@@ -752,6 +777,16 @@ run "all_11_lambda_functions_exist" {
   assert {
     condition     = aws_lambda_function.delete_post.function_name != ""
     error_message = "delete_post Lambda function should exist"
+  }
+
+  assert {
+    condition     = aws_lambda_function.build_status_post.function_name != ""
+    error_message = "build_status_post Lambda function should exist"
+  }
+
+  assert {
+    condition     = aws_lambda_function.reconcile_build_post.function_name != ""
+    error_message = "reconcile_build_post Lambda function should exist"
   }
 
   # Auth domain (3 functions)

--- a/terraform/tests/lambda_iam.tftest.hcl
+++ b/terraform/tests/lambda_iam.tftest.hcl
@@ -47,7 +47,7 @@ variables {
   categories_table_arn   = "arn:aws:dynamodb:ap-northeast-1:123456789012:table/test-blog-categories-table"
 }
 
-# Test 1: Verify Posts domain IAM role names (split into read/write/build-status)
+# Test 1: Verify Posts domain IAM role names
 run "verify_posts_iam_role" {
   command = plan
 
@@ -68,6 +68,11 @@ run "verify_posts_iam_role" {
   assert {
     condition     = aws_iam_role.lambda_posts_build_status.name == "blog-lambda-posts-build-status-role"
     error_message = "Posts domain build-status role name must be 'blog-lambda-posts-build-status-role'"
+  }
+
+  assert {
+    condition     = aws_iam_role.lambda_posts_build_reconciler.name == "blog-lambda-posts-build-reconciler-role"
+    error_message = "Posts domain build-reconciler role name must be 'blog-lambda-posts-build-reconciler-role'"
   }
 }
 
@@ -184,6 +189,11 @@ run "verify_role_outputs" {
   }
 
   assert {
+    condition     = output.posts_build_reconciler_role_name == "blog-lambda-posts-build-reconciler-role"
+    error_message = "posts_build_reconciler_role_name output must be correct"
+  }
+
+  assert {
     condition     = output.auth_role_name == "blog-lambda-auth-role"
     error_message = "auth_role_name output must be correct"
   }
@@ -217,12 +227,13 @@ run "verify_domain_roles_distinct" {
       aws_iam_role.lambda_posts_read.name,
       aws_iam_role.lambda_posts_write.name,
       aws_iam_role.lambda_posts_build_status.name,
+      aws_iam_role.lambda_posts_build_reconciler.name,
       aws_iam_role.lambda_auth.name,
       aws_iam_role.lambda_images.name,
       aws_iam_role.lambda_categories_read.name,
       aws_iam_role.lambda_categories_write.name,
-    ])) == 7
-    error_message = "All seven domain/purpose-specific IAM roles must have distinct names"
+    ])) == 8
+    error_message = "All eight domain/purpose-specific IAM roles must have distinct names"
   }
 }
 
@@ -248,8 +259,8 @@ run "verify_read_roles_are_read_only" {
   }
 }
 
-# Test 11: Least privilege - build-status role can poll CodeBuild but never start a build
-run "verify_build_status_role_cannot_start_build" {
+# Test 11: Least privilege - build-status role only reads durable state
+run "verify_build_status_role_is_read_only" {
   command = plan
 
   module {
@@ -257,23 +268,76 @@ run "verify_build_status_role_cannot_start_build" {
   }
 
   assert {
-    condition = !contains(
-      jsondecode(aws_iam_role_policy.lambda_posts_build_status_codebuild[0].policy).Statement[0].Action,
-      "codebuild:StartBuild"
-    )
-    error_message = "lambda_posts_build_status must never be granted codebuild:StartBuild"
+    condition     = jsondecode(aws_iam_role_policy.lambda_posts_build_status_dynamodb.policy).Statement[0].Action == ["dynamodb:GetItem"]
+    error_message = "lambda_posts_build_status must only read the durable state item"
+  }
+}
+
+# Test 12: Reconciler alone can start and poll CodeBuild
+run "verify_build_reconciler_permissions" {
+  command = plan
+
+  module {
+    source = "./modules/lambda"
   }
 
   assert {
     condition = contains(
-      jsondecode(aws_iam_role_policy.lambda_posts_build_status_codebuild[0].policy).Statement[0].Action,
+      jsondecode(aws_iam_role_policy.lambda_posts_build_reconciler_codebuild[0].policy).Statement[0].Action,
+      "codebuild:StartBuild"
+    )
+    error_message = "lambda_posts_build_reconciler must be able to start the configured project"
+  }
+
+  assert {
+    condition = contains(
+      jsondecode(aws_iam_role_policy.lambda_posts_build_reconciler_codebuild[0].policy).Statement[1].Action,
       "codebuild:BatchGetBuilds"
     )
-    error_message = "lambda_posts_build_status must be able to poll build results via codebuild:BatchGetBuilds"
+    error_message = "lambda_posts_build_reconciler must be able to poll active builds"
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role_policy.lambda_posts_build_reconciler_codebuild[0].policy).Statement[1].Resource == "arn:aws:codebuild:ap-northeast-1:123456789012:build/test-codebuild-project:*"
+    error_message = "BatchGetBuilds must be scoped to builds of the configured project"
   }
 }
 
-# Test 12: Least privilege - write role retains codebuild:StartBuild (create/update/delete post)
+# Test 13: Completion events have retry/DLQ and scheduled compensation
+run "verify_build_reconcile_delivery" {
+  command = plan
+
+  module {
+    source = "./modules/lambda"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_event_rule.codebuild_state_change[0].event_pattern != ""
+    error_message = "CodeBuild state changes must invoke the reconciler"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_event_target.sitebuild_reconciler[0].dead_letter_config) == 1
+    error_message = "EventBridge target must use the encrypted reconciliation DLQ"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_event_target.sitebuild_reconciler[0].retry_policy[0].maximum_retry_attempts >= 1
+    error_message = "EventBridge target must retry failed reconciliation"
+  }
+
+  assert {
+    condition     = aws_sqs_queue.sitebuild_reconcile_dlq[0].sqs_managed_sse_enabled
+    error_message = "Reconciliation DLQ must enable server-side encryption"
+  }
+
+  assert {
+    condition     = aws_scheduler_schedule.sitebuild_reconcile[0].schedule_expression == "rate(5 minutes)"
+    error_message = "A five-minute scheduled reconciliation must compensate for missed events"
+  }
+}
+
+# Test 14: Least privilege - write role retains codebuild:StartBuild (create/update/delete post)
 run "verify_write_role_has_start_build" {
   command = plan
 

--- a/terraform/tests/module_interdependency.tftest.hcl
+++ b/terraform/tests/module_interdependency.tftest.hcl
@@ -208,8 +208,8 @@ run "lambda_outputs_for_monitoring" {
 
   # Verify function_names has expected count (known during plan)
   assert {
-    condition     = length(output.function_names) == 18
-    error_message = "Lambda module must export all 18 function names"
+    condition     = length(output.function_names) == 19
+    error_message = "Lambda module must export all 19 function names"
   }
 
   # Verify role name outputs match expected values.

--- a/tests/e2e/mocks/handlers.ts
+++ b/tests/e2e/mocks/handlers.ts
@@ -33,6 +33,14 @@ const API_BASE_URL =
     ? import.meta.env.VITE_API_BASE_URL
     : '/api';
 
+let nextSiteBuildRevision = 1;
+const siteBuildStartedAt: Record<string, number> = {};
+
+const createSiteBuildRequest = () => ({
+  targetRevision: nextSiteBuildRevision++,
+  status: 'queued' as const,
+});
+
 /**
  * モックJWTトークンを生成（有効期限付き）
  */
@@ -349,6 +357,7 @@ export const handlers = [
       contentMarkdown: string;
       category: string;
       publishStatus: 'draft' | 'published';
+      saveMode?: 'manual' | 'autosave';
       slug?: string;
       excerpt?: string;
       coverImageUrl?: string;
@@ -365,7 +374,15 @@ export const handlers = [
     const newPost = createMockPost(body);
     mockPosts.unshift(newPost);
 
-    return HttpResponse.json(newPost, { status: 201 });
+    return HttpResponse.json(
+      {
+        ...newPost,
+        ...(body.saveMode !== 'autosave' && body.publishStatus === 'published'
+          ? { siteBuild: createSiteBuildRequest() }
+          : {}),
+      },
+      { status: 201 }
+    );
   }),
 
   // 管理画面: 記事取得
@@ -398,6 +415,7 @@ export const handlers = [
       contentMarkdown?: string;
       category?: string;
       publishStatus?: 'draft' | 'published';
+      saveMode?: 'manual' | 'autosave';
       slug?: string;
       excerpt?: string;
       coverImageUrl?: string;
@@ -421,6 +439,7 @@ export const handlers = [
       );
     }
 
+    const wasPublished = mockPosts[postIndex].publishStatus === 'published';
     const updatedPost = {
       ...mockPosts[postIndex],
       ...body,
@@ -437,46 +456,59 @@ export const handlers = [
 
     mockPosts[postIndex] = updatedPost;
 
-    return HttpResponse.json(updatedPost);
+    return HttpResponse.json({
+      ...updatedPost,
+      ...(body.saveMode !== 'autosave' &&
+      (wasPublished || body.publishStatus === 'published')
+        ? { siteBuild: createSiteBuildRequest() }
+        : {}),
+    });
   }),
 
   // 管理画面: ビルドステータス取得 (PR5b)
   // 公開直後のサイトリビルド進捗をバッジに表示するためのモック。
-  // 各記事 ID の最初の呼び出しで `in-progress`、以降は `succeeded` を返し、
-  // ポーリングの遷移を E2E から検証できるようにする。
-  http.get(
-    `${API_BASE_URL}/admin/posts/:id/build-status`,
-    (() => {
-      const callCounts: Record<string, number> = {};
-      return ({ request, params }) => {
-        if (!checkAuth(request)) {
-          return HttpResponse.json(
-            { message: 'Unauthorized' },
-            { status: 401 }
-          );
-        }
-        const id = String(params.id);
-        callCounts[id] = (callCounts[id] ?? 0) + 1;
-        const buildId = `mock-build-${id}`;
-        const startTime = new Date().toISOString();
-        if (callCounts[id] === 1) {
-          return HttpResponse.json({
-            buildId,
-            status: 'in-progress',
-            phase: 'BUILD',
-            startTime,
-          });
-        }
-        return HttpResponse.json({
-          buildId,
-          status: 'succeeded',
-          phase: 'COMPLETED',
-          startTime,
-          endTime: new Date(Date.now() + 1000).toISOString(),
-        });
-      };
-    })()
-  ),
+  // targetRevision ごとに開始から5秒未満は `in-progress`、以降は
+  // `succeeded` を返す。Strict Modeの同時初回取得も同じ状態になる。
+  http.get(`${API_BASE_URL}/admin/posts/:id/build-status`, ({ request }) => {
+    if (!checkAuth(request)) {
+      return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+    const targetRevision = new URL(request.url).searchParams.get(
+      'targetRevision'
+    );
+    if (!targetRevision) {
+      return HttpResponse.json({
+        status: 'idle',
+        desiredRevision: nextSiteBuildRevision - 1,
+        deployedRevision: nextSiteBuildRevision - 1,
+      });
+    }
+    siteBuildStartedAt[targetRevision] ??= Date.now();
+    const revision = Number(targetRevision);
+    const buildId = `mock-build-${targetRevision}`;
+    const startTime = new Date().toISOString();
+    if (Date.now() - siteBuildStartedAt[targetRevision] < 5_000) {
+      return HttpResponse.json({
+        buildId,
+        status: 'in-progress',
+        phase: 'BUILD',
+        startTime,
+        targetRevision: revision,
+        desiredRevision: revision,
+        deployedRevision: revision - 1,
+      });
+    }
+    return HttpResponse.json({
+      buildId,
+      status: 'succeeded',
+      phase: 'COMPLETED',
+      startTime,
+      endTime: new Date(Date.now() + 1000).toISOString(),
+      targetRevision: revision,
+      desiredRevision: revision,
+      deployedRevision: revision,
+    });
+  }),
 
   // 管理画面: 記事削除
   http.delete(`${API_BASE_URL}/admin/posts/:id`, ({ request, params }) => {

--- a/tests/e2e/specs/admin-crud.spec.ts
+++ b/tests/e2e/specs/admin-crud.spec.ts
@@ -62,15 +62,12 @@ test.describe('Admin CRUD - Article Management', () => {
     await adminPostCreatePage.setPublishStatus('published');
     await adminPostCreatePage.clickSaveButton();
 
-    // PR5b: when publishing, the editor page now stays put and surfaces the
-    // build status badge instead of redirecting. Wait for the badge to confirm
-    // the post was created, then SPA-navigate to /posts via the header link
-    // (page.goto would reset the MSW in-memory mockPosts state).
+    // 明示保存後は公開状態にかかわらず記事一覧へ遷移し、保存操作に対応する
+    // build status badgeを一覧上で表示する。
+    await page.waitForURL(/\/posts(\?.*)?$/, { timeout: 10000 });
     await expect(page.getByTestId('build-status-badge')).toBeVisible({
       timeout: 10000,
     });
-    await page.getByRole('link', { name: 'Articles' }).click();
-    await page.waitForURL(/\/posts(\?.*)?$/, { timeout: 10000 });
     await adminDashboardPage.waitForArticleListLoaded();
 
     // Verify the article appears in the list
@@ -104,15 +101,11 @@ test.describe('Admin CRUD - Article Management', () => {
     await adminPostEditPage.fillTitle(updatedTitle);
     await adminPostEditPage.clickSaveButton();
 
-    // PR5b: seed articles are published — saving keeps that status, so the
-    // edit page now stays put and shows the build status badge instead of
-    // redirecting. Confirm the badge, then SPA-navigate to /posts via the
-    // header link (page.goto would reset MSW mockPosts state).
+    // 公開記事の明示保存も記事一覧へ遷移し、対応revisionの状態を表示する。
+    await page.waitForURL(/\/posts(\?.*)?$/, { timeout: 10000 });
     await expect(page.getByTestId('build-status-badge')).toBeVisible({
       timeout: 10000,
     });
-    await page.getByRole('link', { name: 'Articles' }).click();
-    await page.waitForURL(/\/posts(\?.*)?$/, { timeout: 10000 });
     await adminDashboardPage.waitForArticleListLoaded();
 
     const isUpdatedVisible =

--- a/tests/e2e/specs/admin-publish-flow.spec.ts
+++ b/tests/e2e/specs/admin-publish-flow.spec.ts
@@ -49,6 +49,7 @@ test.describe('Admin Publish Flow - Build Status Badge', () => {
     await adminPostCreatePage.setPublishStatus('published');
     await adminPostCreatePage.clickSaveButton();
 
+    await page.waitForURL(/\/posts(\?.*)?$/, { timeout: 10000 });
     const badge = page.getByTestId('build-status-badge');
 
     // First poll returns 'in-progress' — badge appears with that data attr.
@@ -88,8 +89,7 @@ test.describe('Admin Publish Flow - Build Status Badge', () => {
     await adminPostCreatePage.setPublishStatus('draft');
     await adminPostCreatePage.clickSaveButton();
 
-    // Drafts retain the existing redirect-to-list behaviour, so the badge
-    // should never mount.
+    // 下書きも一覧へ遷移するが、サイトビルド要求は作らない。
     await page.waitForURL(/\/posts(\?.*)?$/, { timeout: 10000 });
     await expect(page.getByTestId('build-status-badge')).toHaveCount(0);
   });


### PR DESCRIPTION
## 概要

記事の公開・下書き変更を含むコンテンツ更新について、CodeBuild 実行中の変更も取りこぼさず、最新リビジョンまで公開サイトを収束させます。

Closes #501

## 主な変更

- DynamoDB のコンテンツリビジョンを原子的に更新し、ビルド対象と完了済みリビジョンを永続化
- 実行中ビルドがある場合は後続ビルドを予約し、EventBridge 経由の reconciler で再調整
- 公開から下書きへの変更でもサイトビルドを起動
- 保存後に記事一覧へ遷移し、対象リビジョンに対応するビルド状態を表示
- カテゴリー未設定の自動保存で category を送信せず、バリデーションエラーを回避
- EventBridge、Scheduler、DLQ、必要な IAM 権限を Terraform に追加

## 検証

- bun run verify: 成功
- 管理画面ユニットテスト: 480件成功
- 管理画面 E2E: 33件成功
- Terraform tests: 68件成功
- Terraform fmt / validate: 成功

## 補足

ローカルの pre-commit 実行時、Go 1.25 でビルドされた golangci-lint が既定 PATH の Go 1.26 を読み込んで panic するツールチェーン不整合がありました。固定 Go 1.25.12 環境での lint と全体 verify は成功しています。