### PR TITLE
test(e2e): spec の goto を相対パスに揃える

### DIFF
--- a/tests/e2e/specs/admin-autosave.spec.ts
+++ b/tests/e2e/specs/admin-autosave.spec.ts
@@ -29,7 +29,7 @@ test.describe('Admin Autosave', () => {
   test('新規記事: タイトル+本文入力後、autosave で URL が /posts/edit/{id} に置換される', async ({
     page,
   }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     // 初期状態: 未保存
@@ -50,7 +50,7 @@ test.describe('Admin Autosave', () => {
     page,
   }) => {
     // 既存記事を編集 (mockData の post-1 を利用)
-    await page.goto('/posts/edit/post-1');
+    await page.goto('posts/edit/post-1');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     const status = page.getByTestId('autosave-status');
@@ -68,7 +68,7 @@ test.describe('Admin Autosave', () => {
   test('タイトルのみで本文が空の場合 autosave は走らない (isReady ガード)', async ({
     page,
   }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await page.getByTestId('post-title-input').fill('Title Only');

--- a/tests/e2e/specs/admin-image-drag.spec.ts
+++ b/tests/e2e/specs/admin-image-drag.spec.ts
@@ -35,7 +35,7 @@ test.describe('Admin Tiptap Editor - image drop', () => {
   test('画像をドロップすると UploadImage が S3 PUT を経て最終 URL を markdown に挿入する', async ({
     page,
   }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await dropImage(page, fixtureJpeg({ name: 'drop-test.jpg' }));

--- a/tests/e2e/specs/admin-image-fail.spec.ts
+++ b/tests/e2e/specs/admin-image-fail.spec.ts
@@ -31,7 +31,7 @@ test.describe('Admin Tiptap Editor - image failure', () => {
     page,
   }) => {
     // MSW handler は __force_500__ prefix のファイル名で 500 を返す
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await pasteImage(page, fixturePng({ name: '__force_500__paste.png' }));
@@ -59,7 +59,7 @@ test.describe('Admin Tiptap Editor - image failure', () => {
       }
     });
 
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     // 6MB のファイル (5MB cap を超える)

--- a/tests/e2e/specs/admin-image-paste.spec.ts
+++ b/tests/e2e/specs/admin-image-paste.spec.ts
@@ -35,7 +35,7 @@ test.describe('Admin Tiptap Editor - image paste', () => {
   test('画像を貼り付けると UploadImage が S3 PUT を経て最終 URL を markdown に挿入する', async ({
     page,
   }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await pasteImage(page, fixturePng({ name: 'paste-test.png' }));

--- a/tests/e2e/specs/admin-image-toolbar.spec.ts
+++ b/tests/e2e/specs/admin-image-toolbar.spec.ts
@@ -31,7 +31,7 @@ test.describe('Admin Tiptap Editor - toolbar image button', () => {
   test('ツールバーの画像ボタンから選んだファイルが markdown に挿入される', async ({
     page,
   }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await expect(page.getByTestId('toolbar-image-button')).toBeVisible();

--- a/tests/e2e/specs/admin-metadata-sidebar.spec.ts
+++ b/tests/e2e/specs/admin-metadata-sidebar.spec.ts
@@ -25,7 +25,7 @@ test.describe('Admin Metadata Sidebar', () => {
   });
 
   test('タイトル入力で slug が自動生成される', async ({ page }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await page.getByTestId('post-title-input').fill('Hello PR6 World');
@@ -34,7 +34,7 @@ test.describe('Admin Metadata Sidebar', () => {
   });
 
   test('ロック解除→ロック後の slug は手動編集できる', async ({ page }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await page.getByTestId('post-title-input').fill('First Title');
@@ -55,7 +55,7 @@ test.describe('Admin Metadata Sidebar', () => {
   });
 
   test('excerpt が161字でカウンターが赤くなる', async ({ page }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     const excerpt = page.getByTestId('metadata-excerpt-input');
@@ -66,7 +66,7 @@ test.describe('Admin Metadata Sidebar', () => {
   });
 
   test('本文先頭画像から cover image を自動入力できる', async ({ page }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await page.getByTestId('post-title-input').fill('Cover Test');

--- a/tests/e2e/specs/admin-preview-parity.spec.ts
+++ b/tests/e2e/specs/admin-preview-parity.spec.ts
@@ -27,7 +27,7 @@ test.describe('Admin Tiptap Editor - preview parity', () => {
   test('見出し / コードブロック / 引用 / リストが Preview に表示される', async ({
     page,
   }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     const sample = [

--- a/tests/e2e/specs/admin-slug-conflict.spec.ts
+++ b/tests/e2e/specs/admin-slug-conflict.spec.ts
@@ -23,7 +23,7 @@ test.describe('Admin Slug Conflict', () => {
   });
 
   test('重複 slug で保存すると 409 エラーバナーが出る', async ({ page }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
     // Seed an existing post in browser-side MSW state with the slug we'll
     // collide against. The bridge is exposed by main.tsx when MSW is on.

--- a/tests/e2e/specs/admin-tiptap-basic.spec.ts
+++ b/tests/e2e/specs/admin-tiptap-basic.spec.ts
@@ -32,14 +32,14 @@ test.describe('Admin Tiptap Editor - basic', () => {
   test('エディタが起動して contenteditable とツールバーが表示される', async ({
     page,
   }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(page.getByTestId('tiptap-editor')).toBeVisible();
     await expect(page.getByTestId('tiptap-toolbar')).toBeVisible();
     await expect(getTiptapEditor(page)).toBeVisible();
   });
 
   test('入力した markdown が round-trip で取得できる', async ({ page }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await setEditorContent(page, '## 見出し2\n\n本文段落\n\n- 項目A\n- 項目B');
@@ -49,7 +49,7 @@ test.describe('Admin Tiptap Editor - basic', () => {
   });
 
   test('toolbar の太字ボタンで bold が適用される', async ({ page }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await setEditorContent(page, 'hello');
@@ -65,7 +65,7 @@ test.describe('Admin Tiptap Editor - basic', () => {
   });
 
   test('Edit / Preview タブが切り替わる', async ({ page }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(page.getByTestId('tiptap-editor')).toBeVisible();
     await setEditorContent(page, '## プレビュー見出し');
 

--- a/tests/e2e/specs/admin-unauthorized-access.spec.ts
+++ b/tests/e2e/specs/admin-unauthorized-access.spec.ts
@@ -18,7 +18,7 @@ test.describe('Admin Unauthorized Access - Minimal E2E', () => {
   }) => {
     // Arrange: ストレージをクリアして未認証状態にする
     // admin SPAのコンテキストでストレージをクリア（Cognito認証情報を確実に削除）
-    await page.goto('/login');
+    await page.goto('login');
     await page.context().clearCookies();
     await page.evaluate(() => {
       localStorage.clear();
@@ -26,7 +26,7 @@ test.describe('Admin Unauthorized Access - Minimal E2E', () => {
     });
 
     // Act: 認証が必要なページにアクセス
-    await page.goto('/dashboard');
+    await page.goto('dashboard');
 
     // Assert: ログインページにリダイレクトされることを確認
     await page.waitForURL('**/login', { timeout: 15000 });

--- a/tests/e2e/specs/admin-unsaved-guard.spec.ts
+++ b/tests/e2e/specs/admin-unsaved-guard.spec.ts
@@ -33,7 +33,7 @@ test.describe('Admin Unsaved-Guard', () => {
   test('未保存のままキャンセル → confirm が出る (dismiss で留まる)', async ({
     page,
   }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     // タイトルだけ入力 (本文空 → autosave は走らない → isDirty のまま)
@@ -55,7 +55,7 @@ test.describe('Admin Unsaved-Guard', () => {
   test('未保存のままキャンセル → confirm を accept で離脱する', async ({
     page,
   }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     await page.getByTestId('post-title-input').fill('Dirty Title');
@@ -71,7 +71,7 @@ test.describe('Admin Unsaved-Guard', () => {
   });
 
   test('autosave 完了後にキャンセル → confirm 無しで遷移', async ({ page }) => {
-    await page.goto('/posts/new');
+    await page.goto('posts/new');
     await expect(getTiptapEditor(page)).toBeVisible();
 
     // タイトル + 本文を入れて autosave 完走を待つ


### PR DESCRIPTION
## 概要

`BasePage.goto` は baseURL のパス部分(AWS 環境の `/admin`)を保持するよう相対化済みだが、spec が直接呼ぶ `page.goto` は `'/posts/new'` のままの箇所が 23 件残っていた。ルート絶対パスは URL 解決時に baseURL のパス部分を破棄するため、片方だけ直っている状態になっていた。

現在これらの spec は MSW 環境(baseURL がオリジン直下)でしか動かないため挙動は変わらない。

## 副次的な目的: CI 検証

この PR は #520 で入れた **ci.yml の変更(admin spec 6 件 → 全 15 件をゲート)を ubuntu ランナーで実際に確かめる**ことも兼ねている。追加した 9 spec (tiptap / image-* / autosave / unsaved-guard / publish-flow / preview-parity) は、コミット deee4d8 以降 PR CI から除外されていたため CI 上での実行実績がない。

ローカルでの実測:
- CI と同じ workers=4 / retry 無しで 5 回連続 **33 passed**(各 26 秒)
- 本 PR の変更後も 33 passed / public 側 7 passed

`E2E Tests (Admin - Full Suite)` ジョブが緑になることをもって検証完了とする。