### PR TITLE
test(config): admin baseURL の期待値を末尾スラッシュ付きに更新

### DIFF
--- a/tests/config/playwright-aws-config.test.ts
+++ b/tests/config/playwright-aws-config.test.ts
@@ -46,7 +46,9 @@ describe('playwright.aws.config.ts', () => {
       (p: { name: string }) => p.name === 'admin-chromium'
     );
     expect(adminProject).toBeDefined();
-    expect(adminProject?.use?.baseURL).toBe(`${BASE_URL}/admin`);
+    // 末尾スラッシュは必須。これがないと相対パス解決で /admin が脱落する
+    // (playwright.aws.config.ts の baseURL 正規化と BasePage.goto が対になる仕様)。
+    expect(adminProject?.use?.baseURL).toBe(`${BASE_URL}/admin/`);
   });
 
   test('admin-chromium project should use ADMIN_BASE_URL when set', async () => {


### PR DESCRIPTION
## 背景

`develop` で `bun run verify` が次の 1 件で失敗していた。

```
tests/config/playwright-aws-config.test.ts:49
admin-chromium project should set baseURL to BASE_URL/admin when ADMIN_BASE_URL is not set
Expected: "https://example.cloudfront.net/admin"
Received: "https://example.cloudfront.net/admin/"
```

## 原因

fed32b3（`ci: admin E2E を MSW 全件ゲートに寄せ、実環境は smoke に確定させる`）が `playwright.aws.config.ts:117` で baseURL に `.replace(/\/*$/, '/')` を追加し、末尾スラッシュを必ず付ける仕様にしたが、対応するテストの期待値が追随していなかった。

末尾スラッシュは相対パス解決で `/admin` プレフィックスを保持するために必須の仕様（`BasePage.goto` と対）なので、**実装が正・テストが古い**と判断し、テスト側を更新した。同じ理由での再発を防ぐため、期待値に意図をコメントで添えている。

## 確認

- `bun test tests/config/`: 7 passed / 0 failed
- `bun run verify`: 終了コード 0（修正前は同ジョブで失敗）

## 補足

PR #523（サイトビルドが起動しない障害の修正）の調査中に見つかった無関係な既存の失敗のため、別 PR として切り出した。#523 とは独立にマージできる。

なお同ファイルの `admin-chromium project should use ADMIN_BASE_URL when set` は、config を読まずにテスト内でロジックを再実装しているため実質的に何も検証していない。今回は失敗の解消に絞ったので手を入れていないが、別途見直す価値がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)