### PR TITLE
chore(security): E2E テストユーザーの SSM に CKV_AWS_337 の skip を追加

### DIFF
--- a/terraform/modules/auth/e2e_test_user.tf
+++ b/terraform/modules/auth/e2e_test_user.tf
@@ -64,6 +64,7 @@ resource "aws_cognito_user_in_group" "e2e_admin" {
 # CI (deploy.yml の post-deploy E2E) が読み出す。dev の Basic 認証と同じく
 # SecureString + --with-decryption で扱う。
 resource "aws_ssm_parameter" "e2e_admin_email" {
+  #checkov:skip=CKV_AWS_337:Non-production only (a lifecycle precondition blocks prd). SecureString already encrypts at rest with the AWS-managed key; a CMK would only add a key-policy authorization layer, and every principal able to read this parameter already holds AWS account access that exceeds what the dev admin account grants. Revisit if this user is ever created outside non-production.
   count = var.create_e2e_test_user ? 1 : 0
 
   name        = "/serverless-blog/${var.environment}/e2e/admin-email"
@@ -75,6 +76,7 @@ resource "aws_ssm_parameter" "e2e_admin_email" {
 }
 
 resource "aws_ssm_parameter" "e2e_admin_password" {
+  #checkov:skip=CKV_AWS_337:Non-production only (a lifecycle precondition blocks prd). SecureString already encrypts at rest with the AWS-managed key; a CMK would only add a key-policy authorization layer, and every principal able to read this parameter already holds AWS account access that exceeds what the dev admin account grants. The value is a random_password regenerated whenever the user is recreated, never a human credential. Revisit if this user is ever created outside non-production.
   count = var.create_e2e_test_user ? 1 : 0
 
   name        = "/serverless-blog/${var.environment}/e2e/admin-password"


### PR DESCRIPTION
## 背景

PR #525（develop → main）で Code Scanning の `Checkov` チェックが失敗していた。

```
8 new alerts including 2 errors
```

error 2 件はどちらも今回 develop に入った E2E テストユーザー用の SSM パラメータで、内容は同一。

```
CKV_AWS_337: Ensure SSM parameters are using KMS CMK
terraform/modules/auth/e2e_test_user.tf:66  (e2e_admin_email)
terraform/modules/auth/e2e_test_user.tf:77  (e2e_admin_password)
```

warning 6 件（CKV_AWS_21 / CKV2_AWS_6 / CKV2_AWS_34 / CKV_AWS_297）は既に `#checkov:skip` と根拠コメントが入っている箇所で、dev / prd / examples の各ディレクトリから同じモジュールが解析されるため重複計上されているもの。新規対応は不要。

## 判断

CMK を導入せず、根拠を明記して受け入れる。

- 値は既に `type = "SecureString"`。**平文ではなく**、AWS マネージドキー（`alias/aws/ssm`）で保管時暗号化されている
- CMK が追加するのは**キーポリシーによる二段目の認可のみ**。このパラメータを読める principal は AWS アカウントへのアクセス権を持っており、それは dev の admin アカウントで得られる権限を既に上回る
- 作成は非本番に限定されている（`lifecycle.precondition` が `prd` を拒否）
- パスワードは `random_password`（24文字）の自動生成で、ユーザー再作成のたびに更新される。人間の認証情報ではない

CMK 1 本の運用コストが継続的に効くのに対し、得られる防御はこの文脈では小さいと判断した。

## 実装

`docs/SECURITY_SCANNING.md` の suppression 方針に従い、リポジトリ既存の `#checkov:skip` と同じインライン形式で記載した。既存の skip は全て「値が非機密だから」という根拠だが、今回は**値が機密である**ため同じ理由付けは使わず、非本番限定・アクセス権の前提・自動生成という別の根拠を明記している。

## 確認

```
checkov --config-file terraform/.checkov.yaml --directory terraform
```

| | Failed | Passed | Skipped |
| --- | --- | --- | --- |
| 修正前 | 2 | 411 | 10 |
| 修正後 | **0** | 411 | 12 |

`terraform fmt -check` OK。

## 補足

この skip はあくまで「非本番のテストユーザーである」ことが前提。E2E テストユーザーを本番相当の環境に作る変更が入る場合は、この判断ごと見直す必要がある（コメントにもその旨を明記した）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)